### PR TITLE
sigul-pesign-bridge: add a mapping for pesign-client token/cert names

### DIFF
--- a/devel/github/config.toml
+++ b/devel/github/config.toml
@@ -11,11 +11,15 @@ client_certificate = "sigul.client.certificate.pem"
 ca_certificate = "sigul.ca_certificate.pem"
 
 [[keys]]
+pesign_token_name = "OpenSC Card"
+pesign_certificate_name = "whatever pesign asked for"
 key_name = "Sigul HSM Key"
 certificate_name = "Secure Boot Code Signing Certificate"
 passphrase_path = "sigul.signing-key-passphrase"
 
 [[keys]]
+pesign_token_name = "OpenSC Card"
+pesign_certificate_name = "whatever pesign asked for"
 key_name = "bad key"
 certificate_name = "bad cert"
 passphrase_path = "sigul.signing-key-passphrase"

--- a/devel/local/config.toml
+++ b/devel/local/config.toml
@@ -11,11 +11,15 @@ client_certificate = "sigul.client.certificate.pem"
 ca_certificate = "sigul.ca_certificate.pem"
 
 [[keys]]
+pesign_token_name = "OpenSC Card"
+pesign_certificate_name = "whatever pesign asked for"
 key_name = "Sigul HSM Key"
 certificate_name = "Secure Boot Code Signing Certificate"
 passphrase_path = "sigul.signing-key-passphrase"
 
 [[keys]]
+pesign_token_name = "OpenSC Card"
+pesign_certificate_name = "whatever pesign asked for"
 key_name = "bad key"
 certificate_name = "bad cert"
 passphrase_path = "sigul.signing-key-passphrase"

--- a/sigul-pesign-bridge/CHANGELOG.md
+++ b/sigul-pesign-bridge/CHANGELOG.md
@@ -13,6 +13,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - The minimum supported Rust version (MSRV) is now 1.84 to align with RHEL 9.6 and 10.0 (#45)
 
+- The `keys` section of the configuration file now has two additional required fields:
+  `pesign_token_name` and `pesign_certificate_name`. These are used when looking up
+  the key entry for a pesign-client request and the `key_name` and `certificate_name`
+  fields are used when requesting the signature from Sigul. This allows the names in
+  Sigul to be different from what pesign-client is aware of (#51)
+
 
 ## [0.4.0] - 2025-05-05
 

--- a/sigul-pesign-bridge/config.toml.example
+++ b/sigul-pesign-bridge/config.toml.example
@@ -66,6 +66,16 @@ ca_certificate = "sigul.ca_certificate.pem"
 # and `--certificate` arguments respectively. If the pesign-client specifies
 # a pair that isn't present in this configuration file, the request is rejected.
 [[keys]]
+# The token name that pesign-client provides; it will be mapped to the
+# `key_name` field when passed to sigul. For example, if pesign-client
+# asks for "OpenSC Card" and the key name in Sigul is "fedora-signer",
+# set `pesign_token_name` to "OpenSC Card" and `key_name` to "fedora-signer".
+pesign_token_name = "OpenSC Card"
+
+# The certificate name that pesign-client provides; it will be mapped to
+# the `certificate_name` field just like `pesign_token_name` is mapped.
+pesign_certificate_name = "some certificate"
+
 # The name of the key in Sigul.
 key_name = "signing-key"
 

--- a/sigul-pesign-bridge/src/config.rs
+++ b/sigul-pesign-bridge/src/config.rs
@@ -107,6 +107,14 @@ impl Default for Siguldry {
 /// [`Config`], its request is rejected.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct Key {
+    /// The token name that pesign-client provides; it will be mapped to the
+    /// `key_name` field when passed to sigul. For example, if pesign-client
+    /// asks for "OpenSC Card" and the key name in Sigul is "fedora-signer",
+    /// set `pesign_token_name` to "OpenSC Card" and `key_name` to "fedora-signer".
+    pub pesign_token_name: String,
+    /// The certificate name that pesign-client provides; it will be mapped to
+    /// the `certificate_name` field just like `pesign_token_name` is mapped.
+    pub pesign_certificate_name: String,
     /// The name of the key in the Sigul server.
     pub key_name: String,
     /// The name of the certificate in the Sigul server.
@@ -125,6 +133,8 @@ pub struct Key {
 impl Default for Key {
     fn default() -> Self {
         Self {
+            pesign_token_name: "OpenSC Card".to_string(),
+            pesign_certificate_name: "some-signing-certificate".to_string(),
             key_name: "signing-key".to_string(),
             certificate_name: "codesigning".to_string(),
             passphrase_path: PathBuf::from("sigul.signing-key-passphrase"),

--- a/sigul-pesign-bridge/src/pesign.rs
+++ b/sigul-pesign-bridge/src/pesign.rs
@@ -256,7 +256,8 @@ impl SignAttachedRequest {
         available_keys
             .iter()
             .find(|key| {
-                key.key_name == self.token_name && key.certificate_name == self.certificate_name
+                key.pesign_token_name == self.token_name
+                    && key.pesign_certificate_name == self.certificate_name
             })
             .ok_or_else(|| {
                 tracing::error!(

--- a/sigul-pesign-bridge/src/service.rs
+++ b/sigul-pesign-bridge/src/service.rs
@@ -357,6 +357,7 @@ async fn sign_attached_with_filetype(
     request: SignAttachedRequest,
 ) -> Result<(), anyhow::Error> {
     let key = request.key(&context.config.keys)?;
+    tracing::debug!(?key, "signing request mapped to a known key");
     let temp_dir = tempfile::Builder::new()
         .prefix(".work")
         .rand_bytes(16)

--- a/sigul-pesign-bridge/tests/pesign_client.rs
+++ b/sigul-pesign-bridge/tests/pesign_client.rs
@@ -153,6 +153,8 @@ fn signing_times_out() -> Result<()> {
                 ca_certificate = "sigul.ca_certificate.pem"
 
                 [[keys]]
+                pesign_token_name = "OpenSC Card"
+                pesign_certificate_name = "whatever pesign asked for"
                 key_name = "Sigul HSM Key"
                 certificate_name = "Secure Boot Code Signing Certificate"
                 passphrase_path = "sigul.signing-key-passphrase"
@@ -164,8 +166,8 @@ fn signing_times_out() -> Result<()> {
     let mut client_command = Command::new("pesign-client");
     client_command
         .arg("--sign")
-        .arg("--token=Sigul HSM Key")
-        .arg("--certificate=Secure Boot Code Signing Certificate")
+        .arg("--token=OpenSC Card")
+        .arg("--certificate=whatever pesign asked for")
         .arg(format!("--infile={}", in_file.as_path().display()))
         .arg(format!("--outfile={}", &out_file.as_path().display()));
     let (client_output, service_output) = run_command(client_command, Some(config_path))?;
@@ -217,6 +219,8 @@ fn signing_hangs_up() -> Result<()> {
                 ca_certificate = "sigul.ca_certificate.pem"
 
                 [[keys]]
+                pesign_token_name = "OpenSC Card"
+                pesign_certificate_name = "whatever pesign asked for"
                 key_name = "Sigul HSM Key"
                 certificate_name = "Secure Boot Code Signing Certificate"
                 passphrase_path = "sigul.signing-key-passphrase"
@@ -228,8 +232,8 @@ fn signing_hangs_up() -> Result<()> {
     let mut client_command = Command::new("pesign-client");
     client_command
         .arg("--sign")
-        .arg("--token=Sigul HSM Key")
-        .arg("--certificate=Secure Boot Code Signing Certificate")
+        .arg("--token=OpenSC Card")
+        .arg("--certificate=whatever pesign asked for")
         .arg(format!("--infile={}", in_file.as_path().display()))
         .arg(format!("--outfile={}", &out_file.as_path().display()));
     let (client_output, service_output) = run_command(client_command, Some(config_path))?;
@@ -256,8 +260,8 @@ fn sign_attached() -> Result<()> {
     let mut client_command = Command::new("pesign-client");
     client_command
         .arg("--sign")
-        .arg("--token=Sigul HSM Key")
-        .arg("--certificate=Secure Boot Code Signing Certificate")
+        .arg("--token=OpenSC Card")
+        .arg("--certificate=whatever pesign asked for")
         .arg(format!("--infile={}", in_file.as_path().display()))
         .arg(format!("--outfile={}", &out_file.as_path().display()));
     let (client_output, service_output) = run_command(client_command, None)?;


### PR DESCRIPTION
Add two new fields to the keys configuration which maps the token name and certificate used by pesign-client to different names used in Sigul.