### PR TITLE
client: Add client key management support

### DIFF
--- a/siguldry/CHANGELOG.md
+++ b/siguldry/CHANGELOG.md
@@ -16,6 +16,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Added support for the 'new-user', 'modify-user', and 'delete-user' commands to the siguldry client (#46)
 
+- Added support for the full suite of key management commands to the siguldry client. These include
+'key-user-info', 'modify-key-user', 'list-keys', 'new-key', 'import-key', 'delete-key',
+'modify-key', 'list-key-users', 'grant-key-access', 'revoke-key-access', change-key-expiration',
+'get-public-key', 'change-passphrase', and 'list-binding-methods' (#47)
+
 ### Changed
 
 - The minimum supported Rust version (MSRV) is now 1.84 to align with RHEL 9.6 and 10.0 (#45)

--- a/siguldry/Cargo.toml
+++ b/siguldry/Cargo.toml
@@ -67,6 +67,15 @@ proptest = "1.6"
 version = "0.25"
 features = ["auto-initialize"]
 
+# As we use OpenSSL for the TLS connection, let's stick with it for this as well.
+# The upstream default engine is nettle.
+#
+# Bump to 2.0 once Rust 1.85 is available (November 2025)
+[dev-dependencies.sequoia-openpgp]
+version = "1"
+default-features = false
+features = ["crypto-openssl"]
+
 
 [[bin]]
 name = "siguldry-client"

--- a/siguldry/src/client.rs
+++ b/siguldry/src/client.rs
@@ -3,6 +3,7 @@
 
 //! A Sigul client.
 
+use std::io::Cursor;
 use std::path::Path;
 use std::{collections::HashMap, io::Read};
 
@@ -80,15 +81,46 @@ impl TryFrom<&Path> for Password {
     }
 }
 
+/// The key types supported by Sigul.
+#[derive(Debug, Clone)]
+#[non_exhaustive]
+pub enum KeyType {
+    /// The GnuPG key type.
+    ///
+    /// Server configuration determines the key size and algorithm used when creating a new key.
+    GnuPG {
+        /// The real name field to use on the GPG key, if any.
+        real_name: Option<String>,
+        /// The comment field to use on the GPG key, if any.
+        comment: Option<String>,
+        /// The email address for the GPG key, if any.
+        email: Option<String>,
+        /// The expiration date for the GPG key. If [`Option::None`], the key does not expire.
+        expire_date: Option<String>,
+    },
+    /// The Elliptic Curve Cryptography key type.
+    ///
+    /// Server configuration determines the curve used when creating a new key.
+    Ecc,
+    /// The RSA key type.
+    ///
+    /// Server configuration determines the key size used when creating a new key.
+    Rsa,
+}
+
+impl std::fmt::Display for KeyType {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            KeyType::GnuPG { .. } => write!(f, "gnupg"),
+            KeyType::Ecc => write!(f, "ECC"),
+            KeyType::Rsa => write!(f, "RSA"),
+        }
+    }
+}
+
 /// Sigul commands supported by this client.
 #[derive(Serialize, Debug, Clone)]
 pub(crate) enum Command {
-    SignPe {
-        /// The user to authenticate as.
-        user: String,
-        key: String,
-        cert_name: String,
-    },
     ListUsers {
         /// The user to authenticate as.
         user: String,
@@ -128,6 +160,147 @@ pub(crate) enum Command {
         #[serde(skip_serializing_if = "Option::is_none")]
         new_name: Option<String>,
     },
+    /// Show information about the user's key access.
+    KeyUserInfo {
+        /// The user to authenticate as.
+        user: String,
+        /// The user to list key information for.
+        name: String,
+        /// The key name to list information for.
+        key: String,
+    },
+    ModifyKeyUser {
+        /// The user to authenticate as.
+        user: String,
+        /// The user to update key access for.
+        name: String,
+        /// The key name to update key access for.
+        key: String,
+        /// Whether or not the user is the key admin.
+        #[serde(skip_serializing_if = "Option::is_none")]
+        key_admin: Option<bool>,
+    },
+    ListKeys {
+        /// The user to authenticate as.
+        user: String,
+    },
+    NewKey {
+        /// The user to authenticate as.
+        user: String,
+        /// The key name.
+        key: String,
+        /// The key type.
+        keytype: String,
+        /// The key admin, if any.
+        #[serde(skip_serializing_if = "Option::is_none")]
+        initial_key_admin: Option<String>,
+        /// The "Real name" of the key subject, if the key type is "gnupg".
+        #[serde(skip_serializing_if = "Option::is_none")]
+        name_real: Option<String>,
+        /// A comment about the key, if the key type is "gnupg".
+        #[serde(skip_serializing_if = "Option::is_none")]
+        name_comment: Option<String>,
+        /// The email associated with the key, if the key type is "gnupg".
+        #[serde(skip_serializing_if = "Option::is_none")]
+        name_email: Option<String>,
+        /// The key expiration date in YYYY-MM-DD format, if the key type is "gnupg".
+        #[serde(skip_serializing_if = "Option::is_none")]
+        expire_date: Option<String>,
+    },
+    ImportKey {
+        /// The user to authenticate as.
+        user: String,
+        /// What the imported key should be named.
+        key: String,
+        /// The key type. Must be one of [`KeyType`].
+        keytype: String,
+        /// The key's initial admin. If omitted, the user importing the key is set as the admin.
+        #[serde(skip_serializing_if = "Option::is_none")]
+        initial_key_admin: Option<String>,
+    },
+    DeleteKey {
+        /// The user to authenticate as.
+        user: String,
+        /// The key name to delete.
+        key: String,
+    },
+    ModifyKey {
+        /// The user to authenticate as.
+        user: String,
+        /// The key name to modify.
+        key: String,
+        /// The new key name, if a change is desired. Providing `None` means no change.
+        #[serde(skip_serializing_if = "Option::is_none")]
+        new_name: Option<String>,
+    },
+    ListKeyUsers {
+        /// The user to authenticate as.
+        user: String,
+        /// The key name to list users for.
+        key: String,
+    },
+    GrantKeyAccess {
+        /// The user to authenticate as.
+        user: String,
+        /// The key to grant `name` access to.
+        key: String,
+        /// The user to grant access to the key.
+        name: String,
+    },
+    ChangeKeyExpiration {
+        /// The user to authenticate as.
+        user: String,
+        /// The key to change the expiration date for; note this is only valid for GnuPG keys.
+        key: String,
+        /// The new expiration date in YYYY-MM-DD format.
+        /// If `None`, the key's expiration date is set to "non-expiring".
+        #[serde(skip_serializing_if = "Option::is_none")]
+        expire_date: Option<String>,
+        /// The subkey to change the expiration date for, if any.
+        #[serde(skip_serializing_if = "Option::is_none")]
+        subkey: Option<String>,
+    },
+    RevokeKeyAccess {
+        /// The user to authenticate as.
+        user: String,
+        /// The key to revoke `name` access from.
+        key: String,
+        /// The user to revoke access from the key.
+        name: String,
+    },
+    GetPublicKey {
+        /// The user to authenticate as.
+        user: String,
+        /// The key name to retrieve the public key for.
+        key: String,
+    },
+    ChangePassphrase {
+        /// The user to authenticate as.
+        user: String,
+        /// The key name to change the passphrase for.
+        key: String,
+    },
+    // The following commands are not yet implemented in the client:
+    //
+    // SignText {},
+    // SignData {},
+    // Decrypt {},
+    // SignGitTag {},
+    // SignContainer {},
+    // SignOstree {},
+    // SignRpm {},
+    // SignRpms {},
+    // SignCertificate {},
+    SignPe {
+        /// The user to authenticate as.
+        user: String,
+        key: String,
+        cert_name: String,
+    },
+    ListBindingMethods {
+        /// The user to authenticate as.
+        user: String,
+    },
 }
 
 /// Response types used by the client.
@@ -150,6 +323,65 @@ pub mod responses {
         /// Returns true if the user is a Sigul administrator.
         pub fn admin(&self) -> bool {
             self.admin
+        }
+    }
+
+    /// User's access information for a key.
+    #[derive(Debug, Clone)]
+    pub struct KeyUserInfo {
+        /// The username this key info relates to.
+        pub(crate) user: String,
+        /// The key name this key info relates to.
+        pub(crate) key: String,
+        /// True if the user is the key administrator.
+        pub(crate) admin: bool,
+    }
+
+    impl KeyUserInfo {
+        /// The user's name.
+        pub fn user(&self) -> &str {
+            &self.user
+        }
+
+        /// The key's name
+        pub fn key(&self) -> &str {
+            &self.key
+        }
+
+        /// Returns true if the user is a Sigul administrator.
+        pub fn admin(&self) -> bool {
+            self.admin
+        }
+    }
+
+    /// A public key as returned by the Sigul server.
+    ///
+    /// GnuPG keys are expected to be ASCII-armored, and RSA or ECC keys should be PEM-encoded.
+    #[derive(Debug, Clone)]
+    pub struct PublicKey {
+        /// The key name this public key relates to.
+        pub(crate) key_name: String,
+        /// The public key data.
+        pub(crate) data: Vec<u8>,
+    }
+
+    impl PublicKey {
+        /// The key's name.
+        pub fn key_name(&self) -> &str {
+            &self.key_name
+        }
+
+        /// The public key data.
+        pub fn data(&self) -> &[u8] {
+            &self.data
+        }
+
+        /// Convert the public key data to a string.
+        ///
+        /// As the data is expected to be UTF-8 encoded PEM or ASCII-armored data, this will
+        /// only return an error if the server is misbehaving.
+        pub fn as_string(&self) -> Result<String, std::string::FromUtf8Error> {
+            String::from_utf8(self.data.clone())
         }
     }
 }
@@ -494,6 +726,637 @@ impl Client {
         Ok(())
     }
 
+    /// Show information about a user's key access.
+    ///
+    /// If the user can access the key, the response will include whether or not the user is the key's admin.
+    ///
+    /// This call will return [`crate::error::Sigul::KeyUserNotFound`] if the
+    /// given user cannot access the key.
+    #[instrument(skip_all)]
+    pub async fn key_user_info(
+        &self,
+        admin_passphrase: Password,
+        name: String,
+        key: String,
+    ) -> Result<responses::KeyUserInfo, Error> {
+        let connection = self.connect().await?;
+        let (payload_reader, payload_writer) = get_payload_pipe();
+
+        let mut inner_request = HashMap::new();
+        inner_request.insert("password", admin_passphrase.as_bytes());
+        let response = connection
+            .outer_request::<tokio::io::Empty>(
+                Command::KeyUserInfo {
+                    user: self.user_name.clone(),
+                    name: name.clone(),
+                    key: key.clone(),
+                },
+                None,
+            )
+            .await?
+            .inner_request(self.tls_config.ssl(&self.server_hostname)?, inner_request)
+            .await?
+            .response(payload_writer)
+            .await?;
+        tracing::info!(response.status_code, "Sigul response received");
+        let payload = payload_reader
+            .await
+            .context("response payload could not be read")??;
+        assert!(payload.is_empty());
+
+        let admin = response
+            .fields
+            .get("key-admin")
+            .and_then(|b| b.first())
+            .map(|b| *b == 1)
+            .ok_or(anyhow::anyhow!("missing expected field 'admin'"))?;
+
+        Ok(responses::KeyUserInfo {
+            user: name,
+            key,
+            admin,
+        })
+    }
+
+    /// Modify a key's user by making the user an admin or removing them as an admin.
+    #[instrument(skip_all)]
+    pub async fn modify_key_user(
+        &self,
+        admin_passphrase: Password,
+        name: String,
+        key: String,
+        key_admin: Option<bool>,
+    ) -> Result<(), Error> {
+        let connection = self.connect().await?;
+        let (payload_reader, payload_writer) = get_payload_pipe();
+
+        let mut inner_request = HashMap::new();
+        inner_request.insert("password", admin_passphrase.as_bytes());
+        let response = connection
+            .outer_request::<tokio::io::Empty>(
+                Command::ModifyKeyUser {
+                    user: self.user_name.clone(),
+                    name: name.clone(),
+                    key: key.clone(),
+                    key_admin,
+                },
+                None,
+            )
+            .await?
+            .inner_request(self.tls_config.ssl(&self.server_hostname)?, inner_request)
+            .await?
+            .response(payload_writer)
+            .await?;
+        tracing::info!(response.status_code, "Sigul response received");
+        let payload = payload_reader
+            .await
+            .context("response payload could not be read")??;
+        assert!(payload.is_empty());
+
+        Ok(())
+    }
+
+    /// List the keys available in the Sigul server.
+    #[instrument(skip_all)]
+    pub async fn keys(&self, admin_passphrase: Password) -> Result<Vec<String>, Error> {
+        let connection = self.connect().await?;
+        let (payload_reader, payload_writer) = get_payload_pipe();
+
+        let mut inner_request = HashMap::new();
+        inner_request.insert("password", admin_passphrase.as_bytes());
+        let response = connection
+            .outer_request::<tokio::io::Empty>(
+                Command::ListKeys {
+                    user: self.user_name.clone(),
+                },
+                None,
+            )
+            .await?
+            .inner_request(self.tls_config.ssl(&self.server_hostname)?, inner_request)
+            .await?
+            .response(payload_writer)
+            .await?;
+        tracing::info!(response.status_code, "Sigul response received");
+        let payload = payload_reader
+            .await
+            .context("response payload could not be read")??;
+
+        let mut num_keys = response
+            .fields
+            .get("num-keys")
+            .map(|b| Bytes::from(b.to_vec()))
+            .ok_or(anyhow::anyhow!("missing expected field 'num-keys'"))?;
+
+        if num_keys.len() != 4 {
+            // The expected value of this field is a u32.
+            return Err(anyhow::anyhow!(
+                "the 'num-keys' field was {} bytes; expected 4",
+                num_keys.len()
+            )
+            .into());
+        }
+        let num_keys: usize = num_keys
+            .get_u32()
+            .try_into()
+            .context("the number of keys couldn't be converted to usize")?;
+        let keys = payload
+            .split(|byte| *byte == 0)
+            .filter_map(|name| {
+                if !name.is_empty() {
+                    String::from_utf8(name.into()).ok()
+                } else {
+                    None
+                }
+            })
+            .collect::<Vec<_>>();
+
+        if keys.len() != num_keys {
+            return Err(anyhow::anyhow!(
+                "Server response indicated {} users, but {} names were sent!",
+                num_keys,
+                keys.len()
+            )
+            .into());
+        }
+
+        Ok(keys)
+    }
+
+    /// Create a new key on the Sigul server.
+    ///
+    /// If the `initial_key_admin` parameter is not provided, the current user is set as the key's admin.
+    ///
+    /// The `name_real`, `name_comment`, and `name_email` parameters are only used if the key type is [`KeyType::GnuPG`].
+    #[instrument(skip_all)]
+    pub async fn new_key(
+        &self,
+        admin_passphrase: Password,
+        key_passphrase: Password,
+        key_name: String,
+        key_type: KeyType,
+        initial_key_admin: Option<String>,
+    ) -> Result<responses::PublicKey, Error> {
+        let connection = self.connect().await?;
+        let (payload_reader, payload_writer) = get_payload_pipe();
+
+        let mut inner_request = HashMap::new();
+        inner_request.insert("password", admin_passphrase.as_bytes());
+        inner_request.insert("passphrase", key_passphrase.as_bytes());
+        let keytype = key_type.to_string();
+        let (name_real, name_comment, name_email, expire_date) = match key_type {
+            KeyType::GnuPG {
+                real_name,
+                comment,
+                email,
+                expire_date,
+            } => (real_name, comment, email, expire_date),
+            KeyType::Ecc => (None, None, None, None),
+            KeyType::Rsa => (None, None, None, None),
+        };
+        let response = connection
+            .outer_request::<tokio::io::Empty>(
+                Command::NewKey {
+                    user: self.user_name.clone(),
+                    key: key_name.clone(),
+                    keytype,
+                    initial_key_admin,
+                    name_real,
+                    name_comment,
+                    name_email,
+                    expire_date,
+                },
+                None,
+            )
+            .await?
+            .inner_request(self.tls_config.ssl(&self.server_hostname)?, inner_request)
+            .await?
+            .response(payload_writer)
+            .await?;
+        tracing::info!(response.status_code, "Sigul response received");
+        let payload = payload_reader
+            .await
+            .context("response payload could not be read")??;
+
+        Ok(responses::PublicKey {
+            key_name,
+            data: payload,
+        })
+    }
+
+    /// Import a key into the Sigul server.
+    ///
+    /// `key_passphrase` is the passphrase that can be used to decrypt the key file, and
+    /// `new_key_passphrase` is the passphrase that will unlock the key after it has been imported.
+    /// `key_pem` is the key file in PEM format and must be encrypted with `key_passphrase`, and
+    /// `key_type` is the type of key being imported.
+    ///
+    /// If `initial_key_admin` is not provided, the user importing the key is set as the key's admin.
+    #[instrument(skip_all)]
+    #[allow(clippy::too_many_arguments)]
+    pub async fn import_key(
+        &self,
+        admin_passphrase: Password,
+        key_passphrase: Password,
+        new_key_passphrase: Password,
+        key_name: String,
+        key_pem: &[u8],
+        key_type: KeyType,
+        initial_key_admin: Option<String>,
+    ) -> Result<(), Error> {
+        let connection = self.connect().await?;
+        let (payload_reader, payload_writer) = get_payload_pipe();
+        let request_payload = Cursor::new(key_pem);
+
+        let mut inner_request = HashMap::new();
+        inner_request.insert("password", admin_passphrase.as_bytes());
+        inner_request.insert("passphrase", key_passphrase.as_bytes());
+        inner_request.insert("new-passphrase", new_key_passphrase.as_bytes());
+        let response = connection
+            .outer_request(
+                Command::ImportKey {
+                    user: self.user_name.clone(),
+                    key: key_name,
+                    keytype: key_type.to_string(),
+                    initial_key_admin,
+                },
+                Some(request_payload),
+            )
+            .await?
+            .inner_request(self.tls_config.ssl(&self.server_hostname)?, inner_request)
+            .await?
+            .response(payload_writer)
+            .await?;
+        tracing::info!(response.status_code, "Sigul response received");
+        let payload = payload_reader
+            .await
+            .context("response payload could not be read")??;
+        assert!(payload.is_empty());
+
+        Ok(())
+    }
+
+    /// Delete a key from the Sigul server.
+    #[instrument(skip_all)]
+    pub async fn delete_key(
+        &self,
+        admin_passphrase: Password,
+        key_name: String,
+    ) -> Result<(), Error> {
+        let connection = self.connect().await?;
+        let (payload_reader, payload_writer) = get_payload_pipe();
+
+        let mut inner_request = HashMap::new();
+        inner_request.insert("password", admin_passphrase.as_bytes());
+        let response = connection
+            .outer_request::<tokio::io::Empty>(
+                Command::DeleteKey {
+                    user: self.user_name.clone(),
+                    key: key_name,
+                },
+                None,
+            )
+            .await?
+            .inner_request(self.tls_config.ssl(&self.server_hostname)?, inner_request)
+            .await?
+            .response(payload_writer)
+            .await?;
+        tracing::info!(response.status_code, "Sigul response received");
+        let payload = payload_reader
+            .await
+            .context("response payload could not be read")??;
+        assert!(payload.is_empty());
+
+        Ok(())
+    }
+
+    /// Modify a key on the Sigul server.
+    #[instrument(skip_all)]
+    pub async fn modify_key(
+        &self,
+        admin_passphrase: Password,
+        key_name: String,
+        new_key_name: Option<String>,
+    ) -> Result<(), Error> {
+        let connection = self.connect().await?;
+        let (payload_reader, payload_writer) = get_payload_pipe();
+
+        let mut inner_request = HashMap::new();
+        inner_request.insert("password", admin_passphrase.as_bytes());
+        let response = connection
+            .outer_request::<tokio::io::Empty>(
+                Command::ModifyKey {
+                    user: self.user_name.clone(),
+                    key: key_name,
+                    new_name: new_key_name,
+                },
+                None,
+            )
+            .await?
+            .inner_request(self.tls_config.ssl(&self.server_hostname)?, inner_request)
+            .await?
+            .response(payload_writer)
+            .await?;
+        tracing::info!(response.status_code, "Sigul response received");
+        let payload = payload_reader
+            .await
+            .context("response payload could not be read")??;
+        assert!(payload.is_empty());
+
+        Ok(())
+    }
+
+    /// List the users that have access to a key.
+    #[instrument(skip_all)]
+    pub async fn key_users(
+        &self,
+        admin_passphrase: Password,
+        key_name: String,
+    ) -> Result<Vec<String>, Error> {
+        let connection = self.connect().await?;
+        let (payload_reader, payload_writer) = get_payload_pipe();
+
+        let mut inner_request = HashMap::new();
+        inner_request.insert("password", admin_passphrase.as_bytes());
+        let response = connection
+            .outer_request::<tokio::io::Empty>(
+                Command::ListKeyUsers {
+                    user: self.user_name.clone(),
+                    key: key_name.clone(),
+                },
+                None,
+            )
+            .await?
+            .inner_request(self.tls_config.ssl(&self.server_hostname)?, inner_request)
+            .await?
+            .response(payload_writer)
+            .await?;
+        tracing::info!(response.status_code, "Sigul response received");
+        let payload = payload_reader
+            .await
+            .context("response payload could not be read")??;
+
+        let mut num_users = response
+            .fields
+            .get("num-users")
+            .map(|b| Bytes::from(b.to_vec()))
+            .ok_or(anyhow::anyhow!("missing expected field 'num-users'"))?;
+
+        if num_users.len() != 4 {
+            // The expected value of this field is a u32.
+            return Err(anyhow::anyhow!(
+                "the 'num-users' field was {} bytes; expected 4",
+                num_users.len()
+            )
+            .into());
+        }
+        let num_users: usize = num_users
+            .get_u32()
+            .try_into()
+            .context("the number of users couldn't be converted to usize")?;
+        let users = payload
+            .split(|byte| *byte == 0)
+            .filter_map(|name| {
+                if !name.is_empty() {
+                    String::from_utf8(name.into()).ok()
+                } else {
+                    None
+                }
+            })
+            .collect::<Vec<_>>();
+
+        if users.len() != num_users {
+            return Err(anyhow::anyhow!(
+                "Server response indicated {} users, but {} names were sent!",
+                num_users,
+                users.len()
+            )
+            .into());
+        }
+
+        Ok(users)
+    }
+
+    /// Grant a user access to a key.
+    ///
+    /// The current user must be a key administrator to grant access to the key. `key_passphrase`
+    /// is the passphrase to use the key as the current authenticated user, and `user_passphrase`
+    /// is the passphrase that will be used to unlock the key for the user being granted access.
+    ///
+    /// `client_bindings` and `server_bindings` are optional bindings that can be used to
+    /// restrict the key's use to a specific client or server. If `None`, no bindings are set.
+    /// If `server_bindings` or `client_bindings` is provided, it must be a JSON-serialized string
+    /// containing the bindings.
+    #[instrument(skip_all)]
+    #[allow(clippy::too_many_arguments)]
+    pub async fn grant_key_access(
+        &self,
+        admin_passphrase: Password,
+        key_name: String,
+        key_passphrase: Password,
+        user_name: String,
+        user_passphrase: Password,
+        client_binding: Option<String>,
+        server_binding: Option<String>,
+    ) -> Result<(), Error> {
+        let connection = self.connect().await?;
+        let (payload_reader, payload_writer) = get_payload_pipe();
+
+        let mut inner_request = HashMap::new();
+        inner_request.insert("password", admin_passphrase.as_bytes());
+        inner_request.insert("passphrase", key_passphrase.as_bytes());
+        inner_request.insert("new-passphrase", user_passphrase.as_bytes());
+        // A silly little hack to avoid lifetime issues since everything is borrowed.
+        let client_binding_bytes = client_binding.unwrap_or_default();
+        if !client_binding_bytes.is_empty() {
+            inner_request.insert("client-binding", client_binding_bytes.as_bytes());
+        }
+        let server_binding_bytes = server_binding.unwrap_or_default();
+        if !server_binding_bytes.is_empty() {
+            inner_request.insert("server-binding", server_binding_bytes.as_bytes());
+        }
+        let response = connection
+            .outer_request::<tokio::io::Empty>(
+                Command::GrantKeyAccess {
+                    user: self.user_name.clone(),
+                    key: key_name,
+                    name: user_name,
+                },
+                None,
+            )
+            .await?
+            .inner_request(self.tls_config.ssl(&self.server_hostname)?, inner_request)
+            .await?
+            .response(payload_writer)
+            .await?;
+        tracing::info!(response.status_code, "Sigul response received");
+        let payload = payload_reader
+            .await
+            .context("response payload could not be read")??;
+        assert!(payload.is_empty());
+
+        Ok(())
+    }
+
+    /// Change a key's expiration date.
+    #[instrument(skip_all)]
+    pub async fn change_key_expiration(
+        &self,
+        admin_passphrase: Password,
+        key_name: String,
+        key_passphrase: Password,
+        subkey_id: Option<String>,
+        expire_date: Option<String>,
+    ) -> Result<(), Error> {
+        let connection = self.connect().await?;
+        let (payload_reader, payload_writer) = get_payload_pipe();
+
+        let mut inner_request = HashMap::new();
+        inner_request.insert("password", admin_passphrase.as_bytes());
+        inner_request.insert("passphrase", key_passphrase.as_bytes());
+        let response = connection
+            .outer_request::<tokio::io::Empty>(
+                Command::ChangeKeyExpiration {
+                    user: self.user_name.clone(),
+                    key: key_name,
+                    expire_date,
+                    subkey: subkey_id,
+                },
+                None,
+            )
+            .await?
+            .inner_request(self.tls_config.ssl(&self.server_hostname)?, inner_request)
+            .await?
+            .response(payload_writer)
+            .await?;
+        tracing::info!(response.status_code, "Sigul response received");
+        let payload = payload_reader
+            .await
+            .context("response payload could not be read")??;
+        assert!(payload.is_empty());
+
+        Ok(())
+    }
+
+    /// Revoke a user's key access.
+    #[instrument(skip_all)]
+    pub async fn revoke_key_access(
+        &self,
+        admin_passphrase: Password,
+        key_name: String,
+        user_name: String,
+    ) -> Result<(), Error> {
+        let connection = self.connect().await?;
+        let (payload_reader, payload_writer) = get_payload_pipe();
+
+        let mut inner_request = HashMap::new();
+        inner_request.insert("password", admin_passphrase.as_bytes());
+        let response = connection
+            .outer_request::<tokio::io::Empty>(
+                Command::RevokeKeyAccess {
+                    user: self.user_name.clone(),
+                    key: key_name,
+                    name: user_name,
+                },
+                None,
+            )
+            .await?
+            .inner_request(self.tls_config.ssl(&self.server_hostname)?, inner_request)
+            .await?
+            .response(payload_writer)
+            .await?;
+        tracing::info!(response.status_code, "Sigul response received");
+        let payload = payload_reader
+            .await
+            .context("response payload could not be read")??;
+        assert!(payload.is_empty());
+
+        Ok(())
+    }
+
+    /// Retrieve the public key for a given key name.
+    #[instrument(skip_all)]
+    pub async fn get_public_key(
+        &self,
+        admin_passphrase: Password,
+        key_name: String,
+    ) -> Result<responses::PublicKey, Error> {
+        let connection = self.connect().await?;
+        let (payload_reader, payload_writer) = get_payload_pipe();
+
+        let mut inner_request = HashMap::new();
+        inner_request.insert("password", admin_passphrase.as_bytes());
+        let response = connection
+            .outer_request::<tokio::io::Empty>(
+                Command::GetPublicKey {
+                    user: self.user_name.clone(),
+                    key: key_name.clone(),
+                },
+                None,
+            )
+            .await?
+            .inner_request(self.tls_config.ssl(&self.server_hostname)?, inner_request)
+            .await?
+            .response(payload_writer)
+            .await?;
+        tracing::info!(response.status_code, "Sigul response received");
+        let payload = payload_reader
+            .await
+            .context("response payload could not be read")??;
+
+        Ok(responses::PublicKey {
+            key_name,
+            data: payload,
+        })
+    }
+
+    /// Change the passphrase for a key.
+    ///
+    /// This changes the passphrase for the current user.
+    #[instrument(skip_all)]
+    pub async fn change_passphrase(
+        &self,
+        key_name: String,
+        current_key_passphrase: Password,
+        new_key_passphrase: Password,
+        client_binding: Option<String>,
+        server_binding: Option<String>,
+    ) -> Result<(), Error> {
+        let connection = self.connect().await?;
+        let (payload_reader, payload_writer) = get_payload_pipe();
+
+        let mut inner_request = HashMap::new();
+        inner_request.insert("passphrase", current_key_passphrase.as_bytes());
+        inner_request.insert("new-passphrase", new_key_passphrase.as_bytes());
+        let client_binding_bytes = client_binding.unwrap_or_default();
+        if !client_binding_bytes.is_empty() {
+            inner_request.insert("client-binding", client_binding_bytes.as_bytes());
+        }
+        let server_binding_bytes = server_binding.unwrap_or_default();
+        if !server_binding_bytes.is_empty() {
+            inner_request.insert("server-binding", server_binding_bytes.as_bytes());
+        }
+        let response = connection
+            .outer_request::<tokio::io::Empty>(
+                Command::ChangePassphrase {
+                    user: self.user_name.clone(),
+                    key: key_name,
+                },
+                None,
+            )
+            .await?
+            .inner_request(self.tls_config.ssl(&self.server_hostname)?, inner_request)
+            .await?
+            .response(payload_writer)
+            .await?;
+        tracing::info!(response.status_code, "Sigul response received");
+        let payload = payload_reader
+            .await
+            .context("response payload could not be read")??;
+        assert!(payload.is_empty());
+
+        Ok(())
+    }
+
     /// Sign a platform executable (PE) file for Secure Boot.
     #[instrument(skip_all)]
     pub async fn sign_pe<I, O>(
@@ -529,5 +1392,74 @@ impl Client {
 
         tracing::info!(?response.fields, response.status_code, "Got response fields");
         Ok(())
+    }
+
+    /// List the server binding methods available on the Sigul server.
+    #[instrument(skip_all)]
+    pub async fn server_binding_methods(
+        &self,
+        admin_passphrase: Password,
+    ) -> Result<Vec<String>, Error> {
+        let connection = self.connect().await?;
+        let (payload_reader, payload_writer) = get_payload_pipe();
+
+        let mut inner_request = HashMap::new();
+        inner_request.insert("password", admin_passphrase.as_bytes());
+        let response = connection
+            .outer_request::<tokio::io::Empty>(
+                Command::ListBindingMethods {
+                    user: self.user_name.clone(),
+                },
+                None,
+            )
+            .await?
+            .inner_request(self.tls_config.ssl(&self.server_hostname)?, inner_request)
+            .await?
+            .response(payload_writer)
+            .await?;
+        tracing::info!(response.status_code, "Sigul response received");
+        let payload = payload_reader
+            .await
+            .context("response payload could not be read")??;
+
+        let mut num_methods = response
+            .fields
+            .get("num-methods")
+            .map(|b| Bytes::from(b.to_vec()))
+            .ok_or(anyhow::anyhow!("missing expected field 'num-methods'"))?;
+
+        if num_methods.len() != 4 {
+            // The expected value of this field is a u32.
+            return Err(anyhow::anyhow!(
+                "the 'num-methods' field was {} bytes; expected 4",
+                num_methods.len()
+            )
+            .into());
+        }
+        let num_methods: usize = num_methods
+            .get_u32()
+            .try_into()
+            .context("the number of keys couldn't be converted to usize")?;
+        let binding_methods = payload
+            .split(|byte| *byte == 0)
+            .filter_map(|method| {
+                if !method.is_empty() {
+                    String::from_utf8(method.into()).ok()
+                } else {
+                    None
+                }
+            })
+            .collect::<Vec<_>>();
+
+        if binding_methods.len() != num_methods {
+            return Err(anyhow::anyhow!(
+                "Server response indicated {} binding methods, but {} methods were sent!",
+                num_methods,
+                binding_methods.len()
+            )
+            .into());
+        }
+
+        Ok(binding_methods)
     }
 }

--- a/siguldry/tests/client.rs
+++ b/siguldry/tests/client.rs
@@ -5,8 +5,13 @@
 //
 // These tests are expected to work against sigul v1.3+.
 
-use std::path::PathBuf;
+use std::{
+    path::PathBuf,
+    time::{Duration, SystemTime},
+};
 
+use openssl::{ec, rsa};
+use sequoia_openpgp::{armor, parse::Parse};
 use siguldry::error::{ClientError, Sigul};
 use tokio::sync::RwLock;
 
@@ -316,6 +321,923 @@ async fn modify_user_change_password() -> anyhow::Result<()> {
         .await?;
     assert_eq!(user.name(), test_user);
     assert!(user.admin());
+
+    Ok(())
+}
+
+/// Test that a key created with no owner is owned by the creating user.
+#[tokio::test]
+async fn key_user_info_self_owner() -> anyhow::Result<()> {
+    let client = get_client();
+    let _guard = SIGUL_CLIENT.read().await;
+    let key_name = "gpg-key-self-owner".to_string();
+    let cleanup = client
+        .delete_key("my-admin-password".into(), key_name.clone())
+        .await;
+    if cleanup.is_err() && !matches!(cleanup, Err(ClientError::Sigul(Sigul::KeyNotFound))) {
+        panic!(
+            "unexpected Sigul error while cleaning up, got {:?}",
+            cleanup
+        )
+    }
+
+    let key = client
+        .new_key(
+            "my-admin-password".into(),
+            "my-key-passphrase".into(),
+            key_name.clone(),
+            siguldry::client::KeyType::GnuPG {
+                real_name: Some("my real name".to_string()),
+                comment: Some("a comment".to_string()),
+                email: Some("gpg@example.com".to_string()),
+                expire_date: None,
+            },
+            None,
+        )
+        .await?;
+    assert_eq!(key.key_name(), &key_name);
+    key.as_string().expect("key should be valid UTF-8");
+
+    let key = client
+        .key_user_info(
+            "my-admin-password".into(),
+            "sigul-client".to_string(),
+            key_name.clone(),
+        )
+        .await?;
+    assert_eq!(key.key(), &key_name);
+    assert_eq!(key.user(), "sigul-client");
+    assert!(key.admin());
+
+    Ok(())
+}
+
+/// Test that a key created with an explicit owner is owned by that user.
+#[tokio::test]
+async fn key_user_info_other_owner() -> anyhow::Result<()> {
+    let client = get_client();
+    let _guard = SIGUL_CLIENT.read().await;
+    let key_name = "gpg-key-other-owner".to_string();
+    let test_user = "new-key-admin".to_string();
+    let cleanup_key = client
+        .delete_key("my-admin-password".into(), key_name.clone())
+        .await;
+    if cleanup_key.is_err() && !matches!(cleanup_key, Err(ClientError::Sigul(Sigul::KeyNotFound))) {
+        panic!(
+            "unexpected Sigul error while cleaning up, got {:?}",
+            cleanup_key
+        )
+    }
+    let cleanup_user = client
+        .delete_user("my-admin-password".into(), test_user.clone())
+        .await;
+    if cleanup_user.is_err()
+        && !matches!(cleanup_user, Err(ClientError::Sigul(Sigul::UserNotFound)))
+    {
+        panic!("Expected a Sigul error, got {:?}", cleanup_user)
+    }
+
+    client
+        .create_user(
+            "my-admin-password".into(),
+            test_user.to_string(),
+            false,
+            None,
+        )
+        .await?;
+    let key = client
+        .new_key(
+            "my-admin-password".into(),
+            "my-key-passphrase".into(),
+            key_name.clone(),
+            siguldry::client::KeyType::GnuPG {
+                real_name: Some("my real name".to_string()),
+                comment: Some("a comment".to_string()),
+                email: Some("gpg@example.com".to_string()),
+                expire_date: None,
+            },
+            Some(test_user.clone()),
+        )
+        .await?;
+    assert_eq!(key.key_name(), &key_name);
+    key.as_string().expect("key should be valid UTF-8");
+
+    let key = client
+        .key_user_info(
+            "my-admin-password".into(),
+            test_user.clone(),
+            key_name.clone(),
+        )
+        .await?;
+    assert_eq!(key.key(), &key_name);
+    assert_eq!(key.user(), &test_user);
+    assert!(key.admin());
+
+    let result = client
+        .key_user_info(
+            "my-admin-password".into(),
+            "sigul-client".to_string(),
+            key_name.clone(),
+        )
+        .await;
+
+    if !matches!(result, Err(ClientError::Sigul(Sigul::KeyUserNotFound))) {
+        panic!("Expected a Sigul error, got {:?}", result);
+    }
+
+    Ok(())
+}
+
+/// Test key owners can be modified to not be admins.
+#[tokio::test]
+async fn modify_key_user_demote_promote() -> anyhow::Result<()> {
+    let client = get_client();
+    let _guard = SIGUL_CLIENT.read().await;
+    let key_name = "gpg-key-other-not-owner".to_string();
+    let test_user = "new-key-not-admin".to_string();
+    let cleanup_key = client
+        .delete_key("my-admin-password".into(), key_name.clone())
+        .await;
+    if cleanup_key.is_err() && !matches!(cleanup_key, Err(ClientError::Sigul(Sigul::KeyNotFound))) {
+        panic!(
+            "unexpected Sigul error while cleaning up, got {:?}",
+            cleanup_key
+        )
+    }
+    let cleanup_user = client
+        .delete_user("my-admin-password".into(), test_user.clone())
+        .await;
+    if cleanup_user.is_err()
+        && !matches!(cleanup_user, Err(ClientError::Sigul(Sigul::UserNotFound)))
+    {
+        panic!("Expected a Sigul error, got {:?}", cleanup_user)
+    }
+
+    client
+        .create_user(
+            "my-admin-password".into(),
+            test_user.to_string(),
+            false,
+            None,
+        )
+        .await?;
+    let key = client
+        .new_key(
+            "my-admin-password".into(),
+            "my-key-passphrase".into(),
+            key_name.clone(),
+            siguldry::client::KeyType::GnuPG {
+                real_name: Some("my real name".to_string()),
+                comment: Some("a comment".to_string()),
+                email: Some("gpg@example.com".to_string()),
+                expire_date: None,
+            },
+            Some(test_user.clone()),
+        )
+        .await?;
+    assert_eq!(key.key_name(), &key_name);
+    key.as_string().expect("key should be valid UTF-8");
+
+    let key = client
+        .key_user_info(
+            "my-admin-password".into(),
+            test_user.clone(),
+            key_name.clone(),
+        )
+        .await?;
+    assert_eq!(key.key(), &key_name);
+    assert_eq!(key.user(), &test_user);
+    assert!(key.admin());
+
+    // Demote the user.
+    client
+        .modify_key_user(
+            "my-admin-password".into(),
+            test_user.clone(),
+            key_name.clone(),
+            Some(false),
+        )
+        .await?;
+
+    let key = client
+        .key_user_info(
+            "my-admin-password".into(),
+            test_user.clone(),
+            key_name.clone(),
+        )
+        .await?;
+    assert_eq!(key.key(), &key_name);
+    assert_eq!(key.user(), &test_user);
+    assert!(!key.admin());
+
+    // Promote
+    client
+        .modify_key_user(
+            "my-admin-password".into(),
+            test_user.clone(),
+            key_name.clone(),
+            Some(true),
+        )
+        .await?;
+    let key = client
+        .key_user_info(
+            "my-admin-password".into(),
+            test_user.clone(),
+            key_name.clone(),
+        )
+        .await?;
+    assert_eq!(key.key(), &key_name);
+    assert_eq!(key.user(), &test_user);
+    assert!(key.admin());
+
+    Ok(())
+}
+
+/// Test listing keys and asserting the created key is in the list.
+#[tokio::test]
+async fn key_create_and_list() -> anyhow::Result<()> {
+    let client = get_client();
+    let key_name = "gpg-key-create-list".to_string();
+    let _guard = SIGUL_CLIENT.read().await;
+    let cleanup = client
+        .delete_key("my-admin-password".into(), key_name.clone())
+        .await;
+    if cleanup.is_err() && !matches!(cleanup, Err(ClientError::Sigul(Sigul::KeyNotFound))) {
+        panic!("Expected a Sigul error, got {:?}", cleanup)
+    }
+
+    let key = client
+        .new_key(
+            "my-admin-password".into(),
+            "my-key-passphrase".into(),
+            key_name.clone(),
+            siguldry::client::KeyType::GnuPG {
+                real_name: Some("my real name".to_string()),
+                comment: Some("a comment".to_string()),
+                email: Some("gpg@example.com".to_string()),
+                expire_date: None,
+            },
+            None,
+        )
+        .await?;
+    assert_eq!(key.key_name(), &key_name);
+
+    let keys = client.keys("my-admin-password".into()).await?;
+    assert!(keys.iter().any(|k| *k == format!("{} (gnupg)", &key_name,)));
+
+    client
+        .delete_key("my-admin-password".into(), key_name)
+        .await?;
+
+    Ok(())
+}
+
+/// Test modifying a key name.
+#[tokio::test]
+async fn key_modify() -> anyhow::Result<()> {
+    let client = get_client();
+    let key_name = "gpg-key-modify".to_string();
+    let new_key_name = "gpg-key-modified".to_string();
+    let _guard = SIGUL_CLIENT.read().await;
+
+    let key = client
+        .new_key(
+            "my-admin-password".into(),
+            "my-key-passphrase".into(),
+            key_name.clone(),
+            siguldry::client::KeyType::GnuPG {
+                real_name: Some("my real name".to_string()),
+                comment: Some("a comment".to_string()),
+                email: Some("gpg@example.com".to_string()),
+                expire_date: None,
+            },
+            None,
+        )
+        .await?;
+    assert_eq!(key.key_name(), &key_name);
+    client
+        .modify_key(
+            "my-admin-password".into(),
+            key_name.clone(),
+            Some(new_key_name.clone()),
+        )
+        .await?;
+
+    let keys = client.keys("my-admin-password".into()).await?;
+    assert!(keys
+        .iter()
+        .any(|k| *k == format!("{} (gnupg)", &new_key_name,)));
+
+    client
+        .delete_key("my-admin-password".into(), new_key_name)
+        .await?;
+
+    Ok(())
+}
+
+/// Test creating and then deleting a GPG key.
+#[tokio::test]
+async fn key_gpg_create_and_delete() -> anyhow::Result<()> {
+    let client = get_client();
+    let key_name = "gpg-key-create-delete".to_string();
+    let _guard = SIGUL_CLIENT.read().await;
+    let key = client
+        .new_key(
+            "my-admin-password".into(),
+            "my-key-passphrase".into(),
+            key_name.clone(),
+            siguldry::client::KeyType::GnuPG {
+                real_name: Some("my real name".to_string()),
+                comment: Some("a comment".to_string()),
+                email: Some("gpg@example.com".to_string()),
+                expire_date: None,
+            },
+            None,
+        )
+        .await?;
+    assert_eq!(key.key_name(), &key_name);
+    let cert = sequoia_openpgp::Cert::from_reader(armor::Reader::from_bytes(
+        key.data(),
+        armor::ReaderMode::Tolerant(Some(armor::Kind::PublicKey)),
+    ))?;
+    assert_eq!(
+        cert.primary_key().key().pk_algo(),
+        sequoia_openpgp::types::PublicKeyAlgorithm::RSAEncryptSign
+    );
+
+    client
+        .delete_key("my-admin-password".into(), key_name)
+        .await?;
+
+    Ok(())
+}
+
+/// Test creating a GPG key with an expiration date.
+///
+/// The date needs to be in the future so in a few years this test will fail.
+#[tokio::test]
+pub async fn key_gpg_create_with_expiration() -> anyhow::Result<()> {
+    let client = get_client();
+    let _guard = SIGUL_CLIENT.read().await;
+    let key_name = "gpg-key-with-expiration".to_string();
+    let cleanup = client
+        .delete_key("my-admin-password".into(), key_name.clone())
+        .await;
+    if cleanup.is_err() && !matches!(cleanup, Err(ClientError::Sigul(Sigul::KeyNotFound))) {
+        panic!("Expected a Sigul error, got {:?}", cleanup)
+    }
+
+    let key = client
+        .new_key(
+            "my-admin-password".into(),
+            "my-key-passphrase".into(),
+            key_name.clone(),
+            siguldry::client::KeyType::GnuPG {
+                real_name: Some("my real name".to_string()),
+                comment: Some("a comment".to_string()),
+                email: Some("gpg@example.com".to_string()),
+                expire_date: Some("2032-06-01".to_string()),
+            },
+            None,
+        )
+        .await?;
+    assert_eq!(key.key_name(), &key_name);
+
+    Ok(())
+}
+
+/// Test creating and then deleting an RSA key.
+#[tokio::test]
+#[ignore = "RSA key creation does not work in Sigul"]
+async fn key_rsa_create_and_delete() {
+    let client = get_client();
+    let key_name = "rsa-key-create-delete".to_string();
+    let _guard = SIGUL_CLIENT.read().await;
+    let key = client
+        .new_key(
+            "my-admin-password".into(),
+            "my-key-passphrase".into(),
+            key_name.clone(),
+            siguldry::client::KeyType::Rsa,
+            None,
+        )
+        .await
+        .unwrap();
+    assert_eq!(key.key_name(), &key_name);
+
+    client
+        .delete_key("my-admin-password".into(), key_name)
+        .await
+        .unwrap();
+}
+
+/// Test creating and then deleting an ECC key.
+#[tokio::test]
+async fn key_ecc_create_and_delete() -> anyhow::Result<()> {
+    let client = get_client();
+    let key_name = "ecc-key-create-delete".to_string();
+    let _guard = SIGUL_CLIENT.read().await;
+    let key = client
+        .new_key(
+            "my-admin-password".into(),
+            "my-key-passphrase".into(),
+            key_name.clone(),
+            siguldry::client::KeyType::Ecc,
+            None,
+        )
+        .await?;
+    assert_eq!(key.key_name(), &key_name);
+
+    client
+        .delete_key("my-admin-password".into(), key_name)
+        .await?;
+
+    Ok(())
+}
+
+/// Assert the correct error is returned when trying to delete a key that doesn't exist.
+#[tokio::test]
+async fn key_delete_nonexistent() -> anyhow::Result<()> {
+    let client = get_client();
+    let _guard = SIGUL_CLIENT.read().await;
+    let key_name = "gpg-key-delete-nonexistent".to_string();
+    let result = client
+        .delete_key("my-admin-password".into(), key_name)
+        .await;
+    if !matches!(result, Err(ClientError::Sigul(Sigul::KeyNotFound))) {
+        panic!("Expected a Sigul error, got {:?}", result);
+    }
+    Ok(())
+}
+
+/// Create an RSA key and then import it to Sigul.
+#[tokio::test]
+pub async fn key_rsa_import() -> anyhow::Result<()> {
+    let client = get_client();
+    let _guard = SIGUL_CLIENT.read().await;
+    let key_name = "rsa-key-import".to_string();
+    let cleanup = client
+        .delete_key("my-admin-password".into(), key_name.clone())
+        .await;
+    if cleanup.is_err() && !matches!(cleanup, Err(ClientError::Sigul(Sigul::KeyNotFound))) {
+        panic!("Expected a Sigul error, got {:?}", cleanup)
+    }
+
+    let key = rsa::Rsa::generate(2048)?;
+    let pem = key.private_key_to_pem_passphrase(
+        openssl::symm::Cipher::aes_128_cbc(),
+        "my-key-passphrase".as_bytes(),
+    )?;
+
+    client
+        .import_key(
+            "my-admin-password".into(),
+            "my-key-passphrase".into(),
+            "my-new-key-passphrase".into(),
+            key_name.clone(),
+            pem.as_slice(),
+            siguldry::client::KeyType::Rsa,
+            None,
+        )
+        .await?;
+    let keys = client.keys("my-admin-password".into()).await?;
+    assert!(keys
+        .iter()
+        .any(|k| *k == format!("{} ({})", &key_name, siguldry::client::KeyType::Rsa)));
+
+    client
+        .delete_key("my-admin-password".into(), key_name)
+        .await?;
+
+    Ok(())
+}
+
+/// Create an ECC key and then import it to Sigul.
+#[tokio::test]
+pub async fn key_ecc_import() -> anyhow::Result<()> {
+    let client = get_client();
+    let _guard = SIGUL_CLIENT.read().await;
+    let key_name = "ecc-key-import".to_string();
+    let cleanup = client
+        .delete_key("my-admin-password".into(), key_name.clone())
+        .await;
+    if cleanup.is_err() && !matches!(cleanup, Err(ClientError::Sigul(Sigul::KeyNotFound))) {
+        panic!("Expected a Sigul error, got {:?}", cleanup)
+    }
+
+    let key = ec::EcKey::generate(
+        ec::EcGroup::from_curve_name(openssl::nid::Nid::X9_62_PRIME256V1)?.as_ref(),
+    )?;
+    let pem = key.private_key_to_pem_passphrase(
+        openssl::symm::Cipher::aes_128_cbc(),
+        "my-key-passphrase".as_bytes(),
+    )?;
+
+    client
+        .import_key(
+            "my-admin-password".into(),
+            "my-key-passphrase".into(),
+            "my-new-key-passphrase".into(),
+            key_name.clone(),
+            pem.as_slice(),
+            siguldry::client::KeyType::Ecc,
+            None,
+        )
+        .await?;
+    let keys = client.keys("my-admin-password".into()).await?;
+    assert!(keys
+        .iter()
+        .any(|k| *k == format!("{} ({})", &key_name, siguldry::client::KeyType::Ecc)));
+
+    client
+        .delete_key("my-admin-password".into(), key_name)
+        .await?;
+
+    Ok(())
+}
+
+/// Create an ECC key and try to import it as an RSA key, which should fail.
+#[tokio::test]
+#[ignore = "Sigul doesn't type check key imports"]
+pub async fn key_ecc_import_as_rsa() -> anyhow::Result<()> {
+    let client = get_client();
+    let _guard = SIGUL_CLIENT.read().await;
+    let key_name = "ecc-key-as-rsa-import".to_string();
+    let cleanup = client
+        .delete_key("my-admin-password".into(), key_name.clone())
+        .await;
+    if cleanup.is_err() && !matches!(cleanup, Err(ClientError::Sigul(Sigul::KeyNotFound))) {
+        panic!("Expected a Sigul error, got {:?}", cleanup)
+    }
+
+    let key = ec::EcKey::generate(
+        ec::EcGroup::from_curve_name(openssl::nid::Nid::X9_62_PRIME256V1)?.as_ref(),
+    )?;
+    let pem = key.private_key_to_pem_passphrase(
+        openssl::symm::Cipher::aes_128_cbc(),
+        "my-key-passphrase".as_bytes(),
+    )?;
+
+    let failure = client
+        .import_key(
+            "my-admin-password".into(),
+            "my-key-passphrase".into(),
+            "my-new-key-passphrase".into(),
+            key_name.clone(),
+            pem.as_slice(),
+            siguldry::client::KeyType::Rsa,
+            None,
+        )
+        .await;
+    assert!(matches!(
+        failure,
+        Err(ClientError::Sigul(Sigul::InvalidImport))
+    ));
+
+    Ok(())
+}
+
+/// Create a key, assert it's owned by the creating user.
+#[tokio::test]
+pub async fn key_users() -> anyhow::Result<()> {
+    let client = get_client();
+    let _guard = SIGUL_CLIENT.read().await;
+    let key_name = "gpg-key-users".to_string();
+    let cleanup = client
+        .delete_key("my-admin-password".into(), key_name.clone())
+        .await;
+    if cleanup.is_err() && !matches!(cleanup, Err(ClientError::Sigul(Sigul::KeyNotFound))) {
+        panic!("Expected a Sigul error, got {:?}", cleanup)
+    }
+
+    let key = client
+        .new_key(
+            "my-admin-password".into(),
+            "my-key-passphrase".into(),
+            key_name.clone(),
+            siguldry::client::KeyType::GnuPG {
+                real_name: Some("my real name".to_string()),
+                comment: Some("a comment".to_string()),
+                email: Some("gpg@example.com".to_string()),
+                expire_date: None,
+            },
+            None,
+        )
+        .await?;
+    assert_eq!(key.key_name(), &key_name);
+
+    let key_users = client
+        .key_users("my-admin-password".into(), key_name.clone())
+        .await?;
+    assert_eq!(key_users, vec!["sigul-client".to_string()]);
+
+    Ok(())
+}
+
+/// Create a key and a new user, and then add the user as a key user.
+#[tokio::test]
+pub async fn key_additional_users() -> anyhow::Result<()> {
+    let client = get_client();
+    let _guard = SIGUL_CLIENT.read().await;
+    let key_name = "gpg-key-additional-users".to_string();
+    let user_name = "additional-user".to_string();
+    let cleanup = client
+        .delete_key("my-admin-password".into(), key_name.clone())
+        .await;
+    if cleanup.is_err() && !matches!(cleanup, Err(ClientError::Sigul(Sigul::KeyNotFound))) {
+        panic!("Expected a Sigul error, got {:?}", cleanup)
+    }
+    let cleanup = client
+        .delete_user("my-admin-password".into(), user_name.clone())
+        .await;
+    if cleanup.is_err() && !matches!(cleanup, Err(ClientError::Sigul(Sigul::UserNotFound))) {
+        panic!("Expected a Sigul error, got {:?}", cleanup)
+    }
+
+    let key = client
+        .new_key(
+            "my-admin-password".into(),
+            "my-key-passphrase".into(),
+            key_name.clone(),
+            siguldry::client::KeyType::GnuPG {
+                real_name: Some("my real name".to_string()),
+                comment: Some("a comment".to_string()),
+                email: Some("gpg@example.com".to_string()),
+                expire_date: None,
+            },
+            None,
+        )
+        .await?;
+    assert_eq!(key.key_name(), &key_name);
+    client
+        .create_user(
+            "my-admin-password".into(),
+            user_name.clone(),
+            true,
+            Some("with-password".into()),
+        )
+        .await?;
+    client
+        .grant_key_access(
+            "my-admin-password".into(),
+            key_name.clone(),
+            "my-key-passphrase".into(),
+            user_name.clone(),
+            "user-key-passphrase".into(),
+            None,
+            None,
+        )
+        .await?;
+    let mut key_users = client
+        .key_users("my-admin-password".into(), key_name.clone())
+        .await?;
+    let mut expected_key_users = vec!["sigul-client".to_string(), user_name.clone()];
+    key_users.sort();
+    expected_key_users.sort();
+    assert_eq!(key_users, expected_key_users,);
+
+    Ok(())
+}
+
+/// Revoking a user should remove them from the key users list.
+#[tokio::test]
+pub async fn key_revoke_user() -> anyhow::Result<()> {
+    let client = get_client();
+    let _guard = SIGUL_CLIENT.read().await;
+    let key_name = "gpg-key-revoke-additional-user".to_string();
+    let user_name = "revoked-user".to_string();
+    let cleanup = client
+        .delete_key("my-admin-password".into(), key_name.clone())
+        .await;
+    if cleanup.is_err() && !matches!(cleanup, Err(ClientError::Sigul(Sigul::KeyNotFound))) {
+        panic!("Expected a Sigul error, got {:?}", cleanup)
+    }
+    let cleanup = client
+        .delete_user("my-admin-password".into(), user_name.clone())
+        .await;
+    if cleanup.is_err() && !matches!(cleanup, Err(ClientError::Sigul(Sigul::UserNotFound))) {
+        panic!("Expected a Sigul error, got {:?}", cleanup)
+    }
+
+    let key = client
+        .new_key(
+            "my-admin-password".into(),
+            "my-key-passphrase".into(),
+            key_name.clone(),
+            siguldry::client::KeyType::GnuPG {
+                real_name: Some("my real name".to_string()),
+                comment: Some("a comment".to_string()),
+                email: Some("gpg@example.com".to_string()),
+                expire_date: None,
+            },
+            None,
+        )
+        .await?;
+    assert_eq!(key.key_name(), &key_name);
+    client
+        .create_user(
+            "my-admin-password".into(),
+            user_name.clone(),
+            true,
+            Some("with-password".into()),
+        )
+        .await?;
+    client
+        .grant_key_access(
+            "my-admin-password".into(),
+            key_name.clone(),
+            "my-key-passphrase".into(),
+            user_name.clone(),
+            "user-key-passphrase".into(),
+            None,
+            None,
+        )
+        .await?;
+    let mut key_users = client
+        .key_users("my-admin-password".into(), key_name.clone())
+        .await?;
+    let mut expected_key_users = vec!["sigul-client".to_string(), user_name.clone()];
+    key_users.sort();
+    expected_key_users.sort();
+    assert_eq!(key_users, expected_key_users,);
+
+    client
+        .revoke_key_access(
+            "my-admin-password".into(),
+            key_name.clone(),
+            user_name.clone(),
+        )
+        .await?;
+    let key_users = client
+        .key_users("my-admin-password".into(), key_name.clone())
+        .await?;
+    assert_eq!(key_users, vec!["sigul-client".to_string()]);
+
+    Ok(())
+}
+
+/// Test key expiration for GPG keys can be altered.
+///
+/// The test requires dates in the future, so it will fail if run after the expiration date.
+#[tokio::test]
+pub async fn key_gpg_expiration() -> anyhow::Result<()> {
+    let client = get_client();
+    let _guard = SIGUL_CLIENT.read().await;
+    let key_name = "gpg-key-expiration".to_string();
+    let policy = sequoia_openpgp::policy::StandardPolicy::new();
+    // 2032-05-31
+    let pre_expiration = SystemTime::UNIX_EPOCH + Duration::from_secs(1969574400);
+    // 2032-07-01
+    let post_expiration = SystemTime::UNIX_EPOCH + Duration::from_secs(1972252800);
+    // 2032-07-03
+    let post_post_expiration = SystemTime::UNIX_EPOCH + Duration::from_secs(1972425600);
+    let cleanup = client
+        .delete_key("my-admin-password".into(), key_name.clone())
+        .await;
+    if cleanup.is_err() && !matches!(cleanup, Err(ClientError::Sigul(Sigul::KeyNotFound))) {
+        panic!("Expected a Sigul error, got {:?}", cleanup)
+    }
+
+    let key = client
+        .new_key(
+            "my-admin-password".into(),
+            "my-key-passphrase".into(),
+            key_name.clone(),
+            siguldry::client::KeyType::GnuPG {
+                real_name: Some("my real name".to_string()),
+                comment: Some("a comment".to_string()),
+                email: Some("gpg@example.com".to_string()),
+                expire_date: Some("2032-06-01".to_string()),
+            },
+            None,
+        )
+        .await?;
+    assert_eq!(key.key_name(), &key_name);
+    let cert = sequoia_openpgp::Cert::from_reader(armor::Reader::from_bytes(
+        key.data(),
+        armor::ReaderMode::Tolerant(Some(armor::Kind::PublicKey)),
+    ))?;
+    assert!(cert.with_policy(&policy, pre_expiration)?.alive().is_ok());
+    assert!(cert.with_policy(&policy, post_expiration)?.alive().is_err());
+
+    client
+        .change_key_expiration(
+            "my-admin-password".into(),
+            key_name.clone(),
+            "my-key-passphrase".into(),
+            None,
+            Some("2032-07-02".to_string()),
+        )
+        .await?;
+    let key = client
+        .get_public_key("my-admin-password".into(), key_name.clone())
+        .await?;
+    assert_eq!(key.key_name(), &key_name);
+    let cert = sequoia_openpgp::Cert::from_reader(armor::Reader::from_bytes(
+        key.data(),
+        armor::ReaderMode::Tolerant(Some(armor::Kind::PublicKey)),
+    ))?;
+    assert!(cert.with_policy(&policy, pre_expiration)?.alive().is_ok());
+    assert!(cert.with_policy(&policy, post_expiration)?.alive().is_ok());
+    assert!(cert
+        .with_policy(&policy, post_post_expiration)?
+        .alive()
+        .is_err());
+
+    Ok(())
+}
+
+#[tokio::test]
+pub async fn change_key_passphrase() -> anyhow::Result<()> {
+    let client = get_client();
+    let _guard = SIGUL_CLIENT.read().await;
+    let key_name = "gpg-key-change-passphrase".to_string();
+    let user_name = "changed-passphrase-user".to_string();
+    let cleanup = client
+        .delete_key("my-admin-password".into(), key_name.clone())
+        .await;
+    if cleanup.is_err() && !matches!(cleanup, Err(ClientError::Sigul(Sigul::KeyNotFound))) {
+        panic!("Expected a Sigul error, got {:?}", cleanup)
+    }
+    let cleanup = client
+        .delete_user("my-admin-password".into(), user_name.clone())
+        .await;
+    if cleanup.is_err() && !matches!(cleanup, Err(ClientError::Sigul(Sigul::UserNotFound))) {
+        panic!("Expected a Sigul error, got {:?}", cleanup)
+    }
+
+    client
+        .new_key(
+            "my-admin-password".into(),
+            "my-key-passphrase".into(),
+            key_name.clone(),
+            siguldry::client::KeyType::GnuPG {
+                real_name: Some("my real name".to_string()),
+                comment: Some("a comment".to_string()),
+                email: Some("gpg@example.com".to_string()),
+                expire_date: None,
+            },
+            None,
+        )
+        .await?;
+    client
+        .change_passphrase(
+            key_name.clone(),
+            "my-key-passphrase".into(),
+            "my-new-key-passphrase".into(),
+            None,
+            None,
+        )
+        .await?;
+
+    client
+        .create_user(
+            "my-admin-password".into(),
+            user_name.clone(),
+            true,
+            Some("with-password".into()),
+        )
+        .await?;
+    let failure = client
+        .grant_key_access(
+            "my-admin-password".into(),
+            key_name.clone(),
+            "my-key-passphrase".into(),
+            user_name.clone(),
+            "user-key-passphrase".into(),
+            None,
+            None,
+        )
+        .await;
+    assert!(matches!(
+        failure,
+        Err(ClientError::Sigul(Sigul::AuthenticationFailed))
+    ));
+    client
+        .grant_key_access(
+            "my-admin-password".into(),
+            key_name.clone(),
+            "my-new-key-passphrase".into(),
+            user_name.clone(),
+            "user-key-passphrase".into(),
+            None,
+            None,
+        )
+        .await?;
+
+    Ok(())
+}
+
+#[tokio::test]
+pub async fn server_binding_methods() -> anyhow::Result<()> {
+    let client = get_client();
+    let _guard = SIGUL_CLIENT.read().await;
+    let expected_methods: Vec<String> = vec![];
+
+    let methods = client
+        .server_binding_methods("my-admin-password".into())
+        .await?;
+    assert_eq!(methods, expected_methods);
 
     Ok(())
 }


### PR DESCRIPTION
This commit adds support for key management related commands. These include creating and deleting keys, importing keys, altering access to those keys, modifying their names and expiration dates, getting the public keys, and changing the passphrases for keys.