### PR TITLE
siguldry-server: remove write access to /var

### DIFF
--- a/siguldry/siguldry-server.service
+++ b/siguldry/siguldry-server.service
@@ -53,7 +53,7 @@ RemoveIPC=true
 
 # Restrict write-able and executable filesystem locations
 ReadOnlyPaths=/
-ReadWritePaths=/var /run
+ReadWritePaths=/run
 NoExecPaths=/
 ExecPaths=/usr/bin/siguldry-server /usr/lib /usr/lib64
 


### PR DESCRIPTION
The server should not have write access to the data directory. The only time the database is written is currently using the siguldry-server CLI outside the context of the main service.