### PR TITLE
siguldry-pkcs11: support protected authentication path

### DIFF
--- a/siguldry-pkcs11/src/sign.rs
+++ b/siguldry-pkcs11/src/sign.rs
@@ -196,15 +196,14 @@ pub extern "C" fn C_SignFinal(
         }
     };
 
-    let digests = vec![(digest, data_hex)];
     match CLIENT
         .lock()
         .expect("client lock poisoned")
         .as_mut()
-        .map(|client| client.sign_prehashed(session.key.name.clone(), digests))
+        .map(|client| client.sign(session.key.name.clone(), digest, data_hex))
     {
-        Some(Ok(mut signatures)) => {
-            session.signature = signatures.pop().and_then(|s| s.pkcs11_value());
+        Some(Ok(signature)) => {
+            session.signature = signature.pkcs11_value();
         }
         Some(Err(error)) => {
             session.reset_signing_state();
@@ -307,15 +306,14 @@ pub extern "C" fn C_Sign(
             (algorithm, data_hex)
         };
 
-        let digests = vec![(digest_algorithm, data_hex)];
         match CLIENT
             .lock()
             .expect("client lock poisoned")
             .as_mut()
-            .map(|client| client.sign_prehashed(session.key.name.clone(), digests))
+            .map(|client| client.sign(session.key.name.clone(), digest_algorithm, data_hex))
         {
-            Some(Ok(mut signatures)) => {
-                session.signature = signatures.pop().and_then(|s| s.pkcs11_value());
+            Some(Ok(signature)) => {
+                session.signature = signature.pkcs11_value();
             }
             Some(Err(error)) => {
                 session.reset_signing_state();

--- a/siguldry/tests/end_to_end.rs
+++ b/siguldry/tests/end_to_end.rs
@@ -820,13 +820,11 @@ async fn client_proxy_prehashed_signature() -> anyhow::Result<()> {
             keys::EC_KEY_NAME.to_string(),
             keys::EC_KEY_PASSWORD.to_string(),
         )?;
-        let signature = client_proxy
-            .sign_prehashed(
-                keys::EC_KEY_NAME.to_string(),
-                vec![(DigestAlgorithm::Sha256, data_hex)],
-            )?
-            .pop()
-            .unwrap();
+        let signature = client_proxy.sign(
+            keys::EC_KEY_NAME.to_string(),
+            DigestAlgorithm::Sha256,
+            data_hex,
+        )?;
         Ok::<_, anyhow::Error>(signature)
     })
     .await??;


### PR DESCRIPTION
If a key is configured to be unlocked automatically in the siguldry-client proxy, mark the associated token in the pkcs11 module with the CKF_PROTECTED_AUTHENTICATION_PATH flag; this lets applications know they can pass a null pointer to the login function instead of a PIN.

This is particularly useful for the case of signing content during an RPM build. Pass the client proxy socket into the nspawn environment and have the build install the pkcs11 module; it should then be able to sign using the keys you configure to unlock without needing a PIN. This effectively replaces the need for pesign-daemon or sigul-pesign-bridge.

Fixes #132