### PR TITLE
siguldry-test: simplify the signer helper in testing

### DIFF
--- a/siguldry-test/Cargo.toml
+++ b/siguldry-test/Cargo.toml
@@ -29,5 +29,9 @@ version = "0.5"
 version = "1.27"
 features = ["macros", "net", "process", "rt", "io-util", "time"]
 
+[dependencies.tokio-util]
+version = "0.7"
+features = ["io", "rt"]
+
 [lints]
 workspace = true

--- a/siguldry/src/bin/siguldry-signer/main.rs
+++ b/siguldry/src/bin/siguldry-signer/main.rs
@@ -7,9 +7,15 @@
 //! Requests are sent over stdin as JSON separated by newlines.
 //! Responses are sent over stdout as JSON separated by newlines.
 
+use std::path::PathBuf;
+
 use anyhow::Context;
 use clap::Parser;
 use siguldry::server::ipc;
+use siguldry::signal_handler;
+use tokio::net::UnixListener;
+use tokio_util::{sync::CancellationToken, task::TaskTracker};
+use tracing::Instrument;
 use tracing_subscriber::{EnvFilter, fmt::format::FmtSpan, layer::SubscriberExt};
 
 /// Helper binary for the Siguldry server; this is not intended to be called directly.
@@ -28,6 +34,11 @@ struct Cli {
     /// Details: https://docs.rs/tracing-subscriber/0.3.19/tracing_subscriber/filter/struct.EnvFilter.html#directives
     #[arg(long, env = "SIGULDRY_SIGNER_LOG", default_value = "INFO")]
     pub log_filter: String,
+
+    /// If provided, bind a Unix socket to the given location and proxy clients
+    /// that connect to it rather than using stdin/stdout.
+    #[arg(long)]
+    socket: Option<PathBuf>,
 }
 
 #[tokio::main(flavor = "current_thread")]
@@ -49,6 +60,44 @@ async fn main() -> anyhow::Result<()> {
         .with(log_filter);
     tracing::subscriber::set_global_default(registry)
         .expect("Programming error: set_global_default should only be called once.");
+    let halt_token = CancellationToken::new();
+    tokio::spawn(signal_handler(halt_token.clone()));
 
-    ipc::serve().await
+    if let Some(socket) = opts.socket {
+        let listener = UnixListener::bind(&socket)
+            .with_context(|| format!("Failed to bind to {}", &socket.display()))?;
+        let request_tracker = TaskTracker::new();
+        loop {
+            let stream = tokio::select! {
+                _ = halt_token.cancelled() => {
+                    tracing::info!("proxy halted; shutting down");
+                    return Ok(());
+                }
+                result = listener.accept() => {
+                    match result {
+                        Ok((unix_stream, _)) => {
+                            unix_stream
+                        },
+                        Err(error) => {
+                            tracing::error!(?socket, ?error, "Failed to accept request");
+                            break;
+                        },
+                    }
+                }
+            };
+            let (reader, writer) = tokio::io::split(stream);
+            request_tracker.spawn(
+                ipc::serve(halt_token.clone(), reader, writer)
+                    .instrument(tracing::info_span!("signer")),
+            );
+        }
+        request_tracker.close();
+        request_tracker.wait().await;
+    } else {
+        let requests = tokio::io::stdin();
+        let responses = tokio::io::stdout();
+        ipc::serve(halt_token, requests, responses).await?;
+    }
+
+    Ok(())
 }

--- a/siguldry/src/ipc_common.rs
+++ b/siguldry/src/ipc_common.rs
@@ -1,0 +1,94 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) Microsoft Corporation.
+
+//! Provide some common utilities for doing IPC for various helpers.
+//!
+//! This is primarily used in combination with systemd socket activation.
+
+use std::path::Path;
+
+use anyhow::Context;
+use bytes::Bytes;
+use tokio::io::{
+    AsyncBufReadExt, AsyncReadExt, AsyncWriteExt, BufReader, Lines, ReadHalf, WriteHalf,
+};
+use tokio::net::UnixStream;
+use tracing::{Level, instrument};
+
+pub struct IpcClient {
+    writer: WriteHalf<UnixStream>,
+    reader: Option<Lines<BufReader<ReadHalf<UnixStream>>>>,
+}
+
+impl IpcClient {
+    pub async fn new(socket_path: &Path) -> anyhow::Result<Self> {
+        let stream = UnixStream::connect(socket_path)
+            .await
+            .with_context(|| format!("Failed to connect to socket at {}", socket_path.display()))?;
+        let (reader, writer) = tokio::io::split(stream);
+        Ok(Self {
+            writer,
+            reader: Some(BufReader::new(reader).lines()),
+        })
+    }
+
+    /// Send a request to the IPC server.
+    ///
+    /// The bytes argument exists just because Sequioa doesn't support signing from a digest
+    /// (easily, anyway). Don't use it for anything else, and delete it if signing via PKCS#11
+    /// for PGP is good enough.
+    #[instrument(skip_all, level = Level::DEBUG)]
+    pub async fn request<R: ?Sized + serde::Serialize>(
+        &mut self,
+        request: &R,
+        bytes: Option<&[u8]>,
+    ) -> anyhow::Result<serde_json::Value> {
+        let mut request = serde_json::to_string(request)?;
+        request.push('\n');
+
+        self.writer.write_all(request.as_bytes()).await?;
+        if let Some(bytes) = bytes {
+            self.writer.write_all(bytes).await?;
+        }
+        self.writer.flush().await?;
+
+        let mut reader = self
+            .reader
+            .take()
+            .expect("Programmer error: replace read half");
+        let response = match reader.next_line().await {
+            Ok(Some(response)) => serde_json::from_str(&response)
+                .map_err(|error| anyhow::anyhow!("Failed to deserialize response: {error:?}")),
+            Ok(None) => Err(anyhow::anyhow!("Unexpected EOF from IPC server")),
+            Err(error) => Err(anyhow::anyhow!(
+                "Unexpected error reading from IPC server: {error:?}"
+            )),
+        };
+        self.reader = Some(reader);
+
+        response
+    }
+
+    /// Only use this for PGP signing to read the payload back after the response.
+    ///
+    /// Delete this if we can use PKCS#11 client-side for all signing.
+    #[instrument(skip(self), level = Level::DEBUG)]
+    pub async fn read_bytes(&mut self, payload_size: usize) -> std::io::Result<Bytes> {
+        let mut reader = self
+            .reader
+            .take()
+            .expect("Programmer error: replace read half")
+            .into_inner();
+        let mut buffer = vec![0; payload_size];
+        tracing::trace!(len = buffer.len(), "trying to read into buf");
+        let result = reader.read_exact(&mut buffer).await;
+        self.reader = Some(reader.lines());
+        result?;
+
+        Ok(Bytes::from(buffer))
+    }
+
+    pub async fn shutdown(mut self) -> std::io::Result<()> {
+        self.writer.shutdown().await
+    }
+}

--- a/siguldry/src/lib.rs
+++ b/siguldry/src/lib.rs
@@ -67,6 +67,7 @@ pub mod bridge;
 pub mod client;
 pub mod config;
 pub mod error;
+mod ipc_common;
 pub(crate) mod nestls;
 pub mod protocol;
 #[cfg(feature = "server")]

--- a/siguldry/src/server/config.rs
+++ b/siguldry/src/server/config.rs
@@ -61,13 +61,6 @@ pub struct Config {
     /// The rest of the certificate's subject is specified here.
     pub certificate_subject: X509SubjectName,
 
-    /// Path to the helper executable used by the server to isolate the signing
-    /// operation from the process serving client requests. This option exists primarily for
-    /// testing purposes and should not be used in production. See `signer_socket_path` instead.
-    #[doc(hidden)]
-    #[serde(default)]
-    pub signer_executable: Option<PathBuf>,
-
     /// The set of certificates to encrypt passwords with.
     ///
     /// At least one entry should include a PKCS#11 URI for a private key. Passwords are encrypted
@@ -154,7 +147,6 @@ impl Default for Config {
             bridge_port: 44333,
             connection_pool_size: 32,
             user_password_length: NonZeroU16::new(32).unwrap(),
-            signer_executable: None,
             credentials: Credentials {
                 private_key: PathBuf::from("siguldry.server.private_key.pem"),
                 certificate: PathBuf::from("siguldry.server.certificate.pem"),


### PR DESCRIPTION
This gets rid of the signer_bin configuration since the package should set up the systemd socket unit. Tests now spawn a listener and the code doesn't ever try to spawn a subprocess to handle signing. This gets rid of a lot of prod code that only existed to make testing easier.