### PR TITLE
siguldry-server: Allow 2048 bit RSA keys

### DIFF
--- a/siguldry/migrations/0001_Initial_database_migration.sql
+++ b/siguldry/migrations/0001_Initial_database_migration.sql
@@ -4,6 +4,8 @@ PRAGMA foreign_keys = ON;
 CREATE TABLE IF NOT EXISTS "key_algorithms" (
     "type" TEXT NOT NULL PRIMARY KEY
 );
+-- 2048 bit RSA keys
+INSERT INTO key_algorithms(type) VALUES ("rsa2k");
 -- 4096 bit RSA keys
 INSERT INTO key_algorithms(type) VALUES ("rsa4k");
 -- NIST-P256 ECC keys

--- a/siguldry/src/protocol.rs
+++ b/siguldry/src/protocol.rs
@@ -542,6 +542,8 @@ pub enum GpgSignatureType {
 #[cfg_attr(feature = "cli", derive(clap::ValueEnum))]
 #[non_exhaustive]
 pub enum KeyAlgorithm {
+    /// 2048 bit RSA keys.
+    Rsa2K,
     /// 4096 bit RSA keys.
     #[default]
     Rsa4K,
@@ -552,6 +554,7 @@ pub enum KeyAlgorithm {
 impl KeyAlgorithm {
     pub fn as_str(&self) -> &str {
         match self {
+            KeyAlgorithm::Rsa2K => "rsa2k",
             KeyAlgorithm::Rsa4K => "rsa4k",
             KeyAlgorithm::P256 => "P256",
         }
@@ -563,6 +566,7 @@ impl TryFrom<&str> for KeyAlgorithm {
 
     fn try_from(value: &str) -> Result<Self, Self::Error> {
         match value {
+            "rsa2k" => Ok(Self::Rsa2K),
             "rsa4k" => Ok(Self::Rsa4K),
             "P256" => Ok(Self::P256),
             _ => Err(anyhow::anyhow!("Unknown key type '{value}'!")),

--- a/siguldry/src/server/crypto/mod.rs
+++ b/siguldry/src/server/crypto/mod.rs
@@ -42,6 +42,7 @@ pub fn create_encrypted_key(
 ) -> anyhow::Result<(String, Vec<u8>, String, String)> {
     let key_password = generate_password()?;
     let key = match algorithm {
+        KeyAlgorithm::Rsa2K => PKey::from_rsa(Rsa::generate(2048)?)?,
         KeyAlgorithm::Rsa4K => PKey::from_rsa(Rsa::generate(4096)?)?,
         KeyAlgorithm::P256 => PKey::from_ec_key(EcKey::generate(
             EcGroup::from_curve_name(Nid::X9_62_PRIME256V1)?.as_ref(),

--- a/siguldry/src/server/crypto/signing.rs
+++ b/siguldry/src/server/crypto/signing.rs
@@ -67,7 +67,7 @@ pub fn sign_with_softkey(
     digests: Vec<(DigestAlgorithm, String)>,
 ) -> anyhow::Result<Vec<protocol::json::Signature>> {
     let pkey = match key.key_algorithm {
-        KeyAlgorithm::Rsa4K => password
+        KeyAlgorithm::Rsa4K | KeyAlgorithm::Rsa2K => password
             .map(|password| {
                 Rsa::private_key_from_pem_passphrase(key.key_material.as_bytes(), password)
             })
@@ -132,7 +132,7 @@ pub fn sign_with_pkcs11(
         // the input/output from PKCS#11 signing mechanisms don't match OpenSSL, so we
         // need to handle the differences here
         let (mechanism, data_to_sign) = match key.key_algorithm {
-            KeyAlgorithm::Rsa4K => {
+            KeyAlgorithm::Rsa4K | KeyAlgorithm::Rsa2K => {
                 // For RSA PKCS#1 v1.5 with CKM_RSA_PKCS, we need to provide DigestInfo
                 // structure (DER-encoded hash algorithm OID + hash value)
                 let digest_info = encode_digest_info(algorithm, &hash)?;
@@ -149,7 +149,7 @@ pub fn sign_with_pkcs11(
             .context("PKCS#11 signing operation failed")?;
 
         let signature = match key.key_algorithm {
-            KeyAlgorithm::Rsa4K => signature,
+            KeyAlgorithm::Rsa4K | KeyAlgorithm::Rsa2K => signature,
             KeyAlgorithm::P256 => {
                 // Softkey signatures use OpenSSL, which return a DER-encoded signature, while PKCS #11
                 // returns the raw r and s values (refer to https://www.ietf.org/rfc/rfc6979.html#appendix-A.1.3).

--- a/siguldry/src/server/crypto/token.rs
+++ b/siguldry/src/server/crypto/token.rs
@@ -226,6 +226,7 @@ async fn import_pkcs11_token_private(
                     let _ = public_key.rsa()?;
                     match public_key.bits() {
                         4096 => KeyAlgorithm::Rsa4K,
+                        2048 => KeyAlgorithm::Rsa2K,
                         other => {
                             tracing::warn!(
                                 label = key_info.label,

--- a/siguldry/src/server/db.rs
+++ b/siguldry/src/server/db.rs
@@ -666,7 +666,8 @@ mod tests {
             })
             .collect::<Result<Vec<_>, anyhow::Error>>()?;
 
-        assert_eq!(2, key_algorithms.len());
+        assert_eq!(3, key_algorithms.len());
+        assert!(key_algorithms.contains(&KeyAlgorithm::Rsa2K));
         assert!(key_algorithms.contains(&KeyAlgorithm::Rsa4K));
         assert!(key_algorithms.contains(&KeyAlgorithm::P256));
 


### PR DESCRIPTION
Fedora likely has some historical keys that are 2048 bit RSA keys and we'll want to support importing these keys from Sigul.

This allows users to create these keys, even if you probably shouldn't make new ones.