### PR TITLE
deps: bump cryptoki to 0.12

### DIFF
--- a/deny.toml
+++ b/deny.toml
@@ -74,7 +74,8 @@ ignore = [
     #{ id = "RUSTSEC-0000-0000", reason = "you can specify a reason the advisory is ignored" },
     #"a-crate-that-is-yanked@0.1.1", # you can also ignore yanked crate versions if you wish
     #{ crate = "a-crate-that-is-yanked@0.1.1", reason = "you can specify why you are ignoring the yanked crate" },
-    { id = "RUSTSEC-2024-0436", reason = "Unmaintained dependency of sequoia-keystore; hopefully they address it" }
+    { id = "RUSTSEC-2024-0436", reason = "Unmaintained dependency of sequoia-keystore; revisit once a version > 0.7.1 is out" },
+    { id = "RUSTSEC-2025-0143", reason = "Unmaintained dependency of sequoia-keystore; revisit once a version > 0.7.1 is out" },
 ]
 
 # This section is considered when running `cargo deny check licenses`

--- a/siguldry/Cargo.toml
+++ b/siguldry/Cargo.toml
@@ -41,7 +41,7 @@ features = ["std", "derive", "env", "help", "usage", "error-context"]
 optional = true
 
 [dependencies.cryptoki]
-version = "0.11"
+version = "0.12"
 optional = true
 
 [dependencies.hex]
@@ -66,6 +66,8 @@ version = "2"
 default-features = false
 features = ["crypto-openssl"]
 
+# When updated, audit to see if RUSTSEC-2025-0143 and RUSTSEC-2024-0436
+# have been addressed by dropping them from the deny.toml ignorelist
 [dependencies.sequoia-keystore]
 version = "0.7"
 default-features = false


### PR DESCRIPTION
This addresses its usage of the unmaintained paste crate
(https://rustsec.org/advisories/RUSTSEC-2024-0436). Note that
sequoia-keystore still depends on paste, and separately there's a
capnproto unsound API in 0.24 that sequoia-keystore also depends on.