### PR TITLE
siguldry-server: add command to import from sigul

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -98,8 +98,47 @@ jobs:
       - name: cargo clippy
         run: cargo clippy --all-targets --all-features -- --deny warnings
 
+  generate-sigul-data:
+    name: Generate a Sigul data directory for migration
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+        with:
+          persist-credentials: false
+      - uses: dtolnay/rust-toolchain@fcf085fcb4b4b8f63f96906cd713eb52181b5ea4
+        id: rust-toolchain
+        with:
+          toolchain: stable
+      - uses: Swatinem/rust-cache@779680da715d629ac1d338a641029a2f4372abb5
+
+      - name: Install dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y \
+            capnproto \
+            clang \
+            libsqlite3-dev \
+            libssl-dev \
+            openssl \
+            pkg-config \
+            podman
+          pip3 install podman-compose
+
+      - name: Generate sigul data
+        run: cargo xtask generate-sigul-data
+
+      - name: Upload sigul data artifact
+        uses: actions/upload-artifact@v6
+        with:
+          name: sigul-data
+          path: devel/sigul-data/
+          if-no-files-found: error
+          overwrite: true
+          retention-days: 1
+
   test:
     name: Unit tests
+    needs: generate-sigul-data
     runs-on: ubuntu-latest
     container:
       image: quay.io/fedora/fedora:43
@@ -112,6 +151,13 @@ jobs:
       - uses: actions/checkout@v5
         with:
           persist-credentials: false
+
+      - name: Download sigul data artifact
+        uses: actions/download-artifact@v7
+        with:
+          name: sigul-data
+          path: devel/sigul-data/
+
       - uses: dtolnay/rust-toolchain@fcf085fcb4b4b8f63f96906cd713eb52181b5ea4
         id: rust-toolchain
         with:
@@ -139,6 +185,7 @@ jobs:
             opensc \
             openssl \
             openssl-devel \
+            softhsm \
             sqlite-devel
 
           # pesign-client doesn't let you configure the socket location, so make it available to the world

--- a/.gitignore
+++ b/.gitignore
@@ -4,5 +4,8 @@ Cargo.lock
 **/*.rs.bk
 proptest-regressions/
 
+# generated via cargo xtask generate-sigul-data
+devel/sigul-data/
+
 # Avoid checking in test artifacts
 **/*.efi

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -58,7 +58,7 @@ single_match_else = "warn"
 unnested_or_patterns = "warn"
 
 # The following rules are NOT machine-applicable.
-empty_enum = "warn"
+empty_enums = "warn"
 expl_impl_clone_on_copy = "warn"
 fn_params_excessive_bools = "warn"
 from_iter_instead_of_collect = "warn"

--- a/siguldry/.sqlx/query-0c9f8a1b4e0e1690bfe1c319996dbfc578b230b853850d98a911b4c7fbfe4554.json
+++ b/siguldry/.sqlx/query-0c9f8a1b4e0e1690bfe1c319996dbfc578b230b853850d98a911b4c7fbfe4554.json
@@ -14,13 +14,18 @@
         "type_info": "Integer"
       },
       {
-        "name": "data_type",
+        "name": "name",
         "ordinal": 2,
         "type_info": "Text"
       },
       {
-        "name": "data",
+        "name": "data_type",
         "ordinal": 3,
+        "type_info": "Text"
+      },
+      {
+        "name": "data",
+        "ordinal": 4,
         "type_info": "Text"
       }
     ],
@@ -28,6 +33,7 @@
       "Right": 2
     },
     "nullable": [
+      false,
       false,
       false,
       false,

--- a/siguldry/.sqlx/query-d6c6d041ec44236e8677ba9a1175bcd8fa9bedb100734454cd1180268a679c80.json
+++ b/siguldry/.sqlx/query-d6c6d041ec44236e8677ba9a1175bcd8fa9bedb100734454cd1180268a679c80.json
@@ -1,6 +1,6 @@
 {
   "db_name": "SQLite",
-  "query": "INSERT INTO public_key_material (key_id, data_type, data) VALUES (?, ?, ?) RETURNING id",
+  "query": "INSERT INTO public_key_material (key_id, name, data_type, data) VALUES (?, ?, ?, ?) RETURNING id",
   "describe": {
     "columns": [
       {
@@ -10,11 +10,11 @@
       }
     ],
     "parameters": {
-      "Right": 3
+      "Right": 4
     },
     "nullable": [
       false
     ]
   },
-  "hash": "9be76be1bd3fe38034e97359498a0aef5a7d7bf182fbf0d4393cb5318283865c"
+  "hash": "d6c6d041ec44236e8677ba9a1175bcd8fa9bedb100734454cd1180268a679c80"
 }

--- a/siguldry/migrations/0001_Initial_database_migration.sql
+++ b/siguldry/migrations/0001_Initial_database_migration.sql
@@ -28,8 +28,9 @@ CREATE TABLE IF NOT EXISTS "keys" (
     -- This uniquely identifies a key. For example, the GPG key fingerprint, or the SHA256 sum of
     -- the public key.
     "handle" TEXT NOT NULL UNIQUE,
-    -- The encrypted key material, or in the case of keys stored in hardware, information on how
-    -- to access the key (e.g. a PKCS11 URI).
+    -- The encrypted key material if this is not a PKCS#11-backed key. For PKCS#11-backed keys, this
+    -- is the hex-encoded ID attribute of the key within the associated token. That is, it is a human-
+    -- readable version of the blob stored in the `pkcs11_key_id` field.
     --
     -- The scheme is dependent on the type of key, but it will be a text representation (ASCII-armored, PEM-encoded, etc)
     "key_material" TEXT NOT NULL,
@@ -72,8 +73,11 @@ INSERT INTO public_key_material_types(type) VALUES ("revocation");
 CREATE TABLE IF NOT EXISTS "public_key_material" (
     "id" INTEGER NOT NULL PRIMARY KEY,
     "key_id" INTEGER NOT NULL,
+    -- A friendly identifier for the material; must be unique to the associated key.
+    "name" TEXT NOT NULL,
     "data_type" TEXT NOT NULL,
     "data" TEXT NOT NULL,
+    UNIQUE("key_id", "name"),
     -- If the parent key is deleted, remove all the associated public key material
     FOREIGN KEY(key_id) REFERENCES keys(id) ON DELETE CASCADE,
     FOREIGN KEY(data_type) REFERENCES public_key_material_types(type) ON DELETE RESTRICT

--- a/siguldry/src/bin/siguldry-server/cli.rs
+++ b/siguldry/src/bin/siguldry-server/cli.rs
@@ -119,6 +119,20 @@ pub enum ManagementCommands {
     #[command(subcommand)]
     Users(UserCommands),
 
+    /// Import data from a Sigul server.
+    ImportSigul {
+        /// The PKCS#11 URI for a private key capable of unbinding the Sigul keys if you
+        /// use binding on the Sigul server.
+        ///
+        /// This should be the value provided in your Sigul server's [binding] section.
+        /// For example, "pkcs11:serial=abc123;id=%01;type=private".
+        #[arg(short, long)]
+        binding_uri: Option<String>,
+
+        /// The location of Sigul's data directory.
+        sigul_data_directory: PathBuf,
+    },
+
     /// Apply any database migrations.
     ///
     /// This should be run on first use to create an empty database. This should also be run after

--- a/siguldry/src/bin/siguldry-server/import_sigul.rs
+++ b/siguldry/src/bin/siguldry-server/import_sigul.rs
@@ -1,0 +1,629 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) Microsoft Corporation.
+
+//! Import users and keys from Sigul.
+//!
+//! Sigul uses a combination of an SQLite database and a state directory to manage its users and
+//! keys.
+//!
+//! # SQLite Database
+//!
+//! The database is stored at `server.sqlite` relative to the state directory. The database schema,
+//! as of Sigul 1.3 is as follows:
+//!
+//! CREATE TABLE users (
+//!     id INTEGER NOT NULL,
+//!     name TEXT NOT NULL,
+//!     sha512_password BINARY,
+//!     admin BOOLEAN NOT NULL,
+//!     PRIMARY KEY (id),
+//!     UNIQUE (name)
+//! );
+//! CREATE TABLE keys (
+//!     id INTEGER NOT NULL,
+//!     name TEXT NOT NULL,
+//!     keytype VARCHAR(6) NOT NULL,
+//!     fingerprint TEXT NOT NULL,
+//!     PRIMARY KEY (id),
+//!     UNIQUE (name),
+//!     UNIQUE (fingerprint)
+//! );
+//! CREATE TABLE key_accesses (
+//!     id INTEGER NOT NULL,
+//!     key_id INTEGER NOT NULL,
+//!     user_id INTEGER NOT NULL,
+//!     encrypted_passphrase BINARY NOT NULL,
+//!     key_admin BOOLEAN NOT NULL,
+//!     PRIMARY KEY (id),
+//!     UNIQUE (key_id,user_id),
+//!     FOREIGN KEY(key_id) REFERENCES keys (id),
+//!     FOREIGN KEY(user_id) REFERENCES users (id)
+//! );
+//!
+//! # Keys
+//!
+//! Keys are stored in the state directory. There are three general keytypes.
+//!
+//! ## PGP
+//!
+//! PGP keys are stored in the `gnupg/` directory relative to the state directory root by default,
+//! and is used at the GPG_HOME location. Sigul uses gpg to generate and access the keys so the
+//! layout should follow the standard for the version of gpg installed on the Sigul host.
+//!
+//! Sigul supports configuring a different location for the PGP keys; this is not supported by the
+//! import tool and users must move the non-standard location to gnupg/ relative to the provided
+//! state directory.
+//!
+//! In the database, these keys have the keytype of "gnupg".
+//!
+//! ## Non-PGP Keys and X509 Certificates
+//!
+//! Sigul stores other key pairs and any associated X509 certificates in the `keys/` directory
+//! relative to the state directory. The keys are named using the `fingerprint` value in the
+//! `keys` table in the SQLite database. Private keys are stored in the format `{fingerprint}.pem`.
+//! Public keys are stored in `{fingerprint}.public.pem`. X509 certificates for the key pair are
+//! stored in `{fingerprint}.cert.{certificate-name}.pem`.
+//!
+//! In the database, these keys have the keytype of "ECC" or "RSA".
+//!
+//! ## PKCS #11 Tokens
+//!
+//! Sigul has rudimentary support for PKCS #11 tokens. A row in the `keys` table is added for a
+//! key in the token with the PKCS #11 URI. The user PIN for the token is stored in key_accesses
+//! records for each user. Since Siguldry handles PKCS #11 tokens quite differently, these keys
+//! are not importable.
+//!
+//! In the database, these keys have the keytype of "PKCS11".
+//!
+//! # Key Accesses
+//!
+//! Sigul encrypts keys using a server-generated secret. It then encrypts that secret using
+//! per-user passwords via GPG symmetric encryption. Optionally, it will encrypt the server-
+//! generated secret using a PKCS #11 public key or via TPM 1.2 (unsupported by this tool).
+//! The per-user password is then used to encrypt the output of the "bound" server-generated
+//! secret that was used to encrypt the key.
+//!
+//! To access the secret keys, the operations are:
+//!
+//! 1. Decrypt the value in the `encrypted_passphrase` using GPG.
+//! 2. If the value obtained from step 1 begins with a "{" or "[" character the value is a
+//!    JSON object or list of objects containing the PKCS #11 or TPM 1.2 encrypted secret used
+//!    to encrypt the key. Decrypt the value using the information found in the JSON object
+//! 3. Repeat step 2 until the value does not start with "{" or "["
+//! 4. Use the result to decrypt the private key.
+
+use std::{
+    collections::HashMap,
+    io::Write,
+    path::{Path, PathBuf},
+    process::Stdio,
+    str::FromStr,
+};
+
+use anyhow::Context;
+use sequoia_openpgp::{crypto::Password, serialize::MarshalInto};
+use siguldry::{
+    protocol::KeyAlgorithm,
+    server::{Pkcs11Binding, crypto, db},
+};
+use sqlx::{Pool, Row, Sqlite, SqliteConnection, SqlitePool, sqlite::SqliteConnectOptions};
+use tracing::instrument;
+
+use crate::management::PromptPassword;
+
+/// A user record from the sigul database.
+#[derive(Debug, Clone, sqlx::FromRow)]
+struct SigulUser {
+    id: i64,
+    name: String,
+}
+
+impl SigulUser {
+    #[instrument(skip_all, err)]
+    async fn list(conn: &mut SqliteConnection) -> anyhow::Result<Vec<Self>> {
+        let users = sqlx::query_as("SELECT id, name FROM users ORDER BY id ASC")
+            .fetch_all(&mut *conn)
+            .await?;
+        tracing::info!("Loaded {} users from sigul database", users.len());
+
+        Ok(users)
+    }
+}
+
+/// Key types supported by sigul.
+#[derive(Debug, Clone, Copy, PartialEq)]
+enum SigulKeyType {
+    /// A GPG key stored in the gnupg home directory.
+    Gnupg,
+    /// An ECC key stored as PEM files in the keys/ directory.
+    Ecc,
+    /// An RSA key stored as PEM files in the keys/ directory.
+    Rsa,
+    /// A key stored in a PKCS #11 hardware token (unsupported).
+    Pkcs11,
+}
+
+impl TryFrom<&str> for SigulKeyType {
+    type Error = anyhow::Error;
+
+    fn try_from(value: &str) -> Result<Self, Self::Error> {
+        match value {
+            "gnupg" => Ok(Self::Gnupg),
+            "ECC" => Ok(Self::Ecc),
+            "RSA" => Ok(Self::Rsa),
+            "PKCS11" => Ok(Self::Pkcs11),
+            _ => Err(anyhow::anyhow!(
+                "This Sigul database contains unknown key types and cannot be imported"
+            )),
+        }
+    }
+}
+
+/// A key record from the sigul database.
+#[derive(Debug, Clone, PartialEq, sqlx::FromRow)]
+struct SigulKey {
+    id: i64,
+    name: String,
+    keytype: SigulKeyType,
+    /// For gnupg keys, this is the GPG fingerprint.
+    /// For ECC/RSA keys, this is the SHA1 hash of the public key DER.
+    fingerprint: String,
+    /// Path to where the keys are store; how they're stored depends on the `keytype`
+    ///
+    /// For RSA/ECC keys, public, private, and x509 certs are in this directory and prefixed with
+    /// the fingerprint then ".pem" for encrypted secret, "public.pem" for public keys, and
+    /// "cert.<name>.pem" for certs.
+    ///
+    /// For PGP keys, they're stored however gnupg wrote them out (version-dependent).
+    keys_directory: PathBuf,
+}
+
+impl SigulKey {
+    #[instrument(skip_all, err)]
+    async fn list(
+        conn: &mut SqliteConnection,
+        sigul_data_directory: &Path,
+    ) -> anyhow::Result<Vec<Self>> {
+        let keys = sqlx::query("SELECT id, name, keytype, fingerprint FROM keys ORDER BY id ASC")
+            .fetch_all(&mut *conn)
+            .await?
+            .iter()
+            .map(|row| {
+                let keytype = row
+                    .get::<&str, usize>(2)
+                    .try_into()
+                    .expect("Database contains unknown keytype");
+                let keys_directory = match keytype {
+                    SigulKeyType::Gnupg => sigul_data_directory.join("gnupg"),
+                    SigulKeyType::Ecc | SigulKeyType::Rsa => sigul_data_directory.join("keys"),
+                    SigulKeyType::Pkcs11 => PathBuf::new(),
+                };
+                Self {
+                    id: row.get(0),
+                    name: row.get(1),
+                    keytype,
+                    fingerprint: row.get(3),
+                    keys_directory,
+                }
+            })
+            .collect::<Vec<Self>>();
+        tracing::info!("Loaded {} keys from sigul database", keys.len());
+
+        Ok(keys)
+    }
+
+    fn private_key_pem(&self) -> anyhow::Result<String> {
+        let private_key_path = self
+            .keys_directory
+            .join(format!("{}.pem", self.fingerprint));
+        let private_key = std::fs::read_to_string(&private_key_path).with_context(|| {
+            format!(
+                "Failed to read private key from {}",
+                private_key_path.display()
+            )
+        })?;
+
+        Ok(private_key)
+    }
+
+    fn public_key_pem(&self) -> anyhow::Result<String> {
+        let public_key_path = self
+            .keys_directory
+            .join(format!("{}.public.pem", self.fingerprint));
+        let public_key = std::fs::read_to_string(&public_key_path).with_context(|| {
+            format!(
+                "Failed to read public key from {}",
+                public_key_path.display()
+            )
+        })?;
+
+        Ok(public_key)
+    }
+
+    fn certificates_pem(&self) -> anyhow::Result<Vec<(String, String)>> {
+        let cert_format = format!("{}.cert.", self.fingerprint);
+        let certs = self
+            .keys_directory
+            .read_dir()?
+            .filter_map(|dir_entry| {
+                if let Ok(dir_entry) = dir_entry {
+                    if let Some(name) = dir_entry.file_name().as_os_str().to_str()
+                        && name.starts_with(&cert_format)
+                    {
+                        tracing::debug!(
+                            "Reading certificate for key '{}' from {}",
+                            self.name,
+                            dir_entry.path().display()
+                        );
+                        let cert_name = name
+                            .strip_prefix(&cert_format)
+                            .and_then(|s| s.strip_suffix(".pem"))
+                            .map(String::from);
+                        let pem_cert = std::fs::read_to_string(dir_entry.path()).ok();
+                        if let (Some(cert_name), Some(pem_cert)) = (cert_name, pem_cert) {
+                            Some((cert_name, pem_cert))
+                        } else {
+                            None
+                        }
+                    } else {
+                        None
+                    }
+                } else {
+                    None
+                }
+            })
+            .collect::<Vec<_>>();
+
+        Ok(certs)
+    }
+
+    // Import a non-PGP key pair and any associated certificates.
+    #[instrument(skip_all, err)]
+    async fn import_keypair(
+        &self,
+        conn: &mut SqliteConnection,
+        sigul_key_password: Password,
+    ) -> anyhow::Result<db::Key> {
+        let pubkey_pem = self.public_key_pem()?;
+        let privkey_pem = self.private_key_pem()?;
+
+        let pubkey = openssl::pkey::PKey::public_key_from_pem(pubkey_pem.as_bytes())?;
+        let key_algorithm = if pubkey.rsa().is_ok() {
+            match pubkey.bits() {
+                4096 => KeyAlgorithm::Rsa4K,
+                2048 => KeyAlgorithm::Rsa2K,
+                other => {
+                    tracing::warn!(
+                        sigul_key = self.name,
+                        "RSA key found, but key size ({}) is unsupported",
+                        other
+                    );
+                    return Err(anyhow::anyhow!("Unsupported RSA key size"));
+                }
+            }
+        } else if let Ok(ecc_key) = pubkey.ec_key() {
+            if ecc_key.group().curve_name() == Some(openssl::nid::Nid::X9_62_PRIME256V1) {
+                KeyAlgorithm::P256
+            } else {
+                tracing::warn!(sigul_key = self.name, curve=?ecc_key.group().curve_name(), "Found unsupported ECC key; skipping");
+                return Err(anyhow::anyhow!("ECC key uses unsupported curve"));
+            }
+        } else {
+            return Err(anyhow::anyhow!("Unknown key type"));
+        };
+        tracing::debug!(?key_algorithm, "Key algorithm detected");
+
+        let privkey = sigul_key_password.map(|password| {
+            openssl::pkey::PKey::private_key_from_pem_passphrase(privkey_pem.as_bytes(), password)
+        })?;
+        tracing::debug!("Successfully decrypted private key");
+        let key_material = crypto::sigul::encrypt_key(sigul_key_password, privkey)?;
+        let handle = hex::encode_upper(openssl::hash::hash(
+            openssl::hash::MessageDigest::sha256(),
+            &pubkey.public_key_to_der()?,
+        )?);
+        let key = db::Key::create(
+            conn,
+            &self.name,
+            &handle,
+            key_algorithm,
+            db::KeyPurpose::Signing,
+            &key_material,
+            &pubkey_pem,
+            None,
+            None,
+        )
+        .await?;
+
+        for (name, pem) in self.certificates_pem()? {
+            db::PublicKeyMaterial::create(conn, &key, name, db::PublicKeyMaterialType::X509, pem)
+                .await?;
+        }
+
+        Ok(key)
+    }
+
+    #[instrument(skip_all, err)]
+    async fn import_gnupg(
+        &self,
+        conn: &mut SqliteConnection,
+        sigul_key_password: Password,
+    ) -> anyhow::Result<db::Key> {
+        // It's annoying to use tokio's Command with a protected password
+        let mut child = std::process::Command::new("gpg")
+            .arg("--homedir")
+            .arg(&self.keys_directory)
+            .arg("--batch")
+            .arg("--pinentry-mode")
+            .arg("loopback")
+            .arg("--passphrase-fd")
+            .arg("0")
+            .arg("--armor")
+            .arg("--export-secret-keys")
+            .arg(self.fingerprint.as_str())
+            .stdin(Stdio::piped())
+            .stdout(Stdio::piped())
+            .stderr(Stdio::piped())
+            .spawn()
+            .context("Failed to execute gpg to export secret key")?;
+        let mut stdin = child.stdin.take().expect("Must spawn gpg with piped stdin");
+        sigul_key_password.map(|password| {
+            stdin.write_all(password)?;
+            stdin.write_all(b"\n")
+        })?;
+        drop(stdin);
+        let secret_output = child.wait_with_output()?;
+        if !secret_output.status.success() {
+            return Err(anyhow::anyhow!(
+                "gpg export secret key failed: {}",
+                String::from_utf8_lossy(&secret_output.stderr)
+            ));
+        }
+        let (cert, key_algorithm) =
+            crypto::sigul::check_gpg_key(&secret_output.stdout, sigul_key_password)?;
+        let fingerprint = cert.fingerprint().to_hex();
+        let private_key = String::from_utf8(cert.as_tsk().armored().to_vec()?)?;
+        let public_key = String::from_utf8(cert.strip_secret_key_material().armored().to_vec()?)?;
+        let key = db::Key::create(
+            conn,
+            &self.name,
+            &fingerprint,
+            key_algorithm,
+            db::KeyPurpose::PGP,
+            &private_key,
+            &public_key,
+            None,
+            None,
+        )
+        .await?;
+
+        Ok(key)
+    }
+
+    async fn as_siguldry_key(
+        &self,
+        conn: &mut SqliteConnection,
+        sigul_key_password: Password,
+    ) -> anyhow::Result<db::Key> {
+        match self.keytype {
+            SigulKeyType::Gnupg => self.import_gnupg(conn, sigul_key_password).await,
+            SigulKeyType::Ecc | SigulKeyType::Rsa => {
+                self.import_keypair(conn, sigul_key_password).await
+            }
+            SigulKeyType::Pkcs11 => Err(anyhow::anyhow!(
+                "Skipping PKCS11 key {}; enroll it later",
+                self.name
+            )),
+        }
+    }
+}
+
+/// A key access record from the sigul database.
+#[derive(Debug, Clone, sqlx::FromRow)]
+#[allow(dead_code)]
+struct SigulKeyAccess {
+    id: i64,
+    key_id: i64,
+    user_id: i64,
+    encrypted_passphrase: Vec<u8>,
+    key_admin: bool,
+}
+
+impl SigulKeyAccess {
+    #[instrument(skip_all, err)]
+    async fn for_user(conn: &mut SqliteConnection, user: &SigulUser) -> anyhow::Result<Vec<Self>> {
+        let accesses: Vec<SigulKeyAccess> = sqlx::query_as(
+            "SELECT id, key_id, user_id, encrypted_passphrase, key_admin \
+            FROM key_accesses \
+            WHERE user_id = $1 \
+            ORDER BY key_id ASC",
+        )
+        .bind(user.id)
+        .fetch_all(&mut *conn)
+        .await?;
+
+        tracing::info!(
+            "Loaded {} key access records for {}",
+            accesses.len(),
+            user.name
+        );
+        Ok(accesses)
+    }
+}
+
+fn prompt_yes_no(prompt: &str) -> anyhow::Result<bool> {
+    print!("{} [y/N]: ", prompt);
+    std::io::stdout().flush()?;
+    let answer = std::io::stdin()
+        .lines()
+        .next()
+        .ok_or_else(|| anyhow::anyhow!("Failed to read yes/no"))?
+        .map(|line| line.trim().to_lowercase())?;
+    Ok(answer == "y" || answer == "yes")
+}
+
+pub async fn migrate_sigul(
+    siguldry_conn: &mut SqliteConnection,
+    siguldry_bindings: &[Pkcs11Binding],
+    sigul_data_directory: PathBuf,
+    sigul_binding: Option<Pkcs11Binding>,
+) -> anyhow::Result<()> {
+    let db_path = sigul_data_directory.join("server.sqlite");
+    if !db_path.exists() {
+        return Err(anyhow::anyhow!(
+            "Sigul database not found at {}",
+            db_path.display()
+        ));
+    }
+    let opts = SqliteConnectOptions::from_str(&format!("sqlite://{}", db_path.display()))
+        .context("The database URL couldn't be parsed.")?
+        .create_if_missing(false)
+        .foreign_keys(true)
+        .read_only(true);
+    let sigul_pool: Pool<Sqlite> = SqlitePool::connect_with(opts)
+        .await
+        .with_context(|| format!("Failed to connect to the database at {}", db_path.display()))?;
+    let mut sigul_conn = sigul_pool.acquire().await?;
+
+    let sigul_users = SigulUser::list(&mut sigul_conn)
+        .await
+        .with_context(|| format!("Failed to read user table from {}", db_path.display()))?;
+    let sigul_keys = SigulKey::list(&mut sigul_conn, &sigul_data_directory)
+        .await
+        .with_context(|| format!("Failed to read keys table from {}", db_path.display()))?;
+    // Maps the Sigul key id to the Siguldry key and is used to track if we've imported a key yet
+    let mut imported_keys: HashMap<i64, db::Key> = HashMap::new();
+    let mut imported_users: Vec<db::User> = vec![];
+    let mut imported_key_accesses: Vec<db::KeyAccess> = vec![];
+
+    // To completely migrate, we need to walk through each user's key access tokens to decrypt and re-encrypt
+    // the key's encryption key using the new binding method.
+    let mut skipped_users: Vec<SigulUser> = vec![];
+    let mut skipped_key_accesses: Vec<SigulKeyAccess> = vec![];
+    for sigul_user in sigul_users.iter() {
+        if !prompt_yes_no(&format!("Import user '{}'?", sigul_user.name))? {
+            println!(
+                "Skipping user '{}' (any keys that only they can access will also be skipped)",
+                sigul_user.name
+            );
+            skipped_users.push(sigul_user.clone());
+            continue;
+        }
+        let user = db::User::create(siguldry_conn, &sigul_user.name)
+            .await
+            .context("Failed to create new user record in the siguldry database")?;
+        imported_users.push(user.clone());
+
+        // Walk through the keys they can access and prompt them for the user password
+        let sigul_accesses = SigulKeyAccess::for_user(&mut sigul_conn, sigul_user)
+            .await
+            .with_context(|| format!("Failed to read key accesses from {}", db_path.display()))?;
+        for sigul_key_access in sigul_accesses.iter() {
+            let sigul_key = sigul_keys
+                .iter()
+                .find(|k| k.id == sigul_key_access.key_id)
+                .ok_or_else(|| {
+                    anyhow::anyhow!("foreign key constrait violation on sigul's key access key_id")
+                })?;
+            if sigul_key.keytype == SigulKeyType::Pkcs11 {
+                println!(
+                    "User '{}' has access to '{}' but this is a PKCS#11-backed key which aren't importable; skipping it",
+                    user.name, sigul_key.name
+                );
+                continue;
+            }
+
+            if !prompt_yes_no(&format!(
+                "Import {}'s access to the '{}' key (you need to know their access password)?",
+                sigul_user.name, sigul_key.name
+            ))? {
+                println!("Skipping user's access to '{}'", sigul_key.name);
+                skipped_key_accesses.push(sigul_key_access.clone());
+                continue;
+            }
+            let (sigul_key_password, encrypted_password) = loop {
+                let user_password = PromptPassword::new(format!(
+                    "Enter {}'s user password to access the key '{}':",
+                    user.name, sigul_key.name
+                ))?
+                .prompt()?;
+                match crypto::binding::sigul::unbind_key_password(
+                    user_password.clone(),
+                    &sigul_key_access.encrypted_passphrase,
+                    &sigul_binding,
+                )
+                .await
+                {
+                    Ok(sigul_key_password) => {
+                        let encrypted_password = crypto::binding::encrypt_key_password(
+                            siguldry_bindings,
+                            user_password.clone(),
+                            sigul_key_password.clone(),
+                        )
+                        .context("Failed to bind the key password")?;
+                        tracing::debug!("Key passphrase has been successfully bound for Siguldry");
+                        break Ok::<_, anyhow::Error>((sigul_key_password, encrypted_password));
+                    }
+                    Err(error) => eprintln!(
+                        "Failed to unbind the '{}' key with that password ({}), please try again",
+                        sigul_key.name, error,
+                    ),
+                };
+            }?;
+
+            // Look up the key, then see if we've previously imported the key itself.
+            let key = if let Some(imported_key) = imported_keys.get(&sigul_key.id) {
+                imported_key
+            } else {
+                tracing::debug!(sigul_key.name, "Importing key material");
+                match sigul_key
+                    .as_siguldry_key(siguldry_conn, sigul_key_password)
+                    .await
+                {
+                    Ok(key) => {
+                        imported_keys.insert(sigul_key.id, key);
+                        imported_keys
+                            .get(&sigul_key.id)
+                            .expect("The key was just inserted into the map")
+                    }
+                    Err(error) => {
+                        eprintln!("Failed to import the Sigul key: {error}");
+                        continue;
+                    }
+                }
+            };
+            let siguldry_access = db::KeyAccess::create(
+                siguldry_conn,
+                key,
+                &user,
+                encrypted_password,
+                sigul_key_access.key_admin,
+            )
+            .await?;
+            imported_key_accesses.push(siguldry_access);
+        }
+    }
+
+    if !skipped_users.is_empty() {
+        println!(
+            "\nSkipped {} user(s): {}",
+            skipped_users.len(),
+            skipped_users
+                .into_iter()
+                .map(|u| u.name)
+                .collect::<Vec<_>>()
+                .join(", ")
+        );
+    }
+    for skipped_key in sigul_keys
+        .into_iter()
+        .filter(|k| !imported_keys.contains_key(&k.id))
+    {
+        eprintln!(
+            "WARNING: Did not import the '{}' key as the user was skipped or the key access was skipped",
+            skipped_key.name
+        );
+    }
+
+    Ok(())
+}

--- a/siguldry/src/bin/siguldry-server/main.rs
+++ b/siguldry/src/bin/siguldry-server/main.rs
@@ -23,6 +23,7 @@ use crate::management::PromptPassword;
 
 mod acquire_pin;
 mod cli;
+mod import_sigul;
 mod management;
 
 // The name of the default config file location. Since this is expected to run under systemd,

--- a/siguldry/src/protocol.rs
+++ b/siguldry/src/protocol.rs
@@ -492,6 +492,10 @@ pub enum Certificate {
     },
     /// A key pair with an associated X509 certificate.
     X509 {
+        /// A user-friendly name that uniquely identifies the certificate
+        /// with respect to a key. Different keys may have certificates with
+        /// the same name.
+        name: String,
         /// The PEM-encoded certificate.
         certificate: String,
     },

--- a/siguldry/src/server/handlers.rs
+++ b/siguldry/src/server/handlers.rs
@@ -79,6 +79,7 @@ impl Handler {
                     .await?
                     .into_iter()
                     .map(|cert| crate::protocol::Certificate::X509 {
+                        name: cert.name,
                         certificate: cert.data,
                     })
                     .collect()
@@ -138,6 +139,7 @@ impl Handler {
                 .await?
                 .into_iter()
                 .map(|cert| crate::protocol::Certificate::X509 {
+                    name: cert.name,
                     certificate: cert.data,
                 })
                 .collect()

--- a/xtask/Cargo.toml
+++ b/xtask/Cargo.toml
@@ -18,8 +18,16 @@ version = "0.2"
 [dependencies.clap]
 version = "4"
 
+[dependencies.openssl]
+version = "0.10"
+
+[dependencies.tokio]
+version = "1"
+features = ["rt", "macros", "time"]
+
 [dependencies.sigul-pesign-bridge]
 path = "../sigul-pesign-bridge"
 
 [dependencies.siguldry]
 path = "../siguldry"
+features = ["sigul-client"]

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -1,12 +1,19 @@
 // SPDX-License-Identifier: MIT
 // Copyright (c) Microsoft Corporation.
 
-use std::{env, path::PathBuf};
+use std::{
+    env,
+    path::{Path, PathBuf},
+    process::Command,
+    time::Duration,
+};
 
 use anyhow::anyhow;
 use clap::CommandFactory;
+use openssl::{pkey::PKey, rsa::Rsa, symm::Cipher};
+use siguldry::v1::client::{CertificateType, Client, KeyType, TlsConfig};
 
-const TASKS: [&str; 2] = ["manual", "extract-keys"];
+const TASKS: [&str; 3] = ["manual", "extract-keys", "generate-sigul-data"];
 
 fn main() -> anyhow::Result<()> {
     match env::args()
@@ -16,6 +23,11 @@ fn main() -> anyhow::Result<()> {
     {
         "manual" => generate_manual(),
         "extract-keys" => extract_keys(),
+        "generate-sigul-data" => tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .unwrap()
+            .block_on(generate_sigul_data()),
         _ => Err(anyhow!("Unknown task, use one of {:?}", TASKS)),
     }
 }
@@ -65,5 +77,314 @@ fn extract_keys() -> anyhow::Result<()> {
         anyhow::bail!("Failed to remove container 'sigul-ci-key-extract'");
     }
 
+    Ok(())
+}
+
+/// Generate a sigul database for migration testing.
+async fn generate_sigul_data() -> anyhow::Result<()> {
+    let root = PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("../");
+    let compose_file = root.join("compose.yml");
+    let creds_dir = root.join("devel/creds");
+    let outdir = root.join("devel/sigul-data");
+    let _ = std::fs::remove_dir_all(&outdir);
+    std::fs::create_dir_all(&outdir)?;
+
+    const ADMIN_PASSPHRASE: &str = "my-admin-password";
+    const GPG_PASSPHRASE: &str = "gpg-key-passphrase";
+    const ECC_PASSPHRASE: &str = "ecc-key-passphrase";
+    const RSA_PASSPHRASE: &str = "rsa-key-passphrase";
+    const CA_PASSPHRASE: &str = "ca-key-passphrase";
+    const AUTOSIGNER_USERNAME: &str = "autosigner";
+    const AUTOSIGNER_PASSPHRASE: &str = "autosigner-password";
+    const AUTOSIGNER_RSA_PASSPHRASE: &str = "autosigner-rsa-passphrase";
+    const SIGULDRY_USERNAME: &str = "siguldry-client";
+    const SIGULDRY_PASSPHRASE: &str = "siguldry-client-password";
+    const SIGULDRY_GPG_PASSPHRASE: &str = "siguldry-gpg-key-passphrase";
+
+    println!("Starting sigul server and bridge with podman-compose...");
+    let mut command = Command::new("podman-compose");
+    command
+        .current_dir(&root)
+        .args(["-f", compose_file.to_str().unwrap(), "up", "-d"]);
+    let output = command.output()?;
+    if !output.status.success() {
+        return Err(anyhow::anyhow!(
+            "Failed to start containers: {}",
+            String::from_utf8_lossy(&output.stderr)
+        ));
+    }
+
+    let tls_config = TlsConfig::new(
+        creds_dir.join("sigul.client.certificate.pem"),
+        creds_dir.join("sigul.client.private_key.pem"),
+        None,
+        creds_dir.join("sigul.ca_certificate.pem"),
+    )?;
+    let client = Client::new(
+        tls_config,
+        "localhost".to_string(),
+        44334,
+        "localhost".to_string(),
+        "sigul-client".to_string(),
+    );
+
+    // It can take a bit for the server to connect to the bridge depending on
+    // the order they come up in.
+    let mut retries = 10;
+    loop {
+        match client.users(ADMIN_PASSPHRASE.into()).await {
+            Ok(users) => {
+                println!("Connected to Sigul server. Users: {:?}", users);
+                break;
+            }
+            Err(e) if retries > 0 => {
+                println!("Waiting for server to be ready ({retries} retries left): {e}");
+                retries -= 1;
+                tokio::time::sleep(Duration::from_secs(2)).await;
+            }
+            Err(e) => {
+                cleanup_containers(&root, &compose_file)?;
+                return Err(anyhow::anyhow!(
+                    "Failed to connect to server after retries: {e}"
+                ));
+            }
+        }
+    }
+
+    client
+        .create_user(
+            ADMIN_PASSPHRASE.into(),
+            AUTOSIGNER_USERNAME.to_string(),
+            false,
+            Some(AUTOSIGNER_PASSPHRASE.into()),
+        )
+        .await?;
+    // Siguldry tests use the "siguldry-client" user by default so this makes setup easier
+    client
+        .create_user(
+            ADMIN_PASSPHRASE.into(),
+            SIGULDRY_USERNAME.to_string(),
+            false,
+            Some(SIGULDRY_PASSPHRASE.into()),
+        )
+        .await?;
+
+    println!("Creating GPG key 'test-sigul-gpg-key'...");
+    client
+        .new_key(
+            ADMIN_PASSPHRASE.into(),
+            GPG_PASSPHRASE.into(),
+            "test-sigul-gpg-key".to_string(),
+            KeyType::GnuPG {
+                real_name: Some("Test GPG Key".to_string()),
+                comment: Some("For testing import".to_string()),
+                email: Some("test@example.com".to_string()),
+                expire_date: None,
+            },
+            None,
+        )
+        .await?;
+
+    println!("Creating ECC key 'test-sigul-ca-key'...");
+    client
+        .new_key(
+            ADMIN_PASSPHRASE.into(),
+            CA_PASSPHRASE.into(),
+            "test-sigul-ca-key".to_string(),
+            KeyType::Ecc,
+            None,
+        )
+        .await?;
+    println!("Creating CA certificate for 'test-sigul-ca-key'...");
+    client
+        .sign_certificate(
+            "test-sigul-ca-key".to_string(),
+            CA_PASSPHRASE.into(),
+            None,
+            "test-sigul-ca-key".to_string(),
+            "root".to_string(),
+            CertificateType::Ca,
+            "Test Root CA".to_string(),
+            10,
+        )
+        .await?;
+
+    // We have to import RSA keys since sigul crashes if asked to generate them
+    println!("Importing RSA key 'test-sigul-rsa-key'...");
+    let rsa_key_pem = {
+        let rsa = Rsa::generate(2048)?;
+        let pkey = PKey::from_rsa(rsa)?;
+        pkey.private_key_to_pem_pkcs8_passphrase(Cipher::aes_256_cbc(), RSA_PASSPHRASE.as_bytes())?
+    };
+    client
+        .import_key(
+            ADMIN_PASSPHRASE.into(),
+            RSA_PASSPHRASE.into(),
+            RSA_PASSPHRASE.into(),
+            "test-sigul-rsa-key".to_string(),
+            &rsa_key_pem,
+            KeyType::Rsa,
+            None,
+        )
+        .await?;
+    println!("Creating code signing certificate for test-sigul-rsa-key...");
+    client
+        .sign_certificate(
+            "test-sigul-ca-key".to_string(),
+            CA_PASSPHRASE.into(),
+            Some("root".to_string()),
+            "test-sigul-rsa-key".to_string(),
+            "codesigning".to_string(),
+            CertificateType::CodeSigning,
+            "Test Code Signing".to_string(),
+            5,
+        )
+        .await?;
+
+    println!("Creating ECC key 'test-sigul-ecc-key'...");
+    client
+        .new_key(
+            ADMIN_PASSPHRASE.into(),
+            ECC_PASSPHRASE.into(),
+            "test-sigul-ecc-key".to_string(),
+            KeyType::Ecc,
+            None,
+        )
+        .await?;
+
+    println!(
+        "Granting key access for test-sigul-rsa-key to {}...",
+        AUTOSIGNER_USERNAME
+    );
+    client
+        .grant_key_access(
+            ADMIN_PASSPHRASE.into(),
+            "test-sigul-rsa-key".to_string(),
+            RSA_PASSPHRASE.into(),
+            AUTOSIGNER_USERNAME.to_string(),
+            AUTOSIGNER_RSA_PASSPHRASE.into(),
+            None,
+            None,
+        )
+        .await?;
+    client
+        .grant_key_access(
+            ADMIN_PASSPHRASE.into(),
+            "test-sigul-gpg-key".to_string(),
+            GPG_PASSPHRASE.into(),
+            SIGULDRY_USERNAME.to_string(),
+            SIGULDRY_GPG_PASSPHRASE.into(),
+            None,
+            None,
+        )
+        .await?;
+
+    println!("Sigul keys in server:");
+    for key in client.keys(ADMIN_PASSPHRASE.into()).await? {
+        println!("\t{key}");
+    }
+    println!("Users in server:");
+    for user in client.users(ADMIN_PASSPHRASE.into()).await? {
+        println!("\t{user}");
+    }
+
+    // Dump a file that can be piped to the import-sigul command to answer all the
+    // prompts correctly.
+    //
+    // The expected prompts here are
+    //   - import sigul-client
+    //     - import its access to the GPG key?
+    //     - import its access to the CA key?
+    //     - import its access to the RSA key?
+    //     - import its access to the ECC key?
+    //   - import autosigner
+    //     - import its access to the RSA key?
+    //   - import siguldry-client
+    //     - import its access to the GPG key?
+    let import_dialog_answer = format!(
+        "y\n\
+         y\n\
+         {GPG_PASSPHRASE}\n\
+         y\n\
+         {CA_PASSPHRASE}\n\
+         y\n\
+         {RSA_PASSPHRASE}\n\
+         y\n\
+         {ECC_PASSPHRASE}\n\
+         y\n\
+         y\n\
+         {AUTOSIGNER_RSA_PASSPHRASE}\n\
+         y\n\
+         y\n\
+         {SIGULDRY_GPG_PASSPHRASE}\n"
+    );
+    std::fs::write(outdir.join("import-dialog-answers"), import_dialog_answer)?;
+
+    let mut command = Command::new("podman-compose");
+    command
+        .current_dir(&root)
+        .args(["-f", compose_file.to_str().unwrap(), "ps"]);
+    let ps_output = String::from_utf8(command.output()?.stdout).unwrap();
+    let container_id = if let Some(container_id) = ps_output
+        .lines()
+        .find(|l| l.contains("sigul-server"))
+        .and_then(|l| l.split_whitespace().next())
+    {
+        container_id
+    } else {
+        cleanup_containers(&root, &compose_file)?;
+        return Err(anyhow::anyhow!("Could not find sigul-server container"));
+    };
+
+    println!("Copying sigul data from container {container_id}...");
+    let sigul_data_dir = outdir.join("sigul");
+    let mut command = Command::new("podman");
+    command.args([
+        "cp",
+        &format!("{container_id}:/var/lib/sigul"),
+        sigul_data_dir.to_str().unwrap(),
+    ]);
+    let output = command.output()?;
+    if !output.status.success() {
+        return Err(anyhow::anyhow!(
+            "Failed to copy /var/lib/sigul: {}",
+            String::from_utf8_lossy(&output.stderr)
+        ));
+    }
+
+    let softhsm_dir = outdir.join("softhsm");
+    let mut command = Command::new("podman");
+    command.args([
+        "cp",
+        &format!("{container_id}:/var/lib/softhsm"),
+        softhsm_dir.to_str().unwrap(),
+    ]);
+    let output = command.output()?;
+    if !output.status.success() {
+        return Err(anyhow::anyhow!(
+            "Failed to copy /var/lib/softhsm: {}",
+            String::from_utf8_lossy(&output.stderr)
+        ));
+    }
+
+    cleanup_containers(&root, &compose_file)?;
+    println!("Done! Sigul data extracted to {}", outdir.display());
+
+    Ok(())
+}
+
+fn cleanup_containers(root: &Path, compose_file: &Path) -> anyhow::Result<()> {
+    println!("Stopping containers...");
+    let mut command = Command::new("podman-compose");
+    command
+        .current_dir(root)
+        .args(["-f", compose_file.to_str().unwrap(), "down"]);
+    let output = command.output()?;
+    if !output.status.success() {
+        return Err(anyhow::anyhow!(
+            "Failed to stop containers: {}",
+            String::from_utf8_lossy(&output.stderr)
+        ));
+    }
     Ok(())
 }


### PR DESCRIPTION
This adds a command that is capable of importing sigul's database and state directory to siguldry.

It includes a new xtask to generate sample sigul data, as well.