### PR TITLE
siguldry-server: Allow using the sign APIs with OpenPGP keys

### DIFF
--- a/siguldry/src/server/crypto/signing.rs
+++ b/siguldry/src/server/crypto/signing.rs
@@ -9,12 +9,23 @@
 use anyhow::Context;
 use asn1::{ObjectIdentifier, oid};
 use cryptoki::{mechanism::Mechanism, session::Session};
-use openssl::{ec::EcKey, pkey::PKey, pkey_ctx::PkeyCtx, rsa::Rsa};
-use sequoia_openpgp::crypto::Password;
+use openssl::{
+    bn::{BigNum, BigNumContext},
+    ec::EcKey,
+    nid::Nid,
+    pkey::PKey,
+    pkey_ctx::PkeyCtx,
+    rsa::Rsa,
+};
+use sequoia_openpgp::{
+    crypto::{Password, mpi},
+    parse::Parse,
+    policy::StandardPolicy,
+};
 
 use crate::{
     protocol::{self, DigestAlgorithm, KeyAlgorithm, json::SignaturePayload},
-    server::db,
+    server::{Pkcs11Binding, db},
 };
 
 // Algorithm identifiers for RSA PKCS v1.5 DigestInfo structures.
@@ -74,25 +85,126 @@ pub fn decode_digest_info(digest_info: &[u8]) -> anyhow::Result<(DigestAlgorithm
     Ok((algorithm, hash))
 }
 
+fn pgp_key_to_openssl(
+    cert: &sequoia_openpgp::Cert,
+    password: &Password,
+) -> anyhow::Result<PKey<openssl::pkey::Private>> {
+    let policy = &StandardPolicy::new();
+    let key = cert
+        .keys()
+        .secret()
+        .with_policy(policy, None)
+        .supported()
+        .for_signing()
+        .next()
+        .ok_or_else(|| anyhow::anyhow!("No signing-capable key found in certificate"))?
+        .key()
+        .clone()
+        .decrypt_secret(password)?;
+    let secret = match key.secret() {
+        sequoia_openpgp::packet::key::SecretKeyMaterial::Unencrypted(unencrypted) => unencrypted,
+        sequoia_openpgp::packet::key::SecretKeyMaterial::Encrypted(_) => {
+            return Err(anyhow::anyhow!("OpenPGP wasn't decrypted"));
+        }
+    };
+
+    let key = secret.map(|secret| {
+        match (key.mpis(), secret) {
+            (mpi::PublicKey::RSA { e, n }, mpi::SecretKeyMaterial::RSA { d, p, q, u: _ }) => {
+                let e = BigNum::from_slice(e.value())?;
+                let n = BigNum::from_slice(n.value())?;
+                let d = BigNum::from_slice(d.value())?;
+                let p = BigNum::from_slice(p.value())?;
+                let q = BigNum::from_slice(q.value())?;
+                let one = BigNum::from_u32(1)?;
+
+                // https://en.wikipedia.org/wiki/RSA_cryptosystem#Using_the_Chinese_remainder_algorithm
+                let mut context = BigNumContext::new_secure()?;
+                let mut p_sub_1 = BigNum::new()?;
+                p_sub_1.checked_sub(&p, &one)?;
+                let mut dmp1 = BigNum::new()?;
+                dmp1.checked_rem(&d, &p_sub_1, &mut context)?;
+
+                let mut context = BigNumContext::new_secure()?;
+                let mut q_sub_1 = BigNum::new()?;
+                q_sub_1.checked_sub(&q, &one)?;
+                let mut dmq1 = BigNum::new()?;
+                dmq1.checked_rem(&d, &q_sub_1, &mut context)?;
+
+                let mut context = BigNumContext::new_secure()?;
+                let mut iqmp = BigNum::new()?;
+                iqmp.mod_inverse(&q, &p, &mut context)?;
+
+                let privkey = Rsa::from_private_components(n, e, d, p, q, dmp1, dmq1, iqmp)?;
+                privkey.check_key()?;
+                Ok(PKey::from_rsa(privkey)?)
+            }
+            (mpi::PublicKey::ECDSA { curve, q }, mpi::SecretKeyMaterial::ECDSA { scalar }) => {
+                let curve = match curve {
+                    sequoia_openpgp::types::Curve::NistP256 => Ok(Nid::X9_62_PRIME256V1),
+                    _ => Err(anyhow::anyhow!(
+                        "Only ECDSA keys using the NIST P-256 curve are supported"
+                    )),
+                }?;
+
+                let group = openssl::ec::EcGroup::from_curve_name(curve)?;
+                let scalar = BigNum::from_slice(scalar.value())?;
+                let mut context = BigNumContext::new_secure()?;
+                let public_key = openssl::ec::EcPoint::from_bytes(&group, q.value(), &mut context)?;
+                let privkey = EcKey::from_private_components(&group, &scalar, &public_key)?;
+
+                Ok(PKey::from_ec_key(privkey)?)
+            }
+            _unsupported => Err(anyhow::anyhow!(
+                "No support for signing via OpenSSL with this OpenPGP key type"
+            )),
+        }
+    })?;
+
+    Ok(key)
+}
+
+/// Get a decrypted OpenSSL private key object.
+///
+/// This supports OpenPGP keys as well, allowing them to be used for non-PGP signatures
+/// or, more commonly, OpenPGP signatures through the PKCS11 module.
+pub async fn openssl_private_key(
+    key: &db::Key,
+    pkcs11_bindings: &[Pkcs11Binding],
+    user_password: Password,
+    encrypted_passphrase: &[u8],
+) -> anyhow::Result<PKey<openssl::pkey::Private>> {
+    let password =
+        super::binding::decrypt_key_password(pkcs11_bindings, user_password, encrypted_passphrase)
+            .await?;
+    let pkey = match key.key_purpose {
+        db::KeyPurpose::PGP => {
+            let cert = sequoia_openpgp::Cert::from_bytes(&key.key_material)?;
+            pgp_key_to_openssl(&cert, &password)?
+        }
+        db::KeyPurpose::Signing => match key.key_algorithm {
+            KeyAlgorithm::Rsa4K | KeyAlgorithm::Rsa2K => password
+                .map(|password| {
+                    Rsa::private_key_from_pem_passphrase(key.key_material.as_bytes(), password)
+                })
+                .and_then(PKey::from_rsa),
+            KeyAlgorithm::P256 => password
+                .map(|password| {
+                    EcKey::private_key_from_pem_passphrase(key.key_material.as_bytes(), password)
+                })
+                .and_then(PKey::from_ec_key),
+        }?,
+    };
+
+    Ok(pkey)
+}
+
 /// Sign a set of digests with a key stored in the database protected by a password.
 pub fn sign_with_softkey(
     key: &db::Key,
-    password: &Password,
+    pkey: &PKey<openssl::pkey::Private>,
     digests: Vec<(DigestAlgorithm, String)>,
 ) -> anyhow::Result<Vec<protocol::json::Signature>> {
-    let pkey = match key.key_algorithm {
-        KeyAlgorithm::Rsa4K | KeyAlgorithm::Rsa2K => password
-            .map(|password| {
-                Rsa::private_key_from_pem_passphrase(key.key_material.as_bytes(), password)
-            })
-            .and_then(PKey::from_rsa),
-        KeyAlgorithm::P256 => password
-            .map(|password| {
-                EcKey::private_key_from_pem_passphrase(key.key_material.as_bytes(), password)
-            })
-            .and_then(PKey::from_ec_key),
-    }?;
-
     let mut signatures = Vec::with_capacity(digests.len());
     for (algorithm, hex_hash) in digests {
         let hash = hex::decode(&hex_hash).context("The digest provided was not valid hex")?;
@@ -104,7 +216,7 @@ pub fn sign_with_softkey(
             ));
         }
 
-        let mut ctx = PkeyCtx::new(&pkey)?;
+        let mut ctx = PkeyCtx::new(pkey)?;
         ctx.sign_init()?;
         ctx.set_signature_md(algorithm.into())?;
         if key.key_algorithm == KeyAlgorithm::Rsa4K {
@@ -243,7 +355,9 @@ mod tests {
         )
         .await?;
         let pkcs11 = token.intialize()?;
-        let session = token.pkcs11_session(&pkcs11, &hsm.user_pin)?;
+        let slot = token.slot(&pkcs11)?;
+        let session = pkcs11.open_ro_session(slot)?;
+        session.login(cryptoki::session::UserType::User, Some(&hsm.user_pin))?;
 
         let keys = db::Key::list(&mut conn).await?;
         let rsa_key = keys
@@ -314,7 +428,9 @@ mod tests {
         )
         .await?;
         let pkcs11 = token.intialize()?;
-        let session = token.pkcs11_session(&pkcs11, &hsm.user_pin)?;
+        let slot = token.slot(&pkcs11)?;
+        let session = pkcs11.open_ro_session(slot)?;
+        session.login(cryptoki::session::UserType::User, Some(&hsm.user_pin))?;
 
         let keys = db::Key::list(&mut conn).await?;
         let ecc_key = keys
@@ -379,8 +495,6 @@ mod tests {
         let key_algorithm = KeyAlgorithm::Rsa4K;
         let (handle, key_access_password, key_material, public_key) =
             crypto::create_encrypted_key(&[], user_password.clone(), key_algorithm)?;
-        let key_password =
-            crypto::binding::decrypt_key_password(&[], user_password, &key_access_password).await?;
         let key = db::Key {
             id: 1,
             name: "test-rsa-softkey".to_string(),
@@ -397,9 +511,11 @@ mod tests {
         let digest = openssl::hash::hash(openssl::hash::MessageDigest::sha256(), data)?;
         let hex_hash = hex::encode(digest);
 
+        let pkey =
+            super::openssl_private_key(&key, &[], user_password, &key_access_password).await?;
         let signatures = super::sign_with_softkey(
             &key,
-            &key_password,
+            &pkey,
             vec![(DigestAlgorithm::Sha256, hex_hash.clone())],
         )?;
 
@@ -450,8 +566,6 @@ mod tests {
         let key_algorithm = KeyAlgorithm::P256;
         let (handle, key_access_password, key_material, public_key) =
             crypto::create_encrypted_key(&[], user_password.clone(), key_algorithm)?;
-        let key_password =
-            crypto::binding::decrypt_key_password(&[], user_password, &key_access_password).await?;
         let key = db::Key {
             id: 1,
             name: "test-ecc-softkey".to_string(),
@@ -468,9 +582,11 @@ mod tests {
         let digest = openssl::hash::hash(openssl::hash::MessageDigest::sha256(), data)?;
         let hex_hash = hex::encode(digest);
 
+        let pkey =
+            super::openssl_private_key(&key, &[], user_password, &key_access_password).await?;
         let signatures = super::sign_with_softkey(
             &key,
-            &key_password,
+            &pkey,
             vec![(DigestAlgorithm::Sha256, hex_hash.clone())],
         )?;
 
@@ -495,6 +611,155 @@ mod tests {
         std::fs::write(&data_path, data)?;
         std::fs::write(&signature_path, signature)?;
         std::fs::write(&pubkey_path, key.public_key.as_bytes())?;
+        let output = Command::new("openssl")
+            .args(["dgst", "-sha256", "-verify"])
+            .arg(&pubkey_path)
+            .arg("-signature")
+            .arg(&signature_path)
+            .arg(&data_path)
+            .output()?;
+
+        assert!(
+            output.status.success(),
+            "OpenSSL CLI verification failed: {}",
+            String::from_utf8_lossy(&output.stderr)
+        );
+
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn sign_with_pgp_rsa_key_via_openssl() -> Result<()> {
+        let temp_dir = TempDir::new()?;
+        let user_password = Password::from("test-key-password");
+
+        let key_algorithm = KeyAlgorithm::Rsa4K;
+        let gpg_key = crypto::GpgKey::new(
+            &[],
+            "Test RSA <test@example.com>",
+            user_password.clone(),
+            sequoia_openpgp::Profile::RFC4880,
+            key_algorithm.into(),
+        )?;
+        let key = db::Key {
+            id: 1,
+            name: "test-pgp-rsa".to_string(),
+            key_algorithm,
+            key_purpose: db::KeyPurpose::PGP,
+            handle: gpg_key.fingerprint(),
+            key_material: String::from_utf8(gpg_key.armored_key()?)?,
+            public_key: gpg_key.public_key()?,
+            pkcs11_token_id: None,
+            pkcs11_key_id: None,
+        };
+        let pkey =
+            super::openssl_private_key(&key, &[], user_password, gpg_key.encrypted_password())
+                .await?;
+
+        let data = "🦧📖".as_bytes();
+        let digest = openssl::hash::hash(openssl::hash::MessageDigest::sha256(), data)?;
+        let hex_hash = hex::encode(digest);
+        let signatures = super::sign_with_softkey(
+            &key,
+            &pkey,
+            vec![(DigestAlgorithm::Sha256, hex_hash.clone())],
+        )?;
+        assert_eq!(signatures.len(), 1);
+        assert_eq!(signatures.first().unwrap().digest, DigestAlgorithm::Sha256);
+        assert_eq!(signatures.first().unwrap().hash, hex_hash);
+        assert!(!signatures.first().unwrap().signature.is_empty());
+
+        // Verify the signature using OpenSSL Rust bindings
+        let mut ctx = openssl::pkey_ctx::PkeyCtx::new(&pkey)?;
+        ctx.verify_init()?;
+        ctx.set_signature_md(openssl::md::Md::sha256())?;
+        ctx.set_rsa_padding(openssl::rsa::Padding::PKCS1)?;
+        let signature = signatures.first().unwrap().signature.as_ref();
+        let result = ctx.verify(&digest, signature)?;
+        assert!(result, "Signature should be valid (OpenSSL bindings)");
+
+        // Also verify using the OpenSSL CLI in case I'm using the bindings wrong
+        let data_path = temp_dir.path().join("unsigned_data");
+        let signature_path = temp_dir.path().join("signature.bin");
+        let pubkey_path = temp_dir.path().join("pubkey.pem");
+        std::fs::write(&data_path, data)?;
+        std::fs::write(&signature_path, signature)?;
+        std::fs::write(&pubkey_path, &pkey.public_key_to_pem()?)?;
+        let output = Command::new("openssl")
+            .args(["dgst", "-sha256", "-verify"])
+            .arg(&pubkey_path)
+            .arg("-signature")
+            .arg(&signature_path)
+            .arg(&data_path)
+            .output()?;
+
+        assert!(
+            output.status.success(),
+            "OpenSSL CLI verification failed: {}",
+            String::from_utf8_lossy(&output.stderr)
+        );
+
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn sign_with_pgp_ec_key_via_openssl() -> Result<()> {
+        let temp_dir = TempDir::new()?;
+        let user_password = Password::from("test-key-password");
+
+        let key_algorithm = KeyAlgorithm::P256;
+        let gpg_key = crypto::GpgKey::new(
+            &[],
+            "Test EC <test@example.com>",
+            user_password.clone(),
+            sequoia_openpgp::Profile::RFC9580,
+            key_algorithm.into(),
+        )?;
+        let key = db::Key {
+            id: 1,
+            name: "test-pgp-ec".to_string(),
+            key_algorithm,
+            key_purpose: db::KeyPurpose::PGP,
+            handle: gpg_key.fingerprint(),
+            key_material: String::from_utf8(gpg_key.armored_key()?)?,
+            public_key: gpg_key.public_key()?,
+            pkcs11_token_id: None,
+            pkcs11_key_id: None,
+        };
+        let pkey =
+            super::openssl_private_key(&key, &[], user_password, gpg_key.encrypted_password())
+                .await?;
+
+        let data = "🦧📖".as_bytes();
+        let digest = openssl::hash::hash(openssl::hash::MessageDigest::sha256(), data)?;
+        let hex_hash = hex::encode(digest);
+        let signatures = super::sign_with_softkey(
+            &key,
+            &pkey,
+            vec![(DigestAlgorithm::Sha256, hex_hash.clone())],
+        )?;
+
+        assert_eq!(signatures.len(), 1);
+        assert_eq!(signatures.first().unwrap().digest, DigestAlgorithm::Sha256);
+        assert_eq!(signatures.first().unwrap().hash, hex_hash);
+        assert!(!signatures.first().unwrap().signature.is_empty());
+
+        // Verify the signature using OpenSSL Rust bindings
+        let ec_key = pkey.ec_key()?;
+        let signature = signatures.first().unwrap().signature.as_ref();
+        let ecdsa_sig = openssl::ecdsa::EcdsaSig::from_der(signature)?;
+        assert!(
+            ecdsa_sig.verify(&digest, &ec_key)?,
+            "EC PGP signature should be valid (OpenSSL bindings)"
+        );
+
+        // Also verify using the OpenSSL CLI
+        let data_path = temp_dir.path().join("unsigned_data");
+        let signature_path = temp_dir.path().join("signature.bin");
+        let pubkey_path = temp_dir.path().join("pubkey.pem");
+        std::fs::write(&data_path, data)?;
+        std::fs::write(&signature_path, signature)?;
+        std::fs::write(&pubkey_path, &pkey.public_key_to_pem()?)?;
         let output = Command::new("openssl")
             .args(["dgst", "-sha256", "-verify"])
             .arg(&pubkey_path)


### PR DESCRIPTION
This is primarily to support signing via PKCS11. We currently have Sequoia create the keys and deal with the certificate, but when used with the PKCS11 module we need to produce signatures with the PGP key that align with the PKCS11 values (which happen to mostly align with OpenSSL).