### PR TITLE
deps: Opt into the Rust versions fallback setting for the resolver

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,6 +1,9 @@
 [alias]
 xtask = "run --package xtask --"
 
+[resolver]
+incompatible-rust-versions = "fallback"
+
 [target.'cfg(all())']
 rustflags = [
     # Reject unsafe code - we shouldn't need it for anything here.

--- a/siguldry/Cargo.toml
+++ b/siguldry/Cargo.toml
@@ -69,16 +69,10 @@ features = ["auto-initialize"]
 
 # As we use OpenSSL for the TLS connection, let's stick with it for this as well.
 # The upstream default engine is nettle.
-#
-# Bump to 2.0 once Rust 1.85 is available (November 2025)
 [dev-dependencies.sequoia-openpgp]
 version = "2"
 default-features = false
 features = ["crypto-openssl"]
-
-[dev-dependencies.base64ct]
-# Pinned as 1.8 needs Rust 1.85 and its a dep of sequoia
-version = "< 1.8"
 
 
 [[bin]]


### PR DESCRIPTION
When resolving which version of a dependency to use, select how versions with incompatible package.rust-versions are treated. With fallback, it only considers rust-version-incompatible versions if no other version matched. This is supported as of 1.84.