### PR TITLE
siguldry-client: add config to unlock keys automatically

### DIFF
--- a/siguldry/Cargo.toml
+++ b/siguldry/Cargo.toml
@@ -17,7 +17,7 @@ workspace = true
 [features]
 default = ["server", "cli"]
 # Enable the server APIs
-server = ["sqlx", "sequoia-keystore", "sequoia-openpgp", "rustix"]
+server = ["sqlx", "sequoia-keystore", "rustix"]
 # Build command-line interfaces for enabled components
 cli = ["clap", "tracing-subscriber", "toml", "tokio/rt-multi-thread", "tokio/signal"]
 
@@ -58,7 +58,6 @@ features = ["derive"]
 version = "2"
 default-features = false
 features = ["crypto-openssl"]
-optional = true
 
 [dependencies.sequoia-keystore]
 version = "0.7"

--- a/siguldry/src/protocol.rs
+++ b/siguldry/src/protocol.rs
@@ -292,7 +292,7 @@ impl Frame {
     }
 }
 
-pub(crate) mod json {
+pub mod json {
     use serde::{Deserialize, Serialize};
     use uuid::Uuid;
 
@@ -369,7 +369,8 @@ pub(crate) mod json {
     /// The set of requests a client and server must support.
     #[derive(Debug, Clone, Serialize, Deserialize)]
     #[serde(rename_all = "snake_case")]
-    pub(crate) enum Request {
+    #[non_exhaustive]
+    pub enum Request {
         WhoAmI {},
         ListUsers {},
         ListKeys {},
@@ -408,14 +409,15 @@ pub(crate) mod json {
             /// The set of digests to sign. Digests should be hex-encoded.
             digests: Vec<(super::DigestAlgorithm, String)>,
         },
-        Certificates {
+        GetKey {
             key: String,
         },
     }
 
     #[derive(Debug, Clone, Serialize, Deserialize)]
     #[serde(rename_all = "snake_case")]
-    pub(crate) enum Response {
+    #[non_exhaustive]
+    pub enum Response {
         WhoAmI {
             user: String,
         },
@@ -425,11 +427,9 @@ pub(crate) mod json {
         ListKeys {
             keys: Vec<super::Key>,
         },
-        Unlock {
-            public_key: String,
-        },
-        Certificates {
-            keys: Vec<super::Certificate>,
+        Unlock {},
+        GetKey {
+            key: super::Key,
         },
         GpgSign {},
         Sign {},

--- a/siguldry/src/server/service.rs
+++ b/siguldry/src/server/service.rs
@@ -321,7 +321,7 @@ async fn handle(
                 handlers::sign_prehashed(&mut db_transaction, &mut key_passwords, &key, digests)
                     .await
             }
-            Request::Certificates { key } => handlers::public_key(&mut db_transaction, key).await,
+            Request::GetKey { key } => handlers::public_key(&mut db_transaction, key).await,
         };
 
         match response {


### PR DESCRIPTION
The client handles reconnecting to the server transparently, but since the key unlock state is tied to the connection lifetime, this meant that on reconnects, previously-unlocked keys were relocked. This adds a configuration section for keys to automatically unlock on connection, and it ensures that any explicit calls to the unlock() function will be re-issued on new connections the client creates.