### PR TITLE
Bump Rust MSRV to 1.88 and enable 2024 edition

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -58,18 +58,56 @@ jobs:
       - name: Run zizmor 🌈
         run: zizmor .
 
+  style:
+    name: Code style checks
+    runs-on: ubuntu-latest
+    container:
+      image: quay.io/fedora/fedora:43
+    steps:
+      - uses: actions/checkout@v5
+        with:
+          persist-credentials: false
+      - uses: dtolnay/rust-toolchain@fcf085fcb4b4b8f63f96906cd713eb52181b5ea4
+        id: rust-toolchain
+        with:
+          toolchain: stable
+          components: clippy, rustfmt
+
+      - uses: Swatinem/rust-cache@f13886b937689c021905a6b90929199931d60db1
+
+      - name: cargo fmt
+        run: cargo fmt --all --check
+
+      - name: Install test packages
+        run: |
+          dnf install -y \
+            capnproto \
+            clang \
+            sequoia-sq \
+            sequoia-keystore-server \
+            pesign \
+            pkcs11-provider \
+            pkg-config \
+            python3-devel \
+            opensc \
+            openssl \
+            openssl-devel \
+            softhsm \
+            sqlite-devel
+
+      - name: cargo clippy
+        run: cargo clippy --all-targets --all-features -- --deny warnings
+
   test:
     name: Unit tests
     runs-on: ubuntu-latest
     container:
-      image: quay.io/fedora/fedora:42
+      image: quay.io/fedora/fedora:43
     strategy:
       matrix:
         # Support current stable and the toolchain that ships with
-        # the latest RHEL 9 minor release. 9.6 targets 1.84.
-        #
-        # https://issues.redhat.com/browse/RHEL-61964
-        rust-toolchain: [stable, "1.84"]
+        # the latest RHEL 10 minor release. 10.1 targets 1.88.
+        rust-toolchain: [stable, "1.88"]
     steps:
       - uses: actions/checkout@v5
         with:
@@ -107,14 +145,8 @@ jobs:
           sudo mkdir -p /run/pesign/
           sudo chmod -R 777 /run/pesign/
 
-      - name: cargo fmt
-        run: cargo fmt --all --check
-
       - name: cargo build
         run: cargo build
-
-      - name: cargo clippy
-        run: cargo clippy --all-targets --all-features -- --deny warnings
 
       - name: Run unit tests
         run: cargo nextest run

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,13 +9,11 @@ members = [
 
 [workspace.package]
 # This targets the latest Enterprise Linux Rust version.
-rust-version = "1.84"
-edition = "2021"
+rust-version = "1.88"
+edition = "2024"
 license = "MIT"
 
 [workspace.lints.rust]
-# We shouldn't need to do anything unsafe
-unsafe-code = {level = "forbid", priority = 1}
 # Opt in to a few additional lints from rustc
 #
 # Refer to `rustc -W help` output for lint groups and individual rules.

--- a/sample-uefi/Cargo.toml
+++ b/sample-uefi/Cargo.toml
@@ -1,7 +1,8 @@
 [package]
 name = "sample-uefi"
 version = "0.1.0"
-edition = "2021"
+edition = { workspace = true }
+rust-version = { workspace = true }
 license = "MIT"
 publish = false
 

--- a/sigul-pesign-bridge/CHANGELOG.md
+++ b/sigul-pesign-bridge/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.7.0] - Unreleased
+
+### Changed
+
+- The minimum supported Rust version is now 1.88 (#96)
+
+
 ## [0.6.0] - 2025-11-24
 
 ### Changed

--- a/sigul-pesign-bridge/Cargo.toml
+++ b/sigul-pesign-bridge/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sigul-pesign-bridge"
-version = "0.6.0"
+version = "0.7.0"
 edition = { workspace = true }
 rust-version = { workspace = true }
 license = "MIT"
@@ -37,7 +37,7 @@ features = ["net"]
 
 [dependencies.siguldry]
 path = "../siguldry"
-version = "0.4"
+version = "0.5"
 default-features = false
 features = ["sigul-client"]
 

--- a/sigul-pesign-bridge/docs/sigul-pesign-bridge.1
+++ b/sigul-pesign-bridge/docs/sigul-pesign-bridge.1
@@ -1,6 +1,6 @@
 .ie \n(.g .ds Aq \(aq
 .el .ds Aq '
-.TH sigul-pesign-bridge 1  "sigul-pesign-bridge 0.6.0" 
+.TH sigul-pesign-bridge 1  "sigul-pesign-bridge 0.7.0" 
 .SH NAME
 sigul\-pesign\-bridge \- An alternative to the pesign daemon interface
 .SH SYNOPSIS
@@ -47,4 +47,4 @@ Print the current service configuration to standard output
 sigul\-pesign\-bridge\-help(1)
 Print this message or the help of the given subcommand(s)
 .SH VERSION
-v0.6.0
+v0.7.0

--- a/sigul-pesign-bridge/src/config.rs
+++ b/sigul-pesign-bridge/src/config.rs
@@ -16,7 +16,7 @@
 
 use std::{num::NonZeroU64, path::PathBuf};
 
-use anyhow::{anyhow, Context};
+use anyhow::{Context, anyhow};
 use serde::{Deserialize, Serialize};
 
 /// The configuration file.
@@ -160,11 +160,7 @@ impl Key {
             .next()
             .and_then(|pass| {
                 let pass = pass.trim();
-                if !pass.is_empty() {
-                    Some(pass)
-                } else {
-                    None
-                }
+                if !pass.is_empty() { Some(pass) } else { None }
             })
             .ok_or_else(|| {
                 anyhow!(
@@ -207,15 +203,13 @@ impl Config {
                     key.passphrase_path = passphrase_path;
                 }
 
-                if let Some(ca_cert) = &key.certificate_file {
-                    if !ca_cert.is_absolute() {
+                if let Some(ca_cert) = &key.certificate_file  && !ca_cert.is_absolute() {
                         let absolute_ca_cert = credentials_dir.join(ca_cert);
                         if !absolute_ca_cert.exists() {
                             tracing::error!(key.key_name, ?key.certificate_file, "CA file is not an absolute path and isn't in the credentials directory");
                             return Err(anyhow::anyhow!("CA file '{}' is missing", ca_cert.display()));
                         }
                         key.certificate_file = Some(absolute_ca_cert);
-                    }
 
                 }
 

--- a/sigul-pesign-bridge/src/main.rs
+++ b/sigul-pesign-bridge/src/main.rs
@@ -3,9 +3,9 @@
 
 use anyhow::Context;
 use clap::Parser;
-use tokio::signal::unix::{signal, SignalKind};
+use tokio::signal::unix::{SignalKind, signal};
 use tokio_util::sync::CancellationToken;
-use tracing_subscriber::{fmt::format::FmtSpan, layer::SubscriberExt, EnvFilter};
+use tracing_subscriber::{EnvFilter, fmt::format::FmtSpan, layer::SubscriberExt};
 
 use sigul_pesign_bridge::{cli, listen};
 

--- a/sigul-pesign-bridge/src/service.rs
+++ b/sigul-pesign-bridge/src/service.rs
@@ -17,7 +17,7 @@ use std::{
     time::Duration,
 };
 
-use anyhow::{anyhow, Context as AnyhowContext};
+use anyhow::{Context as AnyhowContext, anyhow};
 use bytes::Bytes;
 use siguldry::v1::error::ClientError;
 use tokio::{
@@ -26,7 +26,7 @@ use tokio::{
     task::JoinHandle,
 };
 use tokio_util::{sync::CancellationToken, task::TaskTracker};
-use tracing::{instrument, Instrument};
+use tracing::{Instrument, instrument};
 
 use crate::pesign::{self, Command, Header, Response, SignAttachedRequest};
 
@@ -491,7 +491,7 @@ mod tests {
     use std::time::Duration;
     use std::{io, num::NonZeroU64};
 
-    use anyhow::{anyhow, Result};
+    use anyhow::{Result, anyhow};
     use bytes::{BufMut, Bytes, BytesMut};
     use rustix::fs::Mode;
     use tokio::io::{AsyncReadExt, AsyncWriteExt};

--- a/sigul-pesign-bridge/tests/pesign_client.rs
+++ b/sigul-pesign-bridge/tests/pesign_client.rs
@@ -18,11 +18,11 @@ use std::{
     time::Duration,
 };
 
-use anyhow::{anyhow, Result};
+use anyhow::{Result, anyhow};
 use assert_cmd::cargo;
 use rustix::{
     fs::Mode,
-    process::{kill_process, Pid},
+    process::{Pid, kill_process},
 };
 use tempfile::NamedTempFile;
 
@@ -347,8 +347,11 @@ fn kill() -> Result<()> {
     );
     assert!(service_output.status.success());
     let service_logs = String::from_utf8_lossy(&service_output.stderr);
-    assert!(service_logs
-        .contains("Client queried for the server version of command Kill, which is not supported"));
+    assert!(
+        service_logs.contains(
+            "Client queried for the server version of command Kill, which is not supported"
+        )
+    );
 
     Ok(())
 }

--- a/siguldry/CHANGELOG.md
+++ b/siguldry/CHANGELOG.md
@@ -5,12 +5,19 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.5.0] - Unreleased
+
+### Changed
+
+- The minimum supported Rust version is now 1.88 (#96)
+
+
 ## [0.4.1] - 2025-11-25
 
 ### Fixed
 
 -  Fixed building the siguldry crate outside the git repository by relocating the sqlx fixtures to
-   the crate (#86)
+   the crate (#95)
 
 
 ## [0.4.0] - 2025-11-24

--- a/siguldry/Cargo.toml
+++ b/siguldry/Cargo.toml
@@ -3,7 +3,7 @@ name = "siguldry"
 license = "MIT"
 edition = { workspace = true }
 rust-version = { workspace = true }
-version = "0.4.1"
+version = "0.5.0"
 readme = "README.md"
 description = """
 An implementation of the Sigul protocol.

--- a/siguldry/benches/end_to_end.rs
+++ b/siguldry/benches/end_to_end.rs
@@ -17,7 +17,7 @@ use std::{
 
 use anyhow::bail;
 use assert_cmd::cargo;
-use criterion::{criterion_group, criterion_main, BenchmarkId, Criterion};
+use criterion::{BenchmarkId, Criterion, criterion_group, criterion_main};
 use siguldry::{bridge, client, config::Credentials, protocol::GpgSignatureType, server};
 use tokio::{process::Command, task::JoinSet};
 use tracing::Instrument;

--- a/siguldry/src/bin/siguldry-bridge/main.rs
+++ b/siguldry/src/bin/siguldry-bridge/main.rs
@@ -9,10 +9,10 @@ use siguldry::{
     bridge::{self, Config},
     config::load_config,
 };
-use tokio::signal::unix::{signal, SignalKind};
+use tokio::signal::unix::{SignalKind, signal};
 use tokio_util::sync::CancellationToken;
 use tracing::Instrument;
-use tracing_subscriber::{fmt::format::FmtSpan, layer::SubscriberExt, EnvFilter};
+use tracing_subscriber::{EnvFilter, fmt::format::FmtSpan, layer::SubscriberExt};
 
 // The path, relative to $XDG_CONFIG_HOME, of the default config file location.
 const DEFAULT_CONFIG: &str = "siguldry/bridge.toml";
@@ -127,7 +127,9 @@ async fn main() -> anyhow::Result<()> {
         Command::Config {
             credentials_directory,
         } => {
-            println!("# This is the current configuration\n\n{config}\n# This concludes the configuration.\n");
+            println!(
+                "# This is the current configuration\n\n{config}\n# This concludes the configuration.\n"
+            );
             _ = config.credentials.with_credentials_dir(&credentials_directory).inspect_err(|error|{
                 eprintln!("The configuration format is valid, but the referenced credentials aren't valid: {error:?}");
             });

--- a/siguldry/src/bin/siguldry-client/main.rs
+++ b/siguldry/src/bin/siguldry-client/main.rs
@@ -9,7 +9,7 @@ use siguldry::{
     client::{Client, Config},
     config::load_config,
 };
-use tracing_subscriber::{fmt::format::FmtSpan, layer::SubscriberExt, EnvFilter};
+use tracing_subscriber::{EnvFilter, fmt::format::FmtSpan, layer::SubscriberExt};
 
 // The path, relative to $XDG_CONFIG_HOME, of the default config file location.
 const DEFAULT_CONFIG: &str = "siguldry/client.toml";
@@ -105,7 +105,9 @@ async fn main() -> anyhow::Result<()> {
     let mut config = load_config::<Config>(opts.config, PathBuf::from(DEFAULT_CONFIG).as_path())?;
 
     if let Command::Config = opts.command {
-        println!("# This is the current configuration\n\n{config}\n# This concludes the configuration.\n");
+        println!(
+            "# This is the current configuration\n\n{config}\n# This concludes the configuration.\n"
+        );
 
         opts.credentials_directory
         .as_ref()

--- a/siguldry/src/bin/siguldry-server/main.rs
+++ b/siguldry/src/bin/siguldry-server/main.rs
@@ -7,17 +7,17 @@ use anyhow::Context;
 use clap::Parser;
 use siguldry::{
     config::load_config,
-    server::{service::Server, Config},
+    server::{Config, service::Server},
 };
 use tokio::{
     io::{AsyncReadExt, AsyncWriteExt},
     net::UnixStream,
-    signal::unix::{signal, SignalKind},
+    signal::unix::{SignalKind, signal},
     time::timeout,
 };
 use tokio_util::sync::CancellationToken;
 use tracing::Instrument;
-use tracing_subscriber::{fmt::format::FmtSpan, layer::SubscriberExt, EnvFilter};
+use tracing_subscriber::{EnvFilter, fmt::format::FmtSpan, layer::SubscriberExt};
 
 use crate::management::PromptPassword;
 
@@ -96,7 +96,9 @@ async fn main() -> anyhow::Result<()> {
         cli::Command::Config {
             credentials_directory,
         } => {
-            println!("# This is the current configuration\n\n{config}\n# This concludes the configuration.\n");
+            println!(
+                "# This is the current configuration\n\n{config}\n# This concludes the configuration.\n"
+            );
             _ = config.credentials.with_credentials_dir(&credentials_directory).inspect_err(|error|{
                 eprintln!("The configuration format is valid, but the referenced credentials aren't valid: {error:?}");
             });

--- a/siguldry/src/bin/siguldry-server/management.rs
+++ b/siguldry/src/bin/siguldry-server/management.rs
@@ -13,12 +13,13 @@ use openssl::{
     x509,
 };
 use rustix::termios::Termios;
-use sequoia_openpgp::{cert::CipherSuite, crypto::Password, Profile};
+use sequoia_openpgp::{Profile, cert::CipherSuite, crypto::Password};
 use siguldry::{
     protocol::KeyAlgorithm,
     server::{
+        Config,
         crypto::{self, create_encrypted_key, decrypt_key_password},
-        db, Config,
+        db,
     },
 };
 use tracing::instrument;

--- a/siguldry/src/client.rs
+++ b/siguldry/src/client.rs
@@ -10,8 +10,8 @@ use std::{sync::Arc, time::Duration};
 use anyhow::Context;
 use bytes::{BufMut, Bytes, BytesMut};
 use serde::{Deserialize, Serialize};
-use tokio::sync::oneshot::Receiver;
 use tokio::sync::Mutex;
+use tokio::sync::oneshot::Receiver;
 use tokio::{
     io::{AsyncReadExt, AsyncWriteExt},
     sync::{mpsc, oneshot},
@@ -27,9 +27,8 @@ use crate::{
     error::{ClientError, ConnectionError},
     nestls::Nestls,
     protocol::{
-        self,
+        self, Frame, Request, Role,
         json::{OuterRequest, OuterResponse, Response},
-        Frame, Request, Role,
     },
 };
 

--- a/siguldry/src/protocol.rs
+++ b/siguldry/src/protocol.rs
@@ -78,8 +78,8 @@ use tokio_openssl::SslStream;
 use tracing::instrument;
 use uuid::Uuid;
 use zerocopy::{
-    byteorder::network_endian::{U128, U32, U64},
     Immutable, IntoBytes, KnownLayout, TryFromBytes,
+    byteorder::network_endian::{U32, U64, U128},
 };
 
 use crate::error::ConnectionError;
@@ -570,7 +570,7 @@ impl std::fmt::Display for DigestAlgorithm {
             DigestAlgorithm::Sha3_256 => "sha3-256",
             DigestAlgorithm::Sha3_512 => "sha3-512",
         };
-        write!(f, "{}", name)
+        write!(f, "{name}")
     }
 }
 

--- a/siguldry/src/serdes/ser.rs
+++ b/siguldry/src/serdes/ser.rs
@@ -25,7 +25,7 @@
 //! - Values must be less than 256 bytes long.
 //!
 //! Additionally, the map must have a known length when serializing.
-use serde::{ser, Serialize};
+use serde::{Serialize, ser};
 
 use super::{Error, Result};
 

--- a/siguldry/src/server/db.rs
+++ b/siguldry/src/server/db.rs
@@ -4,7 +4,7 @@
 use std::str::FromStr;
 
 use anyhow::Context;
-use sqlx::{sqlite::SqliteConnectOptions, Pool, Sqlite, SqliteConnection, SqlitePool};
+use sqlx::{Pool, Sqlite, SqliteConnection, SqlitePool, sqlite::SqliteConnectOptions};
 use tracing::instrument;
 
 use crate::protocol::KeyAlgorithm;
@@ -455,7 +455,7 @@ impl KeyAccess {
 #[cfg(test)]
 mod tests {
     use anyhow::Result;
-    use sqlx::{error::ErrorKind, Row};
+    use sqlx::{Row, error::ErrorKind};
 
     use super::*;
 

--- a/siguldry/src/server/service.rs
+++ b/siguldry/src/server/service.rs
@@ -19,13 +19,13 @@ use tokio::{
     task::JoinSet,
 };
 use tokio_util::{sync::CancellationToken, task::TaskTracker};
-use tracing::{instrument, Instrument};
+use tracing::{Instrument, instrument};
 use zerocopy::{IntoBytes, TryFromBytes};
 
 use crate::{
     error::ConnectionError,
     nestls::Nestls,
-    protocol::{self, json::Request, Role},
+    protocol::{self, Role, json::Request},
     server::{config::Config, db, handlers},
 };
 

--- a/siguldry/src/v1/client.rs
+++ b/siguldry/src/v1/client.rs
@@ -13,7 +13,7 @@ use openssl::ssl::{SslConnector, SslFiletype, SslMethod, SslVerifyMode, SslVersi
 use openssl::x509::X509;
 use serde::Serialize;
 use tokio::io::{AsyncRead, AsyncReadExt, AsyncSeek, AsyncWrite};
-use tracing::{instrument, Instrument};
+use tracing::{Instrument, instrument};
 
 use crate::v1::connection::Connection;
 use crate::v1::error::ClientError as Error;
@@ -64,11 +64,7 @@ impl TryFrom<&Path> for Password {
             .next()
             .and_then(|pass| {
                 let pass = pass.trim();
-                if !pass.is_empty() {
-                    Some(pass)
-                } else {
-                    None
-                }
+                if !pass.is_empty() { Some(pass) } else { None }
             })
             .ok_or_else(|| {
                 anyhow::anyhow!(

--- a/siguldry/src/v1/nestls.rs
+++ b/siguldry/src/v1/nestls.rs
@@ -17,9 +17,9 @@ use tokio::{
     task::JoinHandle,
 };
 use tokio_openssl::SslStream;
-use tracing::{instrument, Instrument};
+use tracing::{Instrument, instrument};
 
-use crate::v1::connection::{Chunk, CHUNK_INNER_MASK, MAX_CHUNK_SIZE, MAX_READ_BUF};
+use crate::v1::connection::{CHUNK_INNER_MASK, Chunk, MAX_CHUNK_SIZE, MAX_READ_BUF};
 use crate::v1::error::ConnectionError as Error;
 
 /// Implements a nested ("inner") TLS session on top of an existing TLS session.

--- a/siguldry/tests/client_v1.rs
+++ b/siguldry/tests/client_v1.rs
@@ -608,9 +608,10 @@ async fn key_modify() -> anyhow::Result<()> {
         .await?;
 
     let keys = client.keys("my-admin-password".into()).await?;
-    assert!(keys
-        .iter()
-        .any(|k| *k == format!("{} (gnupg)", &new_key_name,)));
+    assert!(
+        keys.iter()
+            .any(|k| *k == format!("{} (gnupg)", &new_key_name,))
+    );
 
     client
         .delete_key("my-admin-password".into(), new_key_name)
@@ -785,9 +786,10 @@ pub async fn key_rsa_import() -> anyhow::Result<()> {
         )
         .await?;
     let keys = client.keys("my-admin-password".into()).await?;
-    assert!(keys
-        .iter()
-        .any(|k| *k == format!("{} ({})", &key_name, KeyType::Rsa)));
+    assert!(
+        keys.iter()
+            .any(|k| *k == format!("{} ({})", &key_name, KeyType::Rsa))
+    );
 
     client
         .delete_key("my-admin-password".into(), key_name)
@@ -829,9 +831,10 @@ pub async fn key_ecc_import() -> anyhow::Result<()> {
         )
         .await?;
     let keys = client.keys("my-admin-password".into()).await?;
-    assert!(keys
-        .iter()
-        .any(|k| *k == format!("{} ({})", &key_name, KeyType::Ecc)));
+    assert!(
+        keys.iter()
+            .any(|k| *k == format!("{} ({})", &key_name, KeyType::Ecc))
+    );
 
     client
         .delete_key("my-admin-password".into(), key_name)
@@ -1123,10 +1126,11 @@ pub async fn key_gpg_expiration() -> anyhow::Result<()> {
     ))?;
     assert!(cert.with_policy(&policy, pre_expiration)?.alive().is_ok());
     assert!(cert.with_policy(&policy, post_expiration)?.alive().is_ok());
-    assert!(cert
-        .with_policy(&policy, post_post_expiration)?
-        .alive()
-        .is_err());
+    assert!(
+        cert.with_policy(&policy, post_post_expiration)?
+            .alive()
+            .is_err()
+    );
 
     Ok(())
 }

--- a/xtask/Cargo.toml
+++ b/xtask/Cargo.toml
@@ -1,7 +1,8 @@
 [package]
 name = "xtask"
 version = "0.1.0"
-edition = "2021"
+edition = { workspace = true }
+rust-version = { workspace = true }
 license = "MIT"
 publish = false
 


### PR DESCRIPTION
This project tracks the latest EL Rust version; with 10.1 and 9.7 this is 1.88. This also allows us to switch to the 2024 edition.

The one incompatibility was that for the tests involving SoftHSM, we have to write the configuration file's location to an environment variable. We specifically switched to nextest to make this safe, and with the 2024 edition the `set_env` function is marked unsafe. We can continue to use it, but the lint forbidding unsafe code needs to be removed.

All other changes are due to rustfmt changes.