### PR TITLE
siguldry: Adjust the Sign response to include types

### DIFF
--- a/siguldry/src/client.rs
+++ b/siguldry/src/client.rs
@@ -463,7 +463,7 @@ impl Client {
         key: String,
         digest: DigestAlgorithm,
         data: Bytes,
-    ) -> Result<Bytes, ClientError> {
+    ) -> Result<Signature, ClientError> {
         let request = Request {
             message: protocol::json::Request::Sign { key, digest },
             binary: Some(data),
@@ -471,9 +471,7 @@ impl Client {
 
         let response = self.reconnecting_send(request).await?;
         match response.json {
-            Response::Sign {} => response.binary.ok_or_else(|| {
-                anyhow::anyhow!("Server response didn't include a signature").into()
-            }),
+            Response::Sign { signature } => Ok(signature),
             Response::Error { reason } => Err(reason.into()),
             _other => Err(anyhow::anyhow!("Unexpected response from server").into()),
         }

--- a/siguldry/src/server/handlers.rs
+++ b/siguldry/src/server/handlers.rs
@@ -174,8 +174,10 @@ impl Handler {
             .await?;
 
         Ok(Response {
-            json: json::Response::Sign {},
-            binary: Some(Bytes::from(response.pop().unwrap().signature)),
+            json: json::Response::Sign {
+                signature: response.pop().unwrap(),
+            },
+            binary: None,
         })
     }
 

--- a/siguldry/tests/end_to_end.rs
+++ b/siguldry/tests/end_to_end.rs
@@ -500,7 +500,7 @@ async fn digest_signature() -> anyhow::Result<()> {
     let pubkey_path = instance.state_dir.path().join("codesigning-pubkey.pem");
     std::fs::write(&pubkey_path, &key.public_key)?;
     let sig_path = instance.state_dir.path().join("data.sig");
-    std::fs::write(&sig_path, &signature)?;
+    std::fs::write(&sig_path, signature.value())?;
     let data_path = instance.state_dir.path().join("data");
     std::fs::write(&data_path, data)?;
     let mut command = tokio::process::Command::new("openssl");
@@ -554,7 +554,7 @@ async fn ec_prehashed_signature() -> anyhow::Result<()> {
     let pubkey_path = instance.state_dir.path().join("ec-pubkey.pem");
     std::fs::write(&pubkey_path, &key.public_key)?;
     let sig_path = instance.state_dir.path().join("data.sig");
-    std::fs::write(&sig_path, &signature.signature)?;
+    std::fs::write(&sig_path, signature.value())?;
     let data_path = instance.state_dir.path().join("data");
     std::fs::write(&data_path, data)?;
     // Check the key is the expected format
@@ -622,7 +622,7 @@ async fn hsm_ec_prehashed_signature() -> anyhow::Result<()> {
     let pubkey_path = instance.state_dir.path().join("ec-pubkey.pem");
     std::fs::write(&pubkey_path, &key.public_key)?;
     let sig_path = instance.state_dir.path().join("data.sig");
-    std::fs::write(&sig_path, &signature.signature)?;
+    std::fs::write(&sig_path, signature.value())?;
     let data_path = instance.state_dir.path().join("data");
     std::fs::write(&data_path, data)?;
     // Check the key is the expected format
@@ -694,7 +694,7 @@ async fn prehashed_signature() -> anyhow::Result<()> {
     let pubkey_path = instance.state_dir.path().join("codesigning-pubkey.pem");
     std::fs::write(&pubkey_path, &key.public_key)?;
     let sig_path = instance.state_dir.path().join("data.sig");
-    std::fs::write(&sig_path, &signature.signature)?;
+    std::fs::write(&sig_path, signature.value())?;
     let data_path = instance.state_dir.path().join("data");
     std::fs::write(&data_path, data)?;
     let mut command = tokio::process::Command::new("openssl");
@@ -748,7 +748,7 @@ async fn hsm_rsa_prehashed_signature() -> anyhow::Result<()> {
     let pubkey_path = instance.state_dir.path().join("hsm-rsa-pubkey.pem");
     std::fs::write(&pubkey_path, &key.public_key)?;
     let sig_path = instance.state_dir.path().join("data.sig");
-    std::fs::write(&sig_path, &signature.signature)?;
+    std::fs::write(&sig_path, signature.value())?;
     let data_path = instance.state_dir.path().join("data");
     std::fs::write(&data_path, data)?;
     let mut command = tokio::process::Command::new("openssl");
@@ -804,7 +804,7 @@ async fn hsm_rsa_prehashed_signature_with_pkcs11_binding() -> anyhow::Result<()>
     let pubkey_path = instance.state_dir.path().join("hsm-rsa-pubkey.pem");
     std::fs::write(&pubkey_path, &key.public_key)?;
     let sig_path = instance.state_dir.path().join("data.sig");
-    std::fs::write(&sig_path, &signature)?;
+    std::fs::write(&sig_path, signature.value())?;
     let data_path = instance.state_dir.path().join("data");
     std::fs::write(&data_path, data)?;
     let mut command = tokio::process::Command::new("openssl");


### PR DESCRIPTION
Make the signature field in the response be an enum which includes details on the format of the contained signature. While it's possible to poke at the DER-encoded values, this make it much clearer about what the format of the signature is.