### PR TITLE
tests: Refactor to generate only needed keys

### DIFF
--- a/siguldry/Cargo.toml
+++ b/siguldry/Cargo.toml
@@ -17,7 +17,7 @@ workspace = true
 [features]
 default = ["server", "cli"]
 # Enable the server APIs
-server = ["sqlx", "sequoia-keystore", "rustix"]
+server = ["dep:cryptoki", "dep:sqlx", "dep:sequoia-keystore", "dep:rustix"]
 # Build command-line interfaces for enabled components
 cli = ["clap", "tracing-subscriber", "toml", "tokio/rt-multi-thread", "tokio/signal"]
 
@@ -35,6 +35,10 @@ version = "1"
 version = "4.0"
 default-features = false
 features = ["std", "derive", "env", "help", "usage", "error-context"]
+optional = true
+
+[dependencies.cryptoki]
+version = "0.11"
 optional = true
 
 [dependencies.hex]

--- a/siguldry/benches/end_to_end.rs
+++ b/siguldry/benches/end_to_end.rs
@@ -15,9 +15,17 @@ use std::{
     time::Duration,
 };
 
-use anyhow::bail;
+use anyhow::{Context, bail};
 use assert_cmd::cargo;
 use criterion::{BenchmarkId, Criterion, criterion_group, criterion_main};
+use cryptoki::{
+    context::{CInitializeArgs, CInitializeFlags, Pkcs11},
+    mechanism::Mechanism,
+    object::Attribute,
+    session::UserType,
+    slot::Slot,
+    types::AuthPin,
+};
 use siguldry::{bridge, client, config::Credentials, protocol::GpgSignatureType, server};
 use tokio::{process::Command, task::JoinSet};
 use tracing::Instrument;
@@ -78,103 +86,418 @@ struct Instance {
     pub state_dir: tempfile::TempDir,
 }
 
-async fn create_instance(creds: Option<Creds>) -> anyhow::Result<Instance> {
-    // Unlike the server, which involves no DNS resolution from the client, the
-    // bridge hostname needs to resolve and match the certificate it presents.
-    let bridge_hostname = "localhost";
-    let server_hostname = "sigul-server";
-    let client_name = "sigul-client";
-    let tempdir = tempfile::TempDir::new()?;
-    let creds = if let Some(creds) = creds {
-        creds
-    } else {
-        create_credentials(
-            tempdir.path(),
-            bridge_hostname,
-            server_hostname,
-            client_name,
+impl Instance {
+    pub async fn halt(self) -> anyhow::Result<()> {
+        drop(self.client);
+        self.server.halt().await?;
+        self.bridge.halt().await?;
+        Ok(())
+    }
+}
+
+pub mod keys {
+    pub const GPG_KEY_NAME: &str = "test-gpg-key";
+    pub const GPG_KEY_PASSWORD: &str = "🪿🪿🪿";
+    pub const GPG_KEY_EMAIL: &str = "admin@example.com";
+
+    pub const CA_KEY_NAME: &str = "test-ca-key";
+    pub const CA_KEY_PASSWORD: &str = "🦀🦀🦀🦀";
+
+    pub const CODESIGNING_KEY_NAME: &str = "test-codesigning-key";
+    pub const CODESIGNING_KEY_PASSWORD: &str = "🪶🪶🪶🪶";
+
+    pub const EC_KEY_NAME: &str = "test-ec-key";
+    pub const EC_KEY_PASSWORD: &str = "🌙🌙🌙🌙";
+}
+
+/// Builder for creating test instances with specific key configurations.
+#[derive(Default)]
+struct InstanceBuilder {
+    creds: Option<Creds>,
+    with_gpg_key: bool,
+    with_ca_key: bool,
+    with_codesigning_key: bool,
+    with_ec_key: bool,
+    with_hsm: bool,
+}
+
+#[allow(dead_code)]
+impl InstanceBuilder {
+    fn new() -> Self {
+        Self::default()
+    }
+
+    /// Use pre-generated credentials instead of creating new ones.
+    fn with_creds(mut self, creds: Creds) -> Self {
+        self.creds = Some(creds);
+        self
+    }
+
+    fn with_gpg_key(mut self) -> Self {
+        self.with_gpg_key = true;
+        self
+    }
+
+    fn with_codesigning_key(mut self) -> Self {
+        self.with_ca_key = true;
+        self.with_codesigning_key = true;
+        self
+    }
+
+    fn with_ec_key(mut self) -> Self {
+        self.with_ca_key = true;
+        self.with_ec_key = true;
+        self
+    }
+
+    fn with_all_keys(mut self) -> Self {
+        self.with_gpg_key = true;
+        self.with_ca_key = true;
+        self.with_codesigning_key = true;
+        self.with_ec_key = true;
+        self
+    }
+
+    #[allow(dead_code)]
+    fn with_hsm(mut self) -> Self {
+        self.with_hsm = true;
+        self.with_ca_key = true;
+        self
+    }
+
+    async fn setup_hsm(tempdir: &Path) -> anyhow::Result<(Pkcs11, Slot, AuthPin)> {
+        let hsm_config_path = tempdir.join("kryoptic.toml");
+        let hsm_db_path = tempdir.join("kryoptic.sql");
+        std::fs::write(
+            &hsm_config_path,
+            format!(
+                "[[slots]]\nslot = 1\ndbtype = \"sqlite\"\ndbargs = \"{}\"",
+                hsm_db_path.display()
+            ),
+        )?;
+        // SAFETY:
+        // These tests are required to run with nextest, which starts a new process for each test.
+        // Using set_var is only safe if no other code is interacting with the environment variables,
+        // which should be true under nextest. Refer to
+        // https://nexte.st/docs/configuration/env-vars/#altering-the-environment-within-tests to ensure
+        // this remains the case with current versions of Rust.
+        unsafe {
+            std::env::set_var("KRYOPTIC_CONF", &hsm_config_path);
+        };
+
+        let pkcs11 = Pkcs11::new("/usr/lib64/pkcs11/libkryoptic_pkcs11.so")
+            .context("Install the kryoptic PKCS#11 module")?;
+        pkcs11
+            .initialize(CInitializeArgs::new(CInitializeFlags::OS_LOCKING_OK))
+            .context("Failed to initialized kryoptic PKCS#11 module")?;
+        let slot = pkcs11
+            .get_slots_with_token()?
+            .pop()
+            .expect("no slot available");
+        let so_pin = AuthPin::new("12345678".into());
+        let user_pin = AuthPin::new("654321".into());
+        pkcs11
+            .init_token(slot, &so_pin, "siguldry-test-token")
+            .context("Failed to initialize token")?;
+        pkcs11
+            .open_rw_session(slot)
+            .and_then(|session| {
+                session.login(UserType::So, Some(&so_pin))?;
+                session.init_pin(&user_pin)?;
+                Ok(())
+            })
+            .context("Failed to initialize user pin")?;
+
+        Ok((pkcs11, slot, user_pin))
+    }
+
+    async fn build(self) -> anyhow::Result<Instance> {
+        // Unlike the server, which involves no DNS resolution from the client, the
+        // bridge hostname needs to resolve and match the certificate it presents.
+        let bridge_hostname = "localhost";
+        let server_hostname = "siguldry-server";
+        let client_name = "siguldry-client";
+        let tempdir = tempfile::TempDir::new()?;
+        let pkcs11 = if self.with_hsm {
+            Some(Self::setup_hsm(tempdir.path()).await?)
+        } else {
+            None
+        };
+
+        let creds = if let Some(creds) = self.creds {
+            creds
+        } else {
+            create_credentials(
+                tempdir.path(),
+                bridge_hostname,
+                server_hostname,
+                client_name,
+            )
+            .await?
+        };
+
+        let bridge_config = bridge::Config {
+            server_listening_address: SocketAddr::from_str("127.0.0.1:0").unwrap(),
+            client_listening_address: SocketAddr::from_str("127.0.0.1:0").unwrap(),
+            credentials: creds.bridge.clone(),
+        };
+        let bridge_config_file = tempdir.path().join("bridge.toml");
+        std::fs::write(&bridge_config_file, toml::to_string_pretty(&bridge_config)?)?;
+        let bridge = bridge::listen(bridge_config)
+            .instrument(tracing::info_span!("bridge"))
+            .await?;
+
+        let server_config = server::Config {
+            state_directory: tempdir.path().into(),
+            bridge_hostname: bridge_hostname.to_string(),
+            bridge_port: bridge.server_port(),
+            credentials: creds.server.clone(),
+            user_password_length: NonZeroU16::new(keys::GPG_KEY_PASSWORD.len() as u16)
+                .expect("it's three geese"),
+            pkcs11_bindings: vec![],
+            connection_pool_size: 1,
+            ..Default::default()
+        };
+        let server_config_file = tempdir.path().join("server.toml");
+        std::fs::write(&server_config_file, toml::to_string_pretty(&server_config)?)?;
+
+        Self::run_server_command(&server_config_file, &["manage", "migrate"], None)?;
+        Self::run_server_command(
+            &server_config_file,
+            &["manage", "users", "create", "siguldry-client"],
+            None,
+        )?;
+
+        if self.with_gpg_key {
+            Self::create_gpg_key(&server_config_file)?;
+        }
+
+        if self.with_ca_key {
+            Self::create_ca_key(&server_config_file)?;
+        }
+
+        if let Some((pkcs11, slot, user_pin)) = pkcs11 {
+            Self::create_hsm_rsa_key(pkcs11, slot, &user_pin).await?;
+        }
+
+        if self.with_codesigning_key {
+            Self::create_codesigning_key(&server_config_file)?;
+        }
+
+        if self.with_ec_key {
+            Self::create_ec_key(&server_config_file)?;
+        }
+
+        let server = server::service::Server::new(server_config).await?;
+        let server = server.run();
+
+        let client_config = client::Config {
+            server_hostname: server_hostname.to_string(),
+            bridge_hostname: bridge_hostname.to_string(),
+            bridge_port: bridge.client_port(),
+            credentials: creds.client.clone(),
+            ..Default::default()
+        };
+        let client_config_file = tempdir.path().join("client.toml");
+        std::fs::write(&client_config_file, toml::to_string_pretty(&client_config)?)?;
+        let client = client::Client::new(client_config)?;
+
+        Ok(Instance {
+            server,
+            bridge,
+            client,
+            creds,
+            state_dir: tempdir,
+        })
+    }
+
+    /// Run a siguldry-server command with optional stdin input.
+    fn run_server_command(
+        config_file: &Path,
+        args: &[&str],
+        stdin_input: Option<&str>,
+    ) -> anyhow::Result<()> {
+        let mut command = std::process::Command::new(cargo::cargo_bin!("siguldry-server"));
+        command
+            .env("SIGULDRY_SERVER_CONFIG", config_file)
+            .args(args);
+
+        if let Some(input) = stdin_input {
+            command.stdin(Stdio::piped());
+            let mut child = command.spawn()?;
+            let mut stdin = child.stdin.take().unwrap();
+            stdin.write_all(input.as_bytes())?;
+            drop(stdin);
+            let result = child.wait_with_output()?;
+            if !result.status.success() {
+                bail!("Command failed: {:?}", args);
+            }
+        } else {
+            let result = command.output()?;
+            if !result.status.success() {
+                bail!("Command failed: {:?}", args);
+            }
+        }
+        Ok(())
+    }
+
+    fn create_gpg_key(server_config_file: &Path) -> anyhow::Result<()> {
+        Self::run_server_command(
+            server_config_file,
+            &[
+                "manage",
+                "gpg",
+                "create",
+                "siguldry-client",
+                keys::GPG_KEY_NAME,
+                keys::GPG_KEY_EMAIL,
+            ],
+            Some(&format!("{}\n", keys::GPG_KEY_PASSWORD)),
         )
-        .await?
-    };
-
-    let bridge_config = bridge::Config {
-        server_listening_address: SocketAddr::from_str("127.0.0.1:0").unwrap(),
-        client_listening_address: SocketAddr::from_str("127.0.0.1:0").unwrap(),
-        credentials: creds.bridge.clone(),
-    };
-    let bridge = bridge::listen(bridge_config)
-        .instrument(tracing::info_span!("bridge"))
-        .await?;
-
-    let server_config = server::Config {
-        state_directory: tempdir.path().into(),
-        bridge_hostname: bridge_hostname.to_string(),
-        bridge_port: bridge.server_port(),
-        credentials: creds.server.clone(),
-        user_password_length: NonZeroU16::new("🪿🪿🪿".len() as u16).expect("it's three geese"),
-        pkcs11_bindings: vec![],
-        connection_pool_size: 1,
-        ..Default::default()
-    };
-    let server_config_file = tempdir.path().join("server.toml");
-    std::fs::write(&server_config_file, toml::to_string_pretty(&server_config)?)?;
-    let mut migrate_command = std::process::Command::new(cargo::cargo_bin!("siguldry-server"));
-    let result = migrate_command
-        .env("SIGULDRY_SERVER_CONFIG", &server_config_file)
-        .args(["manage", "migrate"])
-        .output()?;
-    if !result.status.success() {
-        panic!("failed to create test database");
-    }
-    let mut create_user_command = std::process::Command::new(cargo::cargo_bin!("siguldry-server"));
-    let result = create_user_command
-        .env("SIGULDRY_SERVER_CONFIG", &server_config_file)
-        .args(["manage", "users", "create", "sigul-client"])
-        .output()?;
-    if !result.status.success() {
-        panic!("failed to create test user");
-    }
-    let mut create_gpg_key_command =
-        std::process::Command::new(cargo::cargo_bin!("siguldry-server"));
-    let mut child = create_gpg_key_command
-        .env("SIGULDRY_SERVER_CONFIG", &server_config_file)
-        .args([
-            "manage",
-            "gpg",
-            "create",
-            "sigul-client",
-            "test-gpg-key",
-            "admin@example.com",
-        ])
-        .stdin(Stdio::piped())
-        .spawn()?;
-    let mut stdin = child.stdin.take().unwrap();
-    stdin.write_all("🪿🪿🪿\n".as_bytes())?;
-    drop(stdin);
-    let result = child.wait_with_output()?;
-    if !result.status.success() {
-        panic!("failed to create test key");
     }
 
-    let server = server::service::Server::new(server_config).await?;
-    let server = server.run();
+    async fn create_hsm_rsa_key(
+        pkcs11: Pkcs11,
+        slot: Slot,
+        user_pin: &AuthPin,
+    ) -> anyhow::Result<()> {
+        let id = Attribute::Id(vec![1]);
+        let _ = pkcs11.open_rw_session(slot).and_then(|session| {
+            session.login(UserType::User, Some(user_pin))?;
+            let pubkey_template = [
+                Attribute::Token(true),
+                Attribute::Private(false),
+                id.clone(),
+                Attribute::ModulusBits(2048.into()),
+            ];
+            let privkey_template = [Attribute::Token(true), id.clone()];
+            session.generate_key_pair(
+                &Mechanism::RsaPkcsKeyPairGen,
+                &pubkey_template,
+                &privkey_template,
+            )
+        })?;
 
-    let client_config = client::Config {
-        server_hostname: server_hostname.to_string(),
-        bridge_hostname: bridge_hostname.to_string(),
-        bridge_port: bridge.client_port(),
-        credentials: creds.client.clone(),
-        ..Default::default()
-    };
-    let client = client::Client::new(client_config)?;
+        Ok(())
+    }
 
-    Ok(Instance {
-        server,
-        bridge,
-        client,
-        creds,
-        state_dir: tempdir,
-    })
+    fn create_ca_key(server_config_file: &Path) -> anyhow::Result<()> {
+        Self::run_server_command(
+            server_config_file,
+            &[
+                "manage",
+                "key",
+                "create",
+                "siguldry-client",
+                keys::CA_KEY_NAME,
+            ],
+            Some(&format!("{}\n", keys::CA_KEY_PASSWORD)),
+        )?;
+
+        Self::run_server_command(
+            server_config_file,
+            &[
+                "manage",
+                "key",
+                "x509",
+                "--user-name",
+                "siguldry-client",
+                "--key-name",
+                keys::CA_KEY_NAME,
+                "--common-name",
+                keys::CA_KEY_NAME,
+                "--validity-days",
+                "30",
+                "certificate-authority",
+            ],
+            Some(&format!("{}\n", keys::CA_KEY_PASSWORD)),
+        )
+    }
+
+    fn create_codesigning_key(server_config_file: &Path) -> anyhow::Result<()> {
+        Self::run_server_command(
+            server_config_file,
+            &[
+                "manage",
+                "key",
+                "create",
+                "siguldry-client",
+                keys::CODESIGNING_KEY_NAME,
+            ],
+            Some(&format!("{}\n", keys::CODESIGNING_KEY_PASSWORD)),
+        )?;
+
+        Self::run_server_command(
+            server_config_file,
+            &[
+                "manage",
+                "key",
+                "x509",
+                "--user-name",
+                "siguldry-client",
+                "--key-name",
+                keys::CODESIGNING_KEY_NAME,
+                "--common-name",
+                keys::CODESIGNING_KEY_NAME,
+                "--validity-days",
+                "30",
+                "--certificate-authority",
+                keys::CA_KEY_NAME,
+                "code-signing",
+            ],
+            Some(&format!("{}\n", keys::CA_KEY_PASSWORD)),
+        )
+    }
+
+    fn create_ec_key(server_config_file: &Path) -> anyhow::Result<()> {
+        Self::run_server_command(
+            server_config_file,
+            &[
+                "manage",
+                "key",
+                "create",
+                "--algorithm=p256",
+                "siguldry-client",
+                keys::EC_KEY_NAME,
+            ],
+            Some(&format!("{}\n", keys::EC_KEY_PASSWORD)),
+        )?;
+
+        Self::run_server_command(
+            server_config_file,
+            &[
+                "manage",
+                "key",
+                "x509",
+                "--user-name",
+                "siguldry-client",
+                "--key-name",
+                keys::EC_KEY_NAME,
+                "--common-name",
+                keys::EC_KEY_NAME,
+                "--validity-days",
+                "30",
+                "--certificate-authority",
+                keys::CA_KEY_NAME,
+                "code-signing",
+            ],
+            Some(&format!("{}\n", keys::CA_KEY_PASSWORD)),
+        )
+    }
+}
+
+#[tokio::test]
+#[tracing_test::traced_test]
+async fn basic_bridge_config() -> anyhow::Result<()> {
+    let instance = InstanceBuilder::new().build().await?;
+
+    for _ in 0..5 {
+        let username = instance.client.who_am_i().await.unwrap();
+        assert_eq!(username, "siguldry-client");
+    }
+
+    instance.halt().await?;
+    Ok(())
 }
 
 /// Benchmark the end-to-end connection speed.
@@ -190,7 +513,8 @@ fn connection(criterion: &mut Criterion) {
         .unwrap();
     let instance = runtime
         .block_on(async {
-            let instance = create_instance(None).await?;
+            let instance = InstanceBuilder::new().build().await?;
+
             Ok::<_, anyhow::Error>(instance)
         })
         .unwrap();
@@ -204,6 +528,8 @@ fn connection(criterion: &mut Criterion) {
             });
         });
     });
+
+    _ = runtime.block_on(instance.halt());
 }
 
 /// Benchmark the end-to-end connection speed with 32 concurrent connections.
@@ -214,7 +540,7 @@ fn concurrent_connection(criterion: &mut Criterion) {
         .unwrap();
     let instance = runtime
         .block_on(async {
-            let instance = create_instance(None).await?;
+            let instance = InstanceBuilder::new().build().await?;
             Ok::<_, anyhow::Error>(instance)
         })
         .unwrap();
@@ -234,6 +560,8 @@ fn concurrent_connection(criterion: &mut Criterion) {
             });
         });
     });
+
+    _ = runtime.block_on(instance.halt());
 }
 
 /// Benchmark the time to send a request and receive a response, ignoring complex server-side work.
@@ -247,7 +575,7 @@ fn command_roundtrip(criterion: &mut Criterion) {
         .unwrap();
     let instance = runtime
         .block_on(async {
-            let instance = create_instance(None).await?;
+            let instance = InstanceBuilder::new().build().await?;
             Ok::<_, anyhow::Error>(instance)
         })
         .unwrap();
@@ -259,6 +587,8 @@ fn command_roundtrip(criterion: &mut Criterion) {
             });
         });
     });
+
+    _ = runtime.block_on(instance.halt());
 }
 
 fn bench_command_throughput(c: &mut Criterion) {
@@ -269,7 +599,7 @@ fn bench_command_throughput(c: &mut Criterion) {
         .unwrap();
     let instance = runtime
         .block_on(async {
-            let instance = create_instance(None).await?;
+            let instance = InstanceBuilder::new().build().await?;
             Ok::<_, anyhow::Error>(instance)
         })
         .unwrap();
@@ -295,6 +625,8 @@ fn bench_command_throughput(c: &mut Criterion) {
             });
         });
     }
+
+    _ = runtime.block_on(instance.halt());
 }
 
 fn gpg_sign_detached(criterion: &mut Criterion) {
@@ -304,7 +636,7 @@ fn gpg_sign_detached(criterion: &mut Criterion) {
         .unwrap();
     let instance = runtime
         .block_on(async {
-            let instance = create_instance(None).await?;
+            let instance = InstanceBuilder::new().with_gpg_key().build().await?;
             instance
                 .client
                 .unlock("test-gpg-key".to_string(), "🪿🪿🪿".to_string())
@@ -330,6 +662,8 @@ fn gpg_sign_detached(criterion: &mut Criterion) {
             });
         });
     });
+
+    _ = runtime.block_on(instance.halt());
 }
 
 fn gpg_sign_throughput(c: &mut Criterion) {
@@ -340,7 +674,7 @@ fn gpg_sign_throughput(c: &mut Criterion) {
         .unwrap();
     let instance = runtime
         .block_on(async {
-            let instance = create_instance(None).await?;
+            let instance = InstanceBuilder::new().with_gpg_key().build().await?;
             instance
                 .client
                 .unlock("test-gpg-key".to_string(), "🪿🪿🪿".to_string())
@@ -381,6 +715,8 @@ fn gpg_sign_throughput(c: &mut Criterion) {
             },
         );
     }
+
+    _ = runtime.block_on(instance.halt());
 }
 
 criterion_group!(

--- a/siguldry/tests/end_to_end.rs
+++ b/siguldry/tests/end_to_end.rs
@@ -12,8 +12,16 @@ use std::{
     str::FromStr,
 };
 
-use anyhow::bail;
+use anyhow::{Context, bail};
 use assert_cmd::cargo;
+use cryptoki::{
+    context::{CInitializeArgs, CInitializeFlags, Pkcs11},
+    mechanism::Mechanism,
+    object::Attribute,
+    session::UserType,
+    slot::Slot,
+    types::AuthPin,
+};
 use siguldry::{
     bridge, client,
     config::Credentials,
@@ -70,227 +78,426 @@ async fn create_credentials(
     })
 }
 
+// Dropping TempDir cleans up the directory, but it needs to live to the end of the test.
+#[allow(dead_code)]
 struct Instance {
     pub server: server::service::Listener,
     pub bridge: bridge::Listener,
     pub client: client::Client,
     pub creds: Creds,
-    // Dropping TempDir cleans up the directory, but it needs to live to the end of the test.
-    #[allow(dead_code)]
     pub state_dir: tempfile::TempDir,
 }
 
-async fn create_instance(creds: Option<Creds>) -> anyhow::Result<Instance> {
-    // Unlike the server, which involves no DNS resolution from the client, the
-    // bridge hostname needs to resolve and match the certificate it presents.
-    let bridge_hostname = "localhost";
-    let server_hostname = "sigul-server";
-    let client_name = "sigul-client";
-    let tempdir = tempfile::TempDir::new()?;
-    let creds = if let Some(creds) = creds {
-        creds
-    } else {
-        create_credentials(
-            tempdir.path(),
-            bridge_hostname,
-            server_hostname,
-            client_name,
+impl Instance {
+    pub async fn halt(self) -> anyhow::Result<()> {
+        drop(self.client);
+        self.server.halt().await?;
+        self.bridge.halt().await?;
+        Ok(())
+    }
+}
+
+pub mod keys {
+    pub const GPG_KEY_NAME: &str = "test-gpg-key";
+    pub const GPG_KEY_PASSWORD: &str = "🪿🪿🪿";
+    pub const GPG_KEY_EMAIL: &str = "admin@example.com";
+
+    pub const CA_KEY_NAME: &str = "test-ca-key";
+    pub const CA_KEY_PASSWORD: &str = "🦀🦀🦀🦀";
+
+    pub const CODESIGNING_KEY_NAME: &str = "test-codesigning-key";
+    pub const CODESIGNING_KEY_PASSWORD: &str = "🪶🪶🪶🪶";
+
+    pub const EC_KEY_NAME: &str = "test-ec-key";
+    pub const EC_KEY_PASSWORD: &str = "🌙🌙🌙🌙";
+}
+
+/// Builder for creating test instances with specific key configurations.
+#[derive(Default)]
+struct InstanceBuilder {
+    creds: Option<Creds>,
+    with_gpg_key: bool,
+    with_ca_key: bool,
+    with_codesigning_key: bool,
+    with_ec_key: bool,
+    with_hsm: bool,
+}
+
+impl InstanceBuilder {
+    fn new() -> Self {
+        Self::default()
+    }
+
+    /// Use pre-generated credentials instead of creating new ones.
+    fn with_creds(mut self, creds: Creds) -> Self {
+        self.creds = Some(creds);
+        self
+    }
+
+    fn with_gpg_key(mut self) -> Self {
+        self.with_gpg_key = true;
+        self
+    }
+
+    fn with_codesigning_key(mut self) -> Self {
+        self.with_ca_key = true;
+        self.with_codesigning_key = true;
+        self
+    }
+
+    fn with_ec_key(mut self) -> Self {
+        self.with_ca_key = true;
+        self.with_ec_key = true;
+        self
+    }
+
+    fn with_all_keys(mut self) -> Self {
+        self.with_gpg_key = true;
+        self.with_ca_key = true;
+        self.with_codesigning_key = true;
+        self.with_ec_key = true;
+        self
+    }
+
+    #[allow(dead_code)]
+    fn with_hsm(mut self) -> Self {
+        self.with_hsm = true;
+        self.with_ca_key = true;
+        self
+    }
+
+    async fn setup_hsm(tempdir: &Path) -> anyhow::Result<(Pkcs11, Slot, AuthPin)> {
+        let hsm_config_path = tempdir.join("kryoptic.toml");
+        let hsm_db_path = tempdir.join("kryoptic.sql");
+        std::fs::write(
+            &hsm_config_path,
+            format!(
+                "[[slots]]\nslot = 1\ndbtype = \"sqlite\"\ndbargs = \"{}\"",
+                hsm_db_path.display()
+            ),
+        )?;
+        // SAFETY:
+        // These tests are required to run with nextest, which starts a new process for each test.
+        // Using set_var is only safe if no other code is interacting with the environment variables,
+        // which should be true under nextest. Refer to
+        // https://nexte.st/docs/configuration/env-vars/#altering-the-environment-within-tests to ensure
+        // this remains the case with current versions of Rust.
+        unsafe {
+            std::env::set_var("KRYOPTIC_CONF", &hsm_config_path);
+        };
+
+        let pkcs11 = Pkcs11::new("/usr/lib64/pkcs11/libkryoptic_pkcs11.so")
+            .context("Install the kryoptic PKCS#11 module")?;
+        pkcs11
+            .initialize(CInitializeArgs::new(CInitializeFlags::OS_LOCKING_OK))
+            .context("Failed to initialized kryoptic PKCS#11 module")?;
+        let slot = pkcs11
+            .get_slots_with_token()?
+            .pop()
+            .expect("no slot available");
+        let so_pin = AuthPin::new("12345678".into());
+        let user_pin = AuthPin::new("654321".into());
+        pkcs11
+            .init_token(slot, &so_pin, "siguldry-test-token")
+            .context("Failed to initialize token")?;
+        pkcs11
+            .open_rw_session(slot)
+            .and_then(|session| {
+                session.login(UserType::So, Some(&so_pin))?;
+                session.init_pin(&user_pin)?;
+                Ok(())
+            })
+            .context("Failed to initialize user pin")?;
+
+        Ok((pkcs11, slot, user_pin))
+    }
+
+    async fn build(self) -> anyhow::Result<Instance> {
+        // Unlike the server, which involves no DNS resolution from the client, the
+        // bridge hostname needs to resolve and match the certificate it presents.
+        let bridge_hostname = "localhost";
+        let server_hostname = "siguldry-server";
+        let client_name = "siguldry-client";
+        let tempdir = tempfile::TempDir::new()?;
+        let pkcs11 = if self.with_hsm {
+            Some(Self::setup_hsm(tempdir.path()).await?)
+        } else {
+            None
+        };
+
+        let creds = if let Some(creds) = self.creds {
+            creds
+        } else {
+            create_credentials(
+                tempdir.path(),
+                bridge_hostname,
+                server_hostname,
+                client_name,
+            )
+            .await?
+        };
+
+        let bridge_config = bridge::Config {
+            server_listening_address: SocketAddr::from_str("127.0.0.1:0").unwrap(),
+            client_listening_address: SocketAddr::from_str("127.0.0.1:0").unwrap(),
+            credentials: creds.bridge.clone(),
+        };
+        let bridge_config_file = tempdir.path().join("bridge.toml");
+        std::fs::write(&bridge_config_file, toml::to_string_pretty(&bridge_config)?)?;
+        let bridge = bridge::listen(bridge_config)
+            .instrument(tracing::info_span!("bridge"))
+            .await?;
+
+        let server_config = server::Config {
+            state_directory: tempdir.path().into(),
+            bridge_hostname: bridge_hostname.to_string(),
+            bridge_port: bridge.server_port(),
+            credentials: creds.server.clone(),
+            user_password_length: NonZeroU16::new(keys::GPG_KEY_PASSWORD.len() as u16)
+                .expect("it's three geese"),
+            pkcs11_bindings: vec![],
+            connection_pool_size: 1,
+            ..Default::default()
+        };
+        let server_config_file = tempdir.path().join("server.toml");
+        std::fs::write(&server_config_file, toml::to_string_pretty(&server_config)?)?;
+
+        Self::run_server_command(&server_config_file, &["manage", "migrate"], None)?;
+        Self::run_server_command(
+            &server_config_file,
+            &["manage", "users", "create", "siguldry-client"],
+            None,
+        )?;
+
+        if self.with_gpg_key {
+            Self::create_gpg_key(&server_config_file)?;
+        }
+
+        if self.with_ca_key {
+            Self::create_ca_key(&server_config_file)?;
+        }
+
+        if let Some((pkcs11, slot, user_pin)) = pkcs11 {
+            Self::create_hsm_rsa_key(pkcs11, slot, &user_pin).await?;
+        }
+
+        if self.with_codesigning_key {
+            Self::create_codesigning_key(&server_config_file)?;
+        }
+
+        if self.with_ec_key {
+            Self::create_ec_key(&server_config_file)?;
+        }
+
+        let server = server::service::Server::new(server_config).await?;
+        let server = server.run();
+
+        let client_config = client::Config {
+            server_hostname: server_hostname.to_string(),
+            bridge_hostname: bridge_hostname.to_string(),
+            bridge_port: bridge.client_port(),
+            credentials: creds.client.clone(),
+            ..Default::default()
+        };
+        let client_config_file = tempdir.path().join("client.toml");
+        std::fs::write(&client_config_file, toml::to_string_pretty(&client_config)?)?;
+        let client = client::Client::new(client_config)?;
+
+        Ok(Instance {
+            server,
+            bridge,
+            client,
+            creds,
+            state_dir: tempdir,
+        })
+    }
+
+    /// Run a siguldry-server command with optional stdin input.
+    fn run_server_command(
+        config_file: &Path,
+        args: &[&str],
+        stdin_input: Option<&str>,
+    ) -> anyhow::Result<()> {
+        let mut command = std::process::Command::new(cargo::cargo_bin!("siguldry-server"));
+        command
+            .env("SIGULDRY_SERVER_CONFIG", config_file)
+            .args(args);
+
+        if let Some(input) = stdin_input {
+            command.stdin(Stdio::piped());
+            let mut child = command.spawn()?;
+            let mut stdin = child.stdin.take().unwrap();
+            stdin.write_all(input.as_bytes())?;
+            drop(stdin);
+            let result = child.wait_with_output()?;
+            if !result.status.success() {
+                bail!("Command failed: {:?}", args);
+            }
+        } else {
+            let result = command.output()?;
+            if !result.status.success() {
+                bail!("Command failed: {:?}", args);
+            }
+        }
+        Ok(())
+    }
+
+    fn create_gpg_key(server_config_file: &Path) -> anyhow::Result<()> {
+        Self::run_server_command(
+            server_config_file,
+            &[
+                "manage",
+                "gpg",
+                "create",
+                "siguldry-client",
+                keys::GPG_KEY_NAME,
+                keys::GPG_KEY_EMAIL,
+            ],
+            Some(&format!("{}\n", keys::GPG_KEY_PASSWORD)),
         )
-        .await?
-    };
-
-    let bridge_config = bridge::Config {
-        server_listening_address: SocketAddr::from_str("127.0.0.1:0").unwrap(),
-        client_listening_address: SocketAddr::from_str("127.0.0.1:0").unwrap(),
-        credentials: creds.bridge.clone(),
-    };
-    let bridge_config_file = tempdir.path().join("bridge.toml");
-    std::fs::write(&bridge_config_file, toml::to_string_pretty(&bridge_config)?)?;
-    let bridge = bridge::listen(bridge_config)
-        .instrument(tracing::info_span!("bridge"))
-        .await?;
-
-    let server_config = server::Config {
-        state_directory: tempdir.path().into(),
-        bridge_hostname: bridge_hostname.to_string(),
-        bridge_port: bridge.server_port(),
-        credentials: creds.server.clone(),
-        user_password_length: NonZeroU16::new("🪿🪿🪿".len() as u16).expect("it's three geese"),
-        pkcs11_bindings: vec![],
-        connection_pool_size: 1,
-        ..Default::default()
-    };
-    let server_config_file = tempdir.path().join("server.toml");
-    std::fs::write(&server_config_file, toml::to_string_pretty(&server_config)?)?;
-    let mut migrate_command = std::process::Command::new(cargo::cargo_bin!("siguldry-server"));
-    let result = migrate_command
-        .env("SIGULDRY_SERVER_CONFIG", &server_config_file)
-        .args(["manage", "migrate"])
-        .output()?;
-    if !result.status.success() {
-        panic!("failed to create test database");
-    }
-    let mut create_user_command = std::process::Command::new(cargo::cargo_bin!("siguldry-server"));
-    let result = create_user_command
-        .env("SIGULDRY_SERVER_CONFIG", &server_config_file)
-        .args(["manage", "users", "create", "sigul-client"])
-        .output()?;
-    if !result.status.success() {
-        panic!("failed to create test user");
-    }
-    let mut create_gpg_key_command =
-        std::process::Command::new(cargo::cargo_bin!("siguldry-server"));
-    let mut child = create_gpg_key_command
-        .env("SIGULDRY_SERVER_CONFIG", &server_config_file)
-        .args([
-            "manage",
-            "gpg",
-            "create",
-            "sigul-client",
-            "test-gpg-key",
-            "admin@example.com",
-        ])
-        .stdin(Stdio::piped())
-        .spawn()?;
-    let mut stdin = child.stdin.take().unwrap();
-    stdin.write_all("🪿🪿🪿\n".as_bytes())?;
-    drop(stdin);
-    let result = child.wait_with_output()?;
-    if !result.status.success() {
-        panic!("failed to create test key");
     }
 
-    // Set up a CA
-    let mut create_ca_key_command =
-        std::process::Command::new(cargo::cargo_bin!("siguldry-server"));
-    let mut child = create_ca_key_command
-        .env("SIGULDRY_SERVER_CONFIG", &server_config_file)
-        .args(["manage", "key", "create", "sigul-client", "test-ca-key"])
-        .stdin(Stdio::piped())
-        .spawn()?;
-    let mut stdin = child.stdin.take().unwrap();
-    stdin.write_all("🦀🦀🦀🦀\n".as_bytes())?;
-    drop(stdin);
-    let result = child.wait_with_output()?;
-    if !result.status.success() {
-        panic!("failed to create test key");
-    }
-    let mut sign_ca_key_command = std::process::Command::new(cargo::cargo_bin!("siguldry-server"));
-    let mut child = sign_ca_key_command
-        .env("SIGULDRY_SERVER_CONFIG", &server_config_file)
-        .args([
-            "manage",
-            "key",
-            "x509",
-            "--user-name",
-            "sigul-client",
-            "--key-name",
-            "test-ca-key",
-            "--common-name",
-            "test-ca-key",
-            "--validity-days",
-            "30",
-            "certificate-authority",
-        ])
-        .stdin(Stdio::piped())
-        .spawn()?;
-    let mut stdin = child.stdin.take().unwrap();
-    stdin.write_all("🦀🦀🦀🦀\n".as_bytes())?;
-    drop(stdin);
-    let result = child.wait_with_output()?;
-    if !result.status.success() {
-        panic!("failed to create test key");
+    async fn create_hsm_rsa_key(
+        pkcs11: Pkcs11,
+        slot: Slot,
+        user_pin: &AuthPin,
+    ) -> anyhow::Result<()> {
+        let id = Attribute::Id(vec![1]);
+        let _ = pkcs11.open_rw_session(slot).and_then(|session| {
+            session.login(UserType::User, Some(user_pin))?;
+            let pubkey_template = [
+                Attribute::Token(true),
+                Attribute::Private(false),
+                id.clone(),
+                Attribute::ModulusBits(2048.into()),
+            ];
+            let privkey_template = [Attribute::Token(true), id.clone()];
+            session.generate_key_pair(
+                &Mechanism::RsaPkcsKeyPairGen,
+                &pubkey_template,
+                &privkey_template,
+            )
+        })?;
+
+        Ok(())
     }
 
-    // Create codesigning key
-    let mut create_codesigning_key_command =
-        std::process::Command::new(cargo::cargo_bin!("siguldry-server"));
-    let mut child = create_codesigning_key_command
-        .env("SIGULDRY_SERVER_CONFIG", &server_config_file)
-        .args([
-            "manage",
-            "key",
-            "create",
-            "sigul-client",
-            "test-codesigning-key",
-        ])
-        .stdin(Stdio::piped())
-        .spawn()?;
-    let mut stdin = child.stdin.take().unwrap();
-    stdin.write_all("🪶🪶🪶🪶\n".as_bytes())?;
-    drop(stdin);
-    let result = child.wait_with_output()?;
-    if !result.status.success() {
-        panic!("failed to create test key");
-    }
-    let mut sign_codesigning_key_command =
-        std::process::Command::new(cargo::cargo_bin!("siguldry-server"));
-    let mut child = sign_codesigning_key_command
-        .env("SIGULDRY_SERVER_CONFIG", &server_config_file)
-        .args([
-            "manage",
-            "key",
-            "x509",
-            "--user-name",
-            "sigul-client",
-            "--key-name",
-            "test-codesigning-key",
-            "--common-name",
-            "test-codesigning-key",
-            "--validity-days",
-            "30",
-            "--certificate-authority",
-            "test-ca-key",
-            "code-signing",
-        ])
-        .stdin(Stdio::piped())
-        .spawn()?;
-    let mut stdin = child.stdin.take().unwrap();
-    stdin.write_all("🦀🦀🦀🦀\n".as_bytes())?;
-    drop(stdin);
-    let result = child.wait_with_output()?;
-    if !result.status.success() {
-        panic!("failed to create test key");
+    fn create_ca_key(server_config_file: &Path) -> anyhow::Result<()> {
+        Self::run_server_command(
+            server_config_file,
+            &[
+                "manage",
+                "key",
+                "create",
+                "siguldry-client",
+                keys::CA_KEY_NAME,
+            ],
+            Some(&format!("{}\n", keys::CA_KEY_PASSWORD)),
+        )?;
+
+        Self::run_server_command(
+            server_config_file,
+            &[
+                "manage",
+                "key",
+                "x509",
+                "--user-name",
+                "siguldry-client",
+                "--key-name",
+                keys::CA_KEY_NAME,
+                "--common-name",
+                keys::CA_KEY_NAME,
+                "--validity-days",
+                "30",
+                "certificate-authority",
+            ],
+            Some(&format!("{}\n", keys::CA_KEY_PASSWORD)),
+        )
     }
 
-    let server = server::service::Server::new(server_config).await?;
-    let server = server.run();
+    fn create_codesigning_key(server_config_file: &Path) -> anyhow::Result<()> {
+        Self::run_server_command(
+            server_config_file,
+            &[
+                "manage",
+                "key",
+                "create",
+                "siguldry-client",
+                keys::CODESIGNING_KEY_NAME,
+            ],
+            Some(&format!("{}\n", keys::CODESIGNING_KEY_PASSWORD)),
+        )?;
 
-    let client_config = client::Config {
-        server_hostname: server_hostname.to_string(),
-        bridge_hostname: bridge_hostname.to_string(),
-        bridge_port: bridge.client_port(),
-        credentials: creds.client.clone(),
-        ..Default::default()
-    };
-    let client_config_file = tempdir.path().join("client.toml");
-    std::fs::write(&client_config_file, toml::to_string_pretty(&client_config)?)?;
-    let client = client::Client::new(client_config)?;
+        Self::run_server_command(
+            server_config_file,
+            &[
+                "manage",
+                "key",
+                "x509",
+                "--user-name",
+                "siguldry-client",
+                "--key-name",
+                keys::CODESIGNING_KEY_NAME,
+                "--common-name",
+                keys::CODESIGNING_KEY_NAME,
+                "--validity-days",
+                "30",
+                "--certificate-authority",
+                keys::CA_KEY_NAME,
+                "code-signing",
+            ],
+            Some(&format!("{}\n", keys::CA_KEY_PASSWORD)),
+        )
+    }
 
-    Ok(Instance {
-        server,
-        bridge,
-        client,
-        creds,
-        state_dir: tempdir,
-    })
+    fn create_ec_key(server_config_file: &Path) -> anyhow::Result<()> {
+        Self::run_server_command(
+            server_config_file,
+            &[
+                "manage",
+                "key",
+                "create",
+                "--algorithm=p256",
+                "siguldry-client",
+                keys::EC_KEY_NAME,
+            ],
+            Some(&format!("{}\n", keys::EC_KEY_PASSWORD)),
+        )?;
+
+        Self::run_server_command(
+            server_config_file,
+            &[
+                "manage",
+                "key",
+                "x509",
+                "--user-name",
+                "siguldry-client",
+                "--key-name",
+                keys::EC_KEY_NAME,
+                "--common-name",
+                keys::EC_KEY_NAME,
+                "--validity-days",
+                "30",
+                "--certificate-authority",
+                keys::CA_KEY_NAME,
+                "code-signing",
+            ],
+            Some(&format!("{}\n", keys::CA_KEY_PASSWORD)),
+        )
+    }
 }
 
 #[tokio::test]
 #[tracing_test::traced_test]
 async fn basic_bridge_config() -> anyhow::Result<()> {
-    let instance = create_instance(None).await?;
-    let client = instance.client;
+    let instance = InstanceBuilder::new().build().await?;
 
     for _ in 0..5 {
-        let username = client.who_am_i().await.unwrap();
-        assert_eq!(username, "sigul-client");
+        let username = instance.client.who_am_i().await.unwrap();
+        assert_eq!(username, "siguldry-client");
     }
 
-    drop(client);
-    instance.server.halt().await?;
-    instance.bridge.halt().await?;
-
+    instance.halt().await?;
     Ok(())
 }
 
@@ -299,9 +506,9 @@ async fn basic_bridge_config() -> anyhow::Result<()> {
 #[tracing_test::traced_test]
 async fn client_rejects_bridge_cert() -> anyhow::Result<()> {
     let bridge_hostname = "localhost";
-    let server_hostname = "sigul-server";
-    let client_name = "sigul-client";
-    let instance = create_instance(None).await?;
+    let server_hostname = "siguldry-server";
+    let client_name = "siguldry-client";
+    let instance = InstanceBuilder::new().build().await?;
 
     let tempdir = tempfile::TempDir::new()?;
     let creds = create_credentials(
@@ -333,9 +540,7 @@ async fn client_rejects_bridge_cert() -> anyhow::Result<()> {
     }
 
     drop(client);
-    instance.server.halt().await?;
-    instance.bridge.halt().await?;
-
+    instance.halt().await?;
     Ok(())
 }
 
@@ -344,9 +549,9 @@ async fn client_rejects_bridge_cert() -> anyhow::Result<()> {
 #[tracing_test::traced_test]
 async fn bridge_rejects_client_cert() -> anyhow::Result<()> {
     let bridge_hostname = "localhost";
-    let server_hostname = "sigul-server";
-    let client_name = "sigul-client";
-    let instance = create_instance(None).await?;
+    let server_hostname = "siguldry-server";
+    let client_name = "siguldry-client";
+    let instance = InstanceBuilder::new().build().await?;
 
     let tempdir = tempfile::TempDir::new()?;
     let mut creds = create_credentials(
@@ -356,7 +561,7 @@ async fn bridge_rejects_client_cert() -> anyhow::Result<()> {
         client_name,
     )
     .await?;
-    creds.client.ca_certificate = instance.creds.client.ca_certificate;
+    creds.client.ca_certificate = instance.creds.client.ca_certificate.clone();
     let client_config = client::Config {
         server_hostname: server_hostname.to_string(),
         bridge_hostname: bridge_hostname.to_string(),
@@ -380,9 +585,7 @@ async fn bridge_rejects_client_cert() -> anyhow::Result<()> {
     }
 
     drop(client);
-    instance.server.halt().await?;
-    instance.bridge.halt().await?;
-
+    instance.halt().await?;
     Ok(())
 }
 
@@ -391,11 +594,10 @@ async fn bridge_rejects_client_cert() -> anyhow::Result<()> {
 #[tracing_test::traced_test]
 async fn bridge_rejects_client_cert_empty_common_name() -> anyhow::Result<()> {
     let tempdir = tempfile::TempDir::new()?;
-    let creds = create_credentials(tempdir.path(), "localhost", "sigul-server", "").await?;
-    let instance = create_instance(Some(creds)).await?;
-    let client = instance.client;
+    let creds = create_credentials(tempdir.path(), "localhost", "siguldry-server", "").await?;
+    let instance = InstanceBuilder::new().with_creds(creds).build().await?;
 
-    let username = client.who_am_i().await;
+    let username = instance.client.who_am_i().await;
     match username {
         Ok(name) => panic!("The request should not succeed, but server responded with {name}"),
         Err(ClientError::Connection(ConnectionError::Protocol(error))) => {
@@ -404,56 +606,50 @@ async fn bridge_rejects_client_cert_empty_common_name() -> anyhow::Result<()> {
         Err(other) => panic!("Incorrect error variant returned: {other:?}"),
     }
 
-    drop(client);
-    instance.server.halt().await?;
-    instance.bridge.halt().await?;
-
+    instance.halt().await?;
     Ok(())
 }
 
 #[tokio::test]
 #[tracing_test::traced_test]
 async fn unlock_gpg_key() -> anyhow::Result<()> {
-    let instance = create_instance(None).await?;
-    let client = instance.client;
+    let instance = InstanceBuilder::new().with_gpg_key().build().await?;
 
-    client
-        .unlock("test-gpg-key".to_string(), "🪿🪿🪿".to_string())
+    instance
+        .client
+        .unlock(
+            keys::GPG_KEY_NAME.to_string(),
+            keys::GPG_KEY_PASSWORD.to_string(),
+        )
         .await?;
 
-    drop(client);
-    instance.server.halt().await?;
-    instance.bridge.halt().await?;
-
+    instance.halt().await?;
     Ok(())
 }
 
 #[tokio::test]
 #[tracing_test::traced_test]
 async fn wrong_gpg_password() -> anyhow::Result<()> {
-    let instance = create_instance(None).await?;
-    let client = instance.client;
+    let instance = InstanceBuilder::new().with_gpg_key().build().await?;
 
-    let result = client
-        .unlock("test-gpg-key".to_string(), "🪿🪿🦆".to_string())
+    let result = instance
+        .client
+        .unlock(keys::GPG_KEY_NAME.to_string(), "🪿🪿🦆".to_string())
         .await;
     // TODO: split out server-side errors from client request errors
     assert!(result.is_err_and(|err| matches!(err, ClientError::Server(ServerError::Internal))));
 
-    drop(client);
-    instance.server.halt().await?;
-    instance.bridge.halt().await?;
-
+    instance.halt().await?;
     Ok(())
 }
 
 #[tokio::test]
 #[tracing_test::traced_test]
 async fn unlock_key_doesnt_exist() -> anyhow::Result<()> {
-    let instance = create_instance(None).await?;
-    let client = instance.client;
+    let instance = InstanceBuilder::new().build().await?;
 
-    let result = client
+    let result = instance
+        .client
         .unlock(
             "not-a-real-key".to_string(),
             "a boring password".to_string(),
@@ -462,10 +658,7 @@ async fn unlock_key_doesnt_exist() -> anyhow::Result<()> {
     // TODO: split out server-side errors from client request errors
     assert!(result.is_err_and(|err| matches!(err, ClientError::Server(ServerError::Internal))));
 
-    drop(client);
-    instance.server.halt().await?;
-    instance.bridge.halt().await?;
-
+    instance.halt().await?;
     Ok(())
 }
 
@@ -473,35 +666,39 @@ async fn unlock_key_doesnt_exist() -> anyhow::Result<()> {
 #[tokio::test]
 #[tracing_test::traced_test]
 async fn list_keys() -> anyhow::Result<()> {
-    let instance = create_instance(None).await?;
-    let client = instance.client;
+    let instance = InstanceBuilder::new().with_all_keys().build().await?;
 
-    let keys = client.list_keys().await?;
-    assert_eq!(3, keys.len());
+    let keys = instance.client.list_keys().await?;
+    // GPG key + CA key + codesigning key + EC key
+    assert_eq!(4, keys.len());
 
-    drop(client);
-    instance.server.halt().await?;
-    instance.bridge.halt().await?;
+    instance.halt().await?;
     Ok(())
 }
 
 #[tokio::test]
 #[tracing_test::traced_test]
 async fn gpg_sign_inline() -> anyhow::Result<()> {
-    let instance = create_instance(None).await?;
-    let client = instance.client;
+    let instance = InstanceBuilder::new().with_gpg_key().build().await?;
     let data = "🦡🦡🦡🦡🍄🍄".as_bytes();
-    let key_name = "test-gpg-key";
 
-    client
-        .unlock(key_name.to_string(), "🪿🪿🪿".to_string())
+    instance
+        .client
+        .unlock(
+            keys::GPG_KEY_NAME.to_string(),
+            keys::GPG_KEY_PASSWORD.to_string(),
+        )
         .await?;
-    let mut key = client.get_key(key_name.to_string()).await?;
+    let mut key = instance
+        .client
+        .get_key(keys::GPG_KEY_NAME.to_string())
+        .await?;
     assert_eq!(1, key.certificates.len());
     let certificate = key.certificates.pop().unwrap();
-    let signature = client
+    let signature = instance
+        .client
         .gpg_sign(
-            key_name.to_string(),
+            keys::GPG_KEY_NAME.to_string(),
             GpgSignatureType::Inline,
             bytes::Bytes::from(data),
         )
@@ -531,37 +728,42 @@ async fn gpg_sign_inline() -> anyhow::Result<()> {
             let stderr = String::from_utf8(output.stderr)?;
             assert_eq!(stdout, "🦡🦡🦡🦡🍄🍄");
             assert!(stderr.contains(&format!(
-                "Authenticated signature made by {} ({} <admin@example.com>)",
-                fingerprint, key_name
+                "Authenticated signature made by {} ({} <{}>)",
+                fingerprint,
+                keys::GPG_KEY_NAME,
+                keys::GPG_KEY_EMAIL
             )));
         }
         _ => panic!("unexpected key type"),
     }
 
-    drop(client);
-    instance.server.halt().await?;
-    instance.bridge.halt().await?;
-
+    instance.halt().await?;
     Ok(())
 }
 
 #[tokio::test]
 #[tracing_test::traced_test]
 async fn gpg_sign_detached() -> anyhow::Result<()> {
-    let instance = create_instance(None).await?;
-    let client = instance.client;
+    let instance = InstanceBuilder::new().with_gpg_key().build().await?;
     let data = "🦡🦡🦡🦡🍄🍄".as_bytes();
-    let key_name = "test-gpg-key";
 
-    client
-        .unlock(key_name.to_string(), "🪿🪿🪿".to_string())
+    instance
+        .client
+        .unlock(
+            keys::GPG_KEY_NAME.to_string(),
+            keys::GPG_KEY_PASSWORD.to_string(),
+        )
         .await?;
-    let mut key = client.get_key(key_name.to_string()).await?;
+    let mut key = instance
+        .client
+        .get_key(keys::GPG_KEY_NAME.to_string())
+        .await?;
     assert_eq!(1, key.certificates.len());
     let certificate = key.certificates.pop().unwrap();
-    let signature = client
+    let signature = instance
+        .client
         .gpg_sign(
-            key_name.to_string(),
+            keys::GPG_KEY_NAME.to_string(),
             GpgSignatureType::Detached,
             bytes::Bytes::from(data),
         )
@@ -593,38 +795,43 @@ async fn gpg_sign_detached() -> anyhow::Result<()> {
             let stderr = String::from_utf8(output.stderr)?;
             assert!(output.status.success());
             assert!(stderr.contains(&format!(
-                "Authenticated signature made by {} ({} <admin@example.com>)",
-                fingerprint, key_name
+                "Authenticated signature made by {} ({} <{}>)",
+                fingerprint,
+                keys::GPG_KEY_NAME,
+                keys::GPG_KEY_EMAIL
             )));
         }
         _ => panic!("unexpected key type"),
     }
 
-    drop(client);
-    instance.server.halt().await?;
-    instance.bridge.halt().await?;
-
+    instance.halt().await?;
     Ok(())
 }
 
 #[tokio::test]
 #[tracing_test::traced_test]
 async fn gpg_sign_cleartext() -> anyhow::Result<()> {
-    let instance = create_instance(None).await?;
-    let client = instance.client;
+    let instance = InstanceBuilder::new().with_gpg_key().build().await?;
     let data = "🦡🦡🦡🦡🍄🍄".as_bytes();
-    let key_name = "test-gpg-key";
 
-    client
-        .unlock(key_name.to_string(), "🪿🪿🪿".to_string())
+    instance
+        .client
+        .unlock(
+            keys::GPG_KEY_NAME.to_string(),
+            keys::GPG_KEY_PASSWORD.to_string(),
+        )
         .await?;
-    let mut key = client.get_key(key_name.to_string()).await?;
+    let mut key = instance
+        .client
+        .get_key(keys::GPG_KEY_NAME.to_string())
+        .await?;
     assert_eq!(1, key.certificates.len());
     let key = key.certificates.pop().unwrap();
 
-    let signature = client
+    let signature = instance
+        .client
         .gpg_sign(
-            key_name.to_string(),
+            keys::GPG_KEY_NAME.to_string(),
             GpgSignatureType::Cleartext,
             bytes::Bytes::from(data),
         )
@@ -662,29 +869,35 @@ Hash: SHA512
             let stderr = String::from_utf8(output.stderr)?;
             assert_eq!(stdout, "🦡🦡🦡🦡🍄🍄");
             assert!(stderr.contains(&format!(
-                "Authenticated signature made by {} ({} <admin@example.com>)",
-                fingerprint, key_name
+                "Authenticated signature made by {} ({} <{}>)",
+                fingerprint,
+                keys::GPG_KEY_NAME,
+                keys::GPG_KEY_EMAIL
             )));
         }
         _ => panic!("unexpected key type"),
     }
 
-    drop(client);
-    instance.server.halt().await?;
-    instance.bridge.halt().await?;
-
+    instance.halt().await?;
     Ok(())
 }
 
 #[tokio::test]
 #[tracing_test::traced_test]
 async fn check_x509_certs() -> anyhow::Result<()> {
-    let instance = create_instance(None).await?;
-    let client = instance.client;
-    let ca_key_name = "test-ca-key";
-    let codesigning_key_name = "test-codesigning-key";
-    let mut ca_key = client.get_key(ca_key_name.to_string()).await?;
-    let mut codesigning_key = client.get_key(codesigning_key_name.to_string()).await?;
+    let instance = InstanceBuilder::new()
+        .with_codesigning_key()
+        .build()
+        .await?;
+
+    let mut ca_key = instance
+        .client
+        .get_key(keys::CA_KEY_NAME.to_string())
+        .await?;
+    let mut codesigning_key = instance
+        .client
+        .get_key(keys::CODESIGNING_KEY_NAME.to_string())
+        .await?;
     match (
         ca_key.certificates.pop().unwrap(),
         codesigning_key.certificates.pop().unwrap(),
@@ -737,10 +950,7 @@ async fn check_x509_certs() -> anyhow::Result<()> {
         _ => panic!("unexpected key type"),
     }
 
-    drop(client);
-    instance.server.halt().await?;
-    instance.bridge.halt().await?;
-
+    instance.halt().await?;
     Ok(())
 }
 
@@ -748,19 +958,28 @@ async fn check_x509_certs() -> anyhow::Result<()> {
 #[tokio::test]
 #[tracing_test::traced_test]
 async fn digest_signature() -> anyhow::Result<()> {
-    let instance = create_instance(None).await?;
-    let client = instance.client;
-    let data = "🦡🦡🦡🦡🍄🍄".as_bytes();
-    let key_name = "test-codesigning-key";
-
-    client
-        .unlock(key_name.to_string(), "🪶🪶🪶🪶".to_string())
+    let instance = InstanceBuilder::new()
+        .with_codesigning_key()
+        .build()
         .await?;
-    let key = client.get_key(key_name.to_string()).await?;
+    let data = "🦡🦡🦡🦡🍄🍄".as_bytes();
 
-    let signature = client
+    instance
+        .client
+        .unlock(
+            keys::CODESIGNING_KEY_NAME.to_string(),
+            keys::CODESIGNING_KEY_PASSWORD.to_string(),
+        )
+        .await?;
+    let key = instance
+        .client
+        .get_key(keys::CODESIGNING_KEY_NAME.to_string())
+        .await?;
+
+    let signature = instance
+        .client
         .sign(
-            key_name.to_string(),
+            keys::CODESIGNING_KEY_NAME.to_string(),
             DigestAlgorithm::Sha256,
             bytes::Bytes::from(data),
         )
@@ -786,10 +1005,76 @@ async fn digest_signature() -> anyhow::Result<()> {
     let stdout = String::from_utf8(output.stdout)?;
     assert_eq!("Verified OK\n", stdout);
 
-    drop(client);
-    instance.server.halt().await?;
-    instance.bridge.halt().await?;
+    instance.halt().await?;
+    Ok(())
+}
 
+/// Get an EC signature on pre-hashed data.
+#[tokio::test]
+#[tracing_test::traced_test]
+async fn ec_prehashed_signature() -> anyhow::Result<()> {
+    let instance = InstanceBuilder::new().with_ec_key().build().await?;
+    let data = "🦡🦡🦡🦡🍄🍄".as_bytes();
+    let data_sum = openssl::hash::hash(openssl::hash::MessageDigest::sha256(), data)?.to_vec();
+    let data_hex = hex::encode(&data_sum);
+
+    instance
+        .client
+        .unlock(
+            keys::EC_KEY_NAME.to_string(),
+            keys::EC_KEY_PASSWORD.to_string(),
+        )
+        .await?;
+    let key = instance
+        .client
+        .get_key(keys::EC_KEY_NAME.to_string())
+        .await?;
+    let signature = instance
+        .client
+        .sign_prehashed(
+            keys::EC_KEY_NAME.to_string(),
+            vec![(DigestAlgorithm::Sha256, data_hex)],
+        )
+        .await?
+        .pop()
+        .unwrap();
+
+    let pubkey_path = instance.state_dir.path().join("ec-pubkey.pem");
+    std::fs::write(&pubkey_path, &key.public_key)?;
+    let sig_path = instance.state_dir.path().join("data.sig");
+    std::fs::write(&sig_path, &signature.signature)?;
+    let data_path = instance.state_dir.path().join("data");
+    std::fs::write(&data_path, data)?;
+    // Check the key is the expected format
+    let mut command = tokio::process::Command::new("openssl");
+    let output = command
+        .arg("ec")
+        .arg("-pubin")
+        .arg("-in")
+        .arg(&pubkey_path)
+        .arg("-text")
+        .arg("-noout")
+        .output()
+        .await?;
+    assert!(output.status.success());
+    let stdout = String::from_utf8(output.stdout)?;
+    assert!(stdout.contains("NIST CURVE: P-256"));
+
+    let mut command = tokio::process::Command::new("openssl");
+    let output = command
+        .arg("dgst")
+        .arg("-verify")
+        .arg(pubkey_path)
+        .arg("-signature")
+        .arg(sig_path)
+        .arg(data_path)
+        .output()
+        .await?;
+    assert!(output.status.success());
+    let stdout = String::from_utf8(output.stdout)?;
+    assert_eq!("Verified OK\n", stdout);
+
+    instance.halt().await?;
     Ok(())
 }
 
@@ -797,20 +1082,29 @@ async fn digest_signature() -> anyhow::Result<()> {
 #[tokio::test]
 #[tracing_test::traced_test]
 async fn prehashed_signature() -> anyhow::Result<()> {
-    let instance = create_instance(None).await?;
-    let client = instance.client;
+    let instance = InstanceBuilder::new()
+        .with_codesigning_key()
+        .build()
+        .await?;
     let data = "🦡🦡🦡🦡🍄🍄".as_bytes();
     let data_sum = openssl::hash::hash(openssl::hash::MessageDigest::sha256(), data)?.to_vec();
     let data_hex = hex::encode(&data_sum);
-    let key_name = "test-codesigning-key";
 
-    client
-        .unlock(key_name.to_string(), "🪶🪶🪶🪶".to_string())
+    instance
+        .client
+        .unlock(
+            keys::CODESIGNING_KEY_NAME.to_string(),
+            keys::CODESIGNING_KEY_PASSWORD.to_string(),
+        )
         .await?;
-    let key = client.get_key(key_name.to_string()).await?;
-    let signature = client
+    let key = instance
+        .client
+        .get_key(keys::CODESIGNING_KEY_NAME.to_string())
+        .await?;
+    let signature = instance
+        .client
         .sign_prehashed(
-            key_name.to_string(),
+            keys::CODESIGNING_KEY_NAME.to_string(),
             vec![(DigestAlgorithm::Sha256, data_hex)],
         )
         .await?
@@ -837,9 +1131,6 @@ async fn prehashed_signature() -> anyhow::Result<()> {
     let stdout = String::from_utf8(output.stdout)?;
     assert_eq!("Verified OK\n", stdout);
 
-    drop(client);
-    instance.server.halt().await?;
-    instance.bridge.halt().await?;
-
+    instance.halt().await?;
     Ok(())
 }


### PR DESCRIPTION
This should speed up the tests slightly since most tests don't need all the keys. It also adds the machinery to have HSM-backed keys in the test suite.