### PR TITLE
siguldry-server: Encrypt key passwords using AES-256-GCM

### DIFF
--- a/siguldry/src/server/config.rs
+++ b/siguldry/src/server/config.rs
@@ -111,12 +111,12 @@ impl Default for X509SubjectName {
 /// then encrypts _that_ with one or more secrets accessible only to the server.
 #[derive(Debug, Clone, Serialize, Deserialize, Default)]
 pub struct Pkcs11Binding {
-    /// The PEM-encoded public key to use to encrypt secrets.
-    pub public_key: PathBuf,
+    /// The PEM-encoded X509 certificate to use to encrypt secrets.
+    pub certificate: PathBuf,
     /// The PKCS#11 URI of the private key.
     ///
     /// This is optional, and if it is not set, the server will not attempt to decrypt secrets with
-    /// this entry. It will, however, encrypt any key passphrases created with the public key. This
+    /// this entry. It will, however, encrypt any key passphrases created with the certificate. This
     /// is useful when there are multiple servers where each server has its own secret, and the
     /// database is migrated from one to the other.
     ///
@@ -161,7 +161,7 @@ impl Default for Config {
                 ca_certificate: PathBuf::from("siguldry.ca_certificate.pem"),
             },
             pkcs11_bindings: vec![Pkcs11Binding {
-                public_key: PathBuf::from("/etc/siguldry/public_key.pem"),
+                certificate: PathBuf::from("/etc/siguldry/public_key.pem"),
                 private_key: Some("pkcs11:serial=abc123;id=%01;type=private".to_string()),
                 pin: None,
             }],

--- a/siguldry/src/server/crypto/mod.rs
+++ b/siguldry/src/server/crypto/mod.rs
@@ -310,7 +310,7 @@ pub(crate) mod test_utils {
         }
 
         let binding = Pkcs11Binding {
-            public_key: cert_file,
+            certificate: cert_file,
             private_key: Some(rsa_key_uri.to_string()),
             pin: Some(Password::from("secret-password")),
         };
@@ -338,7 +338,7 @@ pub(crate) mod test_utils {
             }
 
             bindings.push(Pkcs11Binding {
-                public_key: pubkey_path,
+                certificate: pubkey_path,
                 ..Default::default()
             });
         }

--- a/siguldry/src/server/ipc.rs
+++ b/siguldry/src/server/ipc.rs
@@ -49,7 +49,7 @@ struct BindingWithPin {
 impl From<BindingWithPin> for Pkcs11Binding {
     fn from(value: BindingWithPin) -> Self {
         Pkcs11Binding {
-            public_key: value.public_key,
+            certificate: value.public_key,
             private_key: Some(value.private_key),
             pin: Some(Password::from(value.pin)),
         }
@@ -132,7 +132,7 @@ impl Client {
             if let (Some(private_key), Some(pin)) = (&binding.private_key, &binding.pin) {
                 let pin = pin.map(|p| String::from_utf8(p.to_vec()))?;
                 bindings.push(BindingWithPin {
-                    public_key: binding.public_key.clone(),
+                    public_key: binding.certificate.clone(),
                     private_key: private_key.clone(),
                     pin,
                 });

--- a/siguldry/tests/end_to_end.rs
+++ b/siguldry/tests/end_to_end.rs
@@ -541,7 +541,7 @@ impl InstanceBuilder {
             );
         }
         Ok(Pkcs11Binding {
-            public_key: cert_file,
+            certificate: cert_file,
             private_key: Some(key_uri),
             pin: Some(Password::from(keys::HSM_PIN)),
         })


### PR DESCRIPTION
During the initial implementation I matched the values used by Sigul. This included using AES-256-CBC when encrypting key passwords. Sigul uses OpenSSL's openssl-smime command to do this, which has been deprecated in favor of openssl-cms, which produces RFC 5652-compliant structures and introduces support for modern ciphers, including GCM.