### PR TITLE
Be consistent in OpenPGP references

### DIFF
--- a/siguldry-pkcs11/src/lib.rs
+++ b/siguldry-pkcs11/src/lib.rs
@@ -6,9 +6,9 @@
 //!
 //! This module requires that users have set up a siguldry-client proxy.
 //!
-//! Sequoia cryptoki support is provided by this module by presenting Siguldry PGP keys
+//! Sequoia cryptoki support is provided by this module by presenting Siguldry OpenPGP keys
 //! in the format expected by the Sequoia key store. Keys with an Id attribute that starts
-//! with "pgp" are PGP keys.
+//! with "pgp" are OpenPGP keys.
 
 #![allow(non_snake_case)]
 use std::{

--- a/siguldry-pkcs11/src/objects.rs
+++ b/siguldry-pkcs11/src/objects.rs
@@ -246,7 +246,7 @@ impl Attribute {
         let mut attrs = HashMap::new();
 
         match key.certificates.first() {
-            Some(Certificate::Gpg {
+            Some(Certificate::Pgp {
                 version,
                 certificate,
                 fingerprint,

--- a/siguldry-pkcs11/tests/signing.rs
+++ b/siguldry-pkcs11/tests/signing.rs
@@ -598,7 +598,7 @@ async fn sign_sha512_ecdsa_openssl_provider() -> anyhow::Result<()> {
 #[ignore = "Sequoia doesn't yet support PKCS11"]
 async fn sign_rsa4k_via_sequoia() -> anyhow::Result<()> {
     let instance = InstanceBuilder::new()
-        .with_gpg_key()
+        .with_pgp_key()
         .with_client_proxy()
         .build()
         .await?;
@@ -609,12 +609,12 @@ async fn sign_rsa4k_via_sequoia() -> anyhow::Result<()> {
 
     let expected_pubkey = instance
         .client
-        .get_key(keys::GPG_KEY_NAME.to_string())
+        .get_key(keys::PGP_KEY_NAME.to_string())
         .await?;
     let certificate_path = instance.state_dir.path().join("signing_key.asc");
     tokio::fs::write(&certificate_path, expected_pubkey.public_key.as_bytes()).await?;
     let password_path = instance.state_dir.path().join("password");
-    tokio::fs::write(&password_path, keys::GPG_KEY_PASSWORD.as_bytes()).await?;
+    tokio::fs::write(&password_path, keys::PGP_KEY_PASSWORD.as_bytes()).await?;
 
     let sequoia_home = instance.state_dir.path().join("sequoia_home");
     let mut command = tokio::process::Command::new("sq");

--- a/siguldry-test/src/lib.rs
+++ b/siguldry-test/src/lib.rs
@@ -113,13 +113,13 @@ impl Instance {
 }
 
 pub mod keys {
-    pub const GPG_KEY_NAME: &str = "test-gpg-key";
-    pub const GPG_KEY_PASSWORD: &str = "🪿🪿🪿";
-    pub const GPG_KEY_EMAIL: &str = "admin@example.com";
+    pub const PGP_KEY_NAME: &str = "test-gpg-key";
+    pub const PGP_KEY_PASSWORD: &str = "🪿🪿🪿";
+    pub const PGP_KEY_EMAIL: &str = "admin@example.com";
 
-    pub const GPG_EC_KEY_NAME: &str = "test-gpg-ec-key";
-    pub const GPG_EC_KEY_PASSWORD: &str = "🐉🐉🐉🐉🐉";
-    pub const GPG_EC_KEY_EMAIL: &str = "admin@example.com";
+    pub const PGP_EC_KEY_NAME: &str = "test-gpg-ec-key";
+    pub const PGP_EC_KEY_PASSWORD: &str = "🐉🐉🐉🐉🐉";
+    pub const PGP_EC_KEY_EMAIL: &str = "admin@example.com";
 
     pub const CA_KEY_NAME: &str = "test-ca-key";
     pub const CA_KEY_PASSWORD: &str = "🦀🦀🦀🦀";
@@ -139,7 +139,7 @@ pub mod keys {
     /// ID used for the PKCS#11 binding key
     pub const HSM_BINDING_KEY_ID: u8 = 99;
 
-    /// GPG key imported from sigul
+    /// OpenPGP key imported from sigul
     pub const SIGUL_GPG_KEY_NAME: &str = "test-sigul-gpg-key";
     pub const SIGUL_GPG_KEY_PASSWORD: &str = "siguldry-gpg-key-passphrase";
 
@@ -161,10 +161,10 @@ pub struct InstanceBuilder {
     creds: Option<Creds>,
     // If true, any keys added will be configured to unlock automatically with the client
     auto_unlock_keys: bool,
-    // If enabled, the gpg keys will use v6 keys.
-    with_gpg_rfc9580_keys: bool,
-    with_gpg_key: bool,
-    with_gpg_ec_key: bool,
+    // If enabled, the pgp keys will use v6 keys.
+    with_pgp_rfc9580_keys: bool,
+    with_pgp_key: bool,
+    with_pgp_ec_key: bool,
     with_ca_key: bool,
     with_codesigning_key: bool,
     with_ec_key: bool,
@@ -193,18 +193,18 @@ impl InstanceBuilder {
         self
     }
 
-    pub fn use_rfc9580_for_gpg(mut self) -> Self {
-        self.with_gpg_rfc9580_keys = true;
+    pub fn use_rfc9580_for_pgp(mut self) -> Self {
+        self.with_pgp_rfc9580_keys = true;
         self
     }
 
-    pub fn with_gpg_key(mut self) -> Self {
-        self.with_gpg_key = true;
+    pub fn with_pgp_key(mut self) -> Self {
+        self.with_pgp_key = true;
         self
     }
 
-    pub fn with_gpg_ec_key(mut self) -> Self {
-        self.with_gpg_ec_key = true;
+    pub fn with_pgp_ec_key(mut self) -> Self {
+        self.with_pgp_ec_key = true;
         self
     }
 
@@ -271,7 +271,7 @@ impl InstanceBuilder {
     }
 
     pub fn with_all_keys(mut self) -> Self {
-        self.with_gpg_key = true;
+        self.with_pgp_key = true;
         self.with_ca_key = true;
         self.with_codesigning_key = true;
         self.with_ec_key = true;
@@ -382,7 +382,7 @@ impl InstanceBuilder {
             bridge_port: bridge.server_port(),
             credentials: creds.server.clone(),
             signer_socket_path: tempdir.path().join("signer-helper.socket"),
-            user_password_length: NonZeroU16::new(keys::GPG_KEY_PASSWORD.len() as u16)
+            user_password_length: NonZeroU16::new(keys::PGP_KEY_PASSWORD.len() as u16)
                 .expect("it's three geese"),
             pkcs11_bindings,
             connection_pool_size: 1,
@@ -409,50 +409,50 @@ impl InstanceBuilder {
                 None,
             )?;
 
-            let profile = if self.with_gpg_rfc9580_keys {
+            let profile = if self.with_pgp_rfc9580_keys {
                 "rfc9580"
             } else {
                 "rfc4880"
             };
 
-            if self.with_gpg_key {
+            if self.with_pgp_key {
                 Self::run_server_command(
                     &server_bin,
                     &server_config_file,
                     &[
                         "manage",
-                        "gpg",
+                        "pgp",
                         "create",
                         "--profile",
                         profile,
                         "siguldry-client",
-                        keys::GPG_KEY_NAME,
-                        keys::GPG_KEY_EMAIL,
+                        keys::PGP_KEY_NAME,
+                        keys::PGP_KEY_EMAIL,
                     ],
-                    Some(&format!("{}\n", keys::GPG_KEY_PASSWORD)),
+                    Some(&format!("{}\n", keys::PGP_KEY_PASSWORD)),
                 )?;
-                maybe_auto_unlock.push((keys::GPG_KEY_NAME, keys::GPG_KEY_PASSWORD));
+                maybe_auto_unlock.push((keys::PGP_KEY_NAME, keys::PGP_KEY_PASSWORD));
             }
 
-            if self.with_gpg_ec_key {
+            if self.with_pgp_ec_key {
                 Self::run_server_command(
                     &server_bin,
                     &server_config_file,
                     &[
                         "manage",
-                        "gpg",
+                        "pgp",
                         "create",
                         "--profile",
                         profile,
                         "--algorithm",
                         "p256",
                         "siguldry-client",
-                        keys::GPG_EC_KEY_NAME,
-                        keys::GPG_EC_KEY_EMAIL,
+                        keys::PGP_EC_KEY_NAME,
+                        keys::PGP_EC_KEY_EMAIL,
                     ],
-                    Some(&format!("{}\n", keys::GPG_EC_KEY_PASSWORD)),
+                    Some(&format!("{}\n", keys::PGP_EC_KEY_PASSWORD)),
                 )?;
-                maybe_auto_unlock.push((keys::GPG_EC_KEY_NAME, keys::GPG_EC_KEY_PASSWORD));
+                maybe_auto_unlock.push((keys::PGP_EC_KEY_NAME, keys::PGP_EC_KEY_PASSWORD));
             }
 
             if self.with_ca_key {

--- a/siguldry/benches/end_to_end.rs
+++ b/siguldry/benches/end_to_end.rs
@@ -8,7 +8,7 @@
 use std::time::Duration;
 
 use criterion::{BenchmarkId, Criterion, criterion_group, criterion_main};
-use siguldry::{client, protocol::GpgSignatureType};
+use siguldry::{client, protocol::PgpSignatureType};
 use tokio::task::JoinSet;
 
 use siguldry_test::InstanceBuilder;
@@ -163,7 +163,7 @@ fn gpg_sign_detached(criterion: &mut Criterion) {
         .unwrap();
     let instance = runtime
         .block_on(async {
-            let instance = InstanceBuilder::new().with_gpg_key().build().await?;
+            let instance = InstanceBuilder::new().with_pgp_key().build().await?;
             instance
                 .client
                 .unlock("test-gpg-key".to_string(), "🪿🪿🪿".to_string())
@@ -181,7 +181,7 @@ fn gpg_sign_detached(criterion: &mut Criterion) {
                     .client
                     .gpg_sign(
                         "test-gpg-key".to_string(),
-                        GpgSignatureType::Detached,
+                        PgpSignatureType::Detached,
                         bytes::Bytes::from(payload.clone()),
                     )
                     .await
@@ -201,7 +201,7 @@ fn gpg_sign_throughput(c: &mut Criterion) {
         .unwrap();
     let instance = runtime
         .block_on(async {
-            let instance = InstanceBuilder::new().with_gpg_key().build().await?;
+            let instance = InstanceBuilder::new().with_pgp_key().build().await?;
             instance
                 .client
                 .unlock("test-gpg-key".to_string(), "🪿🪿🪿".to_string())
@@ -229,7 +229,7 @@ fn gpg_sign_throughput(c: &mut Criterion) {
                                 client
                                     .gpg_sign(
                                         "test-gpg-key".to_string(),
-                                        GpgSignatureType::Detached,
+                                        PgpSignatureType::Detached,
                                         bytes::Bytes::from(payload),
                                     )
                                     .await

--- a/siguldry/src/bin/siguldry-server/cli.rs
+++ b/siguldry/src/bin/siguldry-server/cli.rs
@@ -118,9 +118,9 @@ impl From<OpenPgpProfile> for sequoia_openpgp::Profile {
 
 #[derive(clap::Subcommand, Debug)]
 pub enum ManagementCommands {
-    /// Manage GPG signing keys.
+    /// Manage OpenPGP signing keys.
     #[command(subcommand)]
-    Gpg(GpgCommands),
+    Pgp(PgpCommands),
 
     /// Manage non-GPG signing keys and certificates.
     #[command(subcommand)]
@@ -161,7 +161,7 @@ pub enum ManagementCommands {
 }
 
 #[derive(clap::Subcommand, Debug)]
-pub enum GpgCommands {
+pub enum PgpCommands {
     /// Generate a new signing key.
     Create {
         /// The key algorithm to use.
@@ -183,10 +183,10 @@ pub enum GpgCommands {
         admin: String,
         /// The name of the key in Siguldry.
         name: String,
-        /// The email to use for the GPG user id.
+        /// The email to use for the OpenPGP user id.
         email: String,
     },
-    /// List available GPG keys.
+    /// List available OpenPGP keys.
     List {},
 }
 

--- a/siguldry/src/bin/siguldry-server/import_sigul.rs
+++ b/siguldry/src/bin/siguldry-server/import_sigul.rs
@@ -46,11 +46,11 @@
 //!
 //! ## PGP
 //!
-//! PGP keys are stored in the `gnupg/` directory relative to the state directory root by default,
-//! and is used at the GPG_HOME location. Sigul uses gpg to generate and access the keys so the
-//! layout should follow the standard for the version of gpg installed on the Sigul host.
+//! OpenPGP keys are stored in the `gnupg/` directory relative to the state directory root by default,
+//! and is used at the GPG_HOME location. Sigul uses pgp to generate and access the keys so the
+//! layout should follow the standard for the version of pgp installed on the Sigul host.
 //!
-//! Sigul supports configuring a different location for the PGP keys; this is not supported by the
+//! Sigul supports configuring a different location for the OpenPGP keys; this is not supported by the
 //! import tool and users must move the non-standard location to gnupg/ relative to the provided
 //! state directory.
 //!
@@ -78,7 +78,7 @@
 //! # Key Accesses
 //!
 //! Sigul encrypts keys using a server-generated secret. It then encrypts that secret using
-//! per-user passwords via GPG symmetric encryption. Optionally, it will encrypt the server-
+//! per-user passwords via OpenPGP symmetric encryption. Optionally, it will encrypt the server-
 //! generated secret using a PKCS #11 public key or via TPM 1.2 (unsupported by this tool).
 //! The per-user password is then used to encrypt the output of the "bound" server-generated
 //! secret that was used to encrypt the key.
@@ -133,7 +133,7 @@ impl SigulUser {
 /// Key types supported by sigul.
 #[derive(Debug, Clone, Copy, PartialEq)]
 enum SigulKeyType {
-    /// A GPG key stored in the gnupg home directory.
+    /// A OpenPGP key stored in the gnupg home directory.
     Gnupg,
     /// An ECC key stored as PEM files in the keys/ directory.
     Ecc,
@@ -165,7 +165,7 @@ struct SigulKey {
     id: i64,
     name: String,
     keytype: SigulKeyType,
-    /// For gnupg keys, this is the GPG fingerprint.
+    /// For gnupg keys, this is the OpenPGP fingerprint.
     /// For ECC/RSA keys, this is the SHA1 hash of the public key DER.
     fingerprint: String,
     /// Path to where the keys are store; how they're stored depends on the `keytype`
@@ -174,7 +174,7 @@ struct SigulKey {
     /// the fingerprint then ".pem" for encrypted secret, "public.pem" for public keys, and
     /// "cert.<name>.pem" for certs.
     ///
-    /// For PGP keys, they're stored however gnupg wrote them out (version-dependent).
+    /// For OpenPGP keys, they're stored however gnupg wrote them out (version-dependent).
     keys_directory: PathBuf,
 }
 

--- a/siguldry/src/bin/siguldry-server/management.rs
+++ b/siguldry/src/bin/siguldry-server/management.rs
@@ -22,7 +22,7 @@ use siguldry::server::{
 };
 use tracing::instrument;
 
-use crate::cli::{GpgCommands, KeyCommands, KeyUsage, ManagementCommands, UserCommands};
+use crate::cli::{KeyCommands, KeyUsage, ManagementCommands, PgpCommands, UserCommands};
 
 pub struct PromptPassword {
     termios: Option<Termios>,
@@ -115,8 +115,8 @@ pub async fn manage(command: ManagementCommands, config: Config) -> anyhow::Resu
 
     let mut conn = db_pool.begin().await?;
     match command {
-        ManagementCommands::Gpg(gpg_commands) => match gpg_commands {
-            GpgCommands::Create {
+        ManagementCommands::Pgp(gpg_commands) => match gpg_commands {
+            PgpCommands::Create {
                 algorithm,
                 profile,
                 password_file,
@@ -183,7 +183,7 @@ pub async fn manage(command: ManagementCommands, config: Config) -> anyhow::Resu
 
                 println!("Successfully created key {key} with {user} as the key administrator");
             }
-            GpgCommands::List {} => {
+            PgpCommands::List {} => {
                 for key in db::Key::list(&mut conn).await? {
                     match key.key_purpose {
                         db::KeyPurpose::PGP => println!("{key}"),
@@ -567,7 +567,7 @@ mod tests {
     use tempfile::TempDir;
 
     use crate::cli::{
-        GpgCommands, KeyCommands, KeyUsage, ManagementCommands, OpenPgpProfile, Pkcs11Commands,
+        KeyCommands, KeyUsage, ManagementCommands, OpenPgpProfile, PgpCommands, Pkcs11Commands,
         UserCommands,
     };
 
@@ -1088,7 +1088,7 @@ mod tests {
         std::fs::write(&password_file, "gpg-password\n")?;
 
         manage(
-            ManagementCommands::Gpg(GpgCommands::Create {
+            ManagementCommands::Pgp(PgpCommands::Create {
                 algorithm: KeyAlgorithm::Rsa4K,
                 profile: OpenPgpProfile::RFC4880,
                 password_file: Some(password_file),
@@ -1113,7 +1113,7 @@ mod tests {
         std::fs::write(&password_file, "gpg-password\n")?;
 
         manage(
-            ManagementCommands::Gpg(GpgCommands::Create {
+            ManagementCommands::Pgp(PgpCommands::Create {
                 algorithm: KeyAlgorithm::P256,
                 profile: OpenPgpProfile::RFC4880,
                 password_file: Some(password_file),
@@ -1138,7 +1138,7 @@ mod tests {
         std::fs::write(&password_file, "gpg-password\n")?;
 
         manage(
-            ManagementCommands::Gpg(GpgCommands::Create {
+            ManagementCommands::Pgp(PgpCommands::Create {
                 algorithm: KeyAlgorithm::P256,
                 profile: OpenPgpProfile::RFC9580,
                 password_file: Some(password_file),
@@ -1163,7 +1163,7 @@ mod tests {
         std::fs::write(&password_file, "short\n")?;
 
         let result = manage(
-            ManagementCommands::Gpg(GpgCommands::Create {
+            ManagementCommands::Pgp(PgpCommands::Create {
                 algorithm: KeyAlgorithm::Rsa4K,
                 profile: OpenPgpProfile::RFC4880,
                 password_file: Some(password_file),
@@ -1188,7 +1188,7 @@ mod tests {
         std::fs::write(&password_file, "gpg-password\n")?;
 
         let result = manage(
-            ManagementCommands::Gpg(GpgCommands::Create {
+            ManagementCommands::Pgp(PgpCommands::Create {
                 algorithm: KeyAlgorithm::Rsa4K,
                 profile: OpenPgpProfile::RFC4880,
                 password_file: Some(password_file),
@@ -1352,7 +1352,7 @@ mod tests {
                 admin: "admin".to_string(),
                 name: "test-rsa-key".to_string(),
             }),
-            ManagementCommands::Gpg(GpgCommands::Create {
+            ManagementCommands::Pgp(PgpCommands::Create {
                 algorithm: KeyAlgorithm::Rsa4K,
                 profile: OpenPgpProfile::RFC4880,
                 password_file: Some("/path/does/not/exist".into()),
@@ -1399,7 +1399,7 @@ mod tests {
                 admin: "admin".to_string(),
                 name: "test-rsa-key".to_string(),
             }),
-            ManagementCommands::Gpg(GpgCommands::Create {
+            ManagementCommands::Pgp(PgpCommands::Create {
                 profile: OpenPgpProfile::RFC4880,
                 algorithm: KeyAlgorithm::Rsa4K,
                 password_file: Some("/path/does/not/exist".into()),
@@ -1450,7 +1450,7 @@ mod tests {
                 admin: "admin".to_string(),
                 name: "test-rsa-key".to_string(),
             }),
-            ManagementCommands::Gpg(GpgCommands::Create {
+            ManagementCommands::Pgp(PgpCommands::Create {
                 algorithm: KeyAlgorithm::Rsa4K,
                 profile: OpenPgpProfile::RFC4880,
                 password_file: Some(password_file),

--- a/siguldry/src/client/mod.rs
+++ b/siguldry/src/client/mod.rs
@@ -10,7 +10,7 @@ use bytes::Bytes;
 use tokio::sync::Mutex;
 
 use crate::protocol::json::Signature;
-use crate::protocol::{DigestAlgorithm, GpgSignatureType};
+use crate::protocol::{DigestAlgorithm, PgpSignatureType};
 use crate::{
     error::{ClientError, ConnectionError},
     nestls::Nestls,
@@ -319,11 +319,11 @@ impl Client {
     pub async fn gpg_sign(
         &self,
         key: String,
-        signature_type: GpgSignatureType,
+        signature_type: PgpSignatureType,
         data: Bytes,
     ) -> Result<Bytes, ClientError> {
         let request = Request {
-            message: protocol::json::Request::GpgSign {
+            message: protocol::json::Request::PgpSign {
                 key,
                 signature_type,
             },

--- a/siguldry/src/ipc_common.rs
+++ b/siguldry/src/ipc_common.rs
@@ -36,7 +36,7 @@ impl IpcClient {
     ///
     /// The bytes argument exists just because Sequioa doesn't support signing from a digest
     /// (easily, anyway). Don't use it for anything else, and delete it if signing via PKCS#11
-    /// for PGP is good enough.
+    /// for OpenPGP is good enough.
     #[instrument(skip_all, level = Level::DEBUG)]
     pub async fn request<R: ?Sized + serde::Serialize>(
         &mut self,
@@ -69,7 +69,7 @@ impl IpcClient {
         response
     }
 
-    /// Only use this for PGP signing to read the payload back after the response.
+    /// Only use this for OpenPGP signing to read the payload back after the response.
     ///
     /// Delete this if we can use PKCS#11 client-side for all signing.
     #[instrument(skip(self), level = Level::DEBUG)]

--- a/siguldry/src/protocol.rs
+++ b/siguldry/src/protocol.rs
@@ -385,14 +385,14 @@ pub mod json {
             /// The password to unlock the key with.
             password: String,
         },
-        /// Request a GPG signature.
+        /// Request a OpenPGP signature.
         ///
         /// The content to be signed should be sent in the binary section of the request.
-        GpgSign {
-            /// The key to use for signing. The request will fail if this is not a GPG key.
+        PgpSign {
+            /// The key to use for signing. The request will fail if this is not a OpenPGP key.
             key: String,
             /// The format of the signature to produce.
-            signature_type: super::GpgSignatureType,
+            signature_type: super::PgpSignatureType,
         },
         /// Request an RSA or ECDSA signature.
         ///
@@ -546,8 +546,8 @@ pub mod json {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[non_exhaustive]
 pub enum Certificate {
-    /// A key pair that can be used for GPG signatures.
-    Gpg {
+    /// A key pair that can be used for OpenPGP signatures.
+    Pgp {
         /// The key version; likely either 4 or 6, but refer to RFC 9580 and any superceding RFCs.
         version: u8,
         /// The ASCII-armored public key
@@ -572,7 +572,7 @@ pub struct Key {
     pub name: String,
     /// Indicates the key type.
     pub key_algorithm: KeyAlgorithm,
-    /// This uniquely identifies a key. For example, the GPG key fingerprint, or the SHA256 sum of
+    /// This uniquely identifies a key. For example, the OpenPGP key fingerprint, or the SHA256 sum of
     /// the public key.
     pub handle: String,
     /// The public key in a text-friendly encoding (ASCII-armored, PEM-encoded, etc).
@@ -582,7 +582,7 @@ pub struct Key {
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[non_exhaustive]
-pub enum GpgSignatureType {
+pub enum PgpSignatureType {
     /// Create a detached signature as described in [Section 10.4 of RFC 9580].
     ///
     /// Detached signatures are one or more Signature packets stored separately from the

--- a/siguldry/src/server/crypto/binding.rs
+++ b/siguldry/src/server/crypto/binding.rs
@@ -333,7 +333,7 @@ pub mod sigul {
         token: String,
     }
 
-    // Shell out to gpg to decrypt the key password.
+    // Shell out to pgp to decrypt the key password.
     //
     // This is done rather than use Sequioa because the OpenPGP data structure written by
     // sigul is considered malformed to Sequoia.
@@ -351,12 +351,12 @@ pub mod sigul {
             .stdout(Stdio::piped())
             .stderr(Stdio::piped())
             .spawn()
-            .context("Failed to spawn gpg process")?;
+            .context("Failed to spawn pgp process")?;
 
         let mut stdin = child
             .stdin
             .take()
-            .ok_or_else(|| anyhow::anyhow!("Failed to open gpg stdin"))?;
+            .ok_or_else(|| anyhow::anyhow!("Failed to open pgp stdin"))?;
         password.map(|p| {
             stdin.write_all(p)?;
             stdin.write_all(b"\n")?;
@@ -366,7 +366,7 @@ pub mod sigul {
 
         let output = child
             .wait_with_output()
-            .context("Failed to wait for gpg process")?;
+            .context("Failed to wait for pgp process")?;
 
         if !output.status.success() {
             let stderr = String::from_utf8_lossy(&output.stderr);

--- a/siguldry/src/server/crypto/mod.rs
+++ b/siguldry/src/server/crypto/mod.rs
@@ -3,7 +3,7 @@
 
 //! All the cryptography-related operations are in these modules.
 //!
-//! Sequoia is used for GPG signatures and for the symmetric encryption of keys managed by Siguldry.
+//! Sequoia is used for OpenPGP signatures and for the symmetric encryption of keys managed by Siguldry.
 //! OpenSSL is used for other signatures.
 
 use openssl::{
@@ -70,7 +70,7 @@ pub fn create_encrypted_key(
     Ok((handle, encrypted_password, private_key_pem, public_key_pem))
 }
 
-/// A GPG key.
+/// A OpenPGP key.
 #[derive(Debug, Clone, PartialEq)]
 pub struct GpgKey {
     cert: sequoia_openpgp::Cert,
@@ -78,7 +78,7 @@ pub struct GpgKey {
 }
 
 impl GpgKey {
-    /// Create a new GPG key bound to the server.
+    /// Create a new OpenPGP key bound to the server.
     pub fn new<U: Into<packet::UserID>>(
         bindings: &[Pkcs11Binding],
         user_id: U,
@@ -118,7 +118,7 @@ impl GpgKey {
         )?)
     }
 
-    /// Get the hex GPG fingerprint.
+    /// Get the hex OpenPGP fingerprint.
     pub fn fingerprint(&self) -> String {
         self.cert.fingerprint().to_hex()
     }
@@ -158,7 +158,7 @@ pub mod sigul {
         key_password: Password,
     ) -> anyhow::Result<(sequoia_openpgp::Cert, KeyAlgorithm)> {
         let cert = sequoia_openpgp::Cert::from_bytes(bytes)
-            .context("Failed to parse the exported GPG secret key with Sequoia")?;
+            .context("Failed to parse the exported OpenPGP secret key with Sequoia")?;
 
         // Check that there's a secret key we can decrypt that's marked for signing to ensure
         // we've unbound the key properly. We may need to tweak this policy if we import very

--- a/siguldry/src/server/crypto/signing.rs
+++ b/siguldry/src/server/crypto/signing.rs
@@ -750,7 +750,7 @@ mod tests {
         let ecdsa_sig = openssl::ecdsa::EcdsaSig::from_der(signature)?;
         assert!(
             ecdsa_sig.verify(&digest, &ec_key)?,
-            "EC PGP signature should be valid (OpenSSL bindings)"
+            "EC OpenPGP signature should be valid (OpenSSL bindings)"
         );
 
         // Also verify using the OpenSSL CLI

--- a/siguldry/src/server/db.rs
+++ b/siguldry/src/server/db.rs
@@ -104,7 +104,7 @@ impl User {
 #[allow(clippy::exhaustive_enums)]
 #[doc(hidden)]
 pub enum KeyPurpose {
-    /// The key is meant to be used for PGP signatures
+    /// The key is meant to be used for OpenPGP signatures
     PGP,
     /// The key is intended to be used for signing using its algorithm-specific signing scheme.
     Signing,
@@ -345,7 +345,7 @@ pub struct Key {
     /// The key location indicates where the key is stored. Keys may be stored on the filesystem
     /// or in a hardware security module.
     pub key_purpose: KeyPurpose,
-    /// This uniquely identifies a key. For example, the GPG key fingerprint, or the SHA256 sum of
+    /// This uniquely identifies a key. For example, the OpenPGP key fingerprint, or the SHA256 sum of
     /// the public key.
     pub handle: String,
     /// The encrypted key material, or in the case of keys stored in hardware, information on how

--- a/siguldry/src/server/handlers.rs
+++ b/siguldry/src/server/handlers.rs
@@ -11,7 +11,7 @@ use tracing::instrument;
 use uuid::Uuid;
 
 use crate::{
-    protocol::{self, DigestAlgorithm, GpgSignatureType, Response, ServerError, json},
+    protocol::{self, DigestAlgorithm, PgpSignatureType, Response, ServerError, json},
     server::{
         Config,
         db::{self, KeyPurpose, User},
@@ -69,7 +69,7 @@ impl Handler {
                 let cert = sequoia_openpgp::Cert::from_bytes(&key.key_material.as_bytes())?;
                 let version = cert.primary_key().key().version();
                 let fingerprint = cert.fingerprint().to_hex();
-                vec![crate::protocol::Certificate::Gpg {
+                vec![crate::protocol::Certificate::Pgp {
                     version,
                     fingerprint,
                     certificate: key.public_key.clone(),
@@ -109,7 +109,7 @@ impl Handler {
     pub(crate) async fn pgp_sign(
         &mut self,
         key: String,
-        signature_type: GpgSignatureType,
+        signature_type: PgpSignatureType,
         blob: Bytes,
     ) -> Result<Response, ServerError> {
         self.ipc_helper
@@ -129,7 +129,7 @@ impl Handler {
             let cert = sequoia_openpgp::Cert::from_bytes(&key.key_material.as_bytes())?;
             let version = cert.primary_key().key().version();
             let fingerprint = cert.fingerprint().to_hex();
-            vec![crate::protocol::Certificate::Gpg {
+            vec![crate::protocol::Certificate::Pgp {
                 version,
                 fingerprint,
                 certificate: key.public_key.clone(),

--- a/siguldry/src/server/ipc.rs
+++ b/siguldry/src/server/ipc.rs
@@ -27,7 +27,7 @@ use uuid::Uuid;
 
 use crate::error::ServerError;
 use crate::ipc_common::IpcClient;
-use crate::protocol::{self, GpgSignatureType};
+use crate::protocol::{self, PgpSignatureType};
 use crate::server::config::Pkcs11Binding;
 use crate::{
     protocol::{DigestAlgorithm, json::Signature},
@@ -91,7 +91,7 @@ enum Request {
     },
     PgpSign {
         key: String,
-        signature_type: GpgSignatureType,
+        signature_type: PgpSignatureType,
         payload_size: usize,
     },
 }
@@ -214,7 +214,7 @@ impl Client {
     pub(crate) async fn pgp_sign_request(
         &mut self,
         key: String,
-        signature_type: GpgSignatureType,
+        signature_type: PgpSignatureType,
         blob: Bytes,
     ) -> anyhow::Result<protocol::Response> {
         let payload_size = blob.len();
@@ -517,7 +517,7 @@ async fn pgp_sign(
     conn: &mut SqliteConnection,
     keystore: &HashMap<String, UnlockedKey>,
     key_name: &str,
-    signature_type: GpgSignatureType,
+    signature_type: PgpSignatureType,
     blob: Vec<u8>,
 ) -> anyhow::Result<(Response, Vec<u8>)> {
     let key = db::Key::get(conn, key_name).await?;
@@ -554,9 +554,9 @@ async fn pgp_sign(
         let mut sink = vec![];
         let signer = PgpSigner::new(Message::new(&mut sink), signing_key)?;
         let mut message = match signature_type {
-            GpgSignatureType::Detached => signer.detached().build()?,
-            GpgSignatureType::Cleartext => signer.cleartext().build()?,
-            GpgSignatureType::Inline => LiteralWriter::new(signer.build()?).build()?,
+            PgpSignatureType::Detached => signer.detached().build()?,
+            PgpSignatureType::Cleartext => signer.cleartext().build()?,
+            PgpSignatureType::Inline => LiteralWriter::new(signer.build()?).build()?,
         };
 
         message.write_all(&blob)?;

--- a/siguldry/src/server/service.rs
+++ b/siguldry/src/server/service.rs
@@ -271,7 +271,7 @@ async fn handle(
             Request::ListUsers {} => request_handler.list_users(&mut db_transaction).await,
             Request::ListKeys {} => request_handler.list_keys(&mut db_transaction).await,
             Request::Unlock { key, password } => request_handler.unlock(key, password).await,
-            Request::GpgSign {
+            Request::PgpSign {
                 key,
                 signature_type,
             } => {

--- a/siguldry/src/v1/client.rs
+++ b/siguldry/src/v1/client.rs
@@ -86,13 +86,13 @@ pub enum KeyType {
     ///
     /// Server configuration determines the key size and algorithm used when creating a new key.
     GnuPG {
-        /// The real name field to use on the GPG key, if any.
+        /// The real name field to use on the OpenPGP key, if any.
         real_name: Option<String>,
-        /// The comment field to use on the GPG key, if any.
+        /// The comment field to use on the OpenPGP key, if any.
         comment: Option<String>,
-        /// The email address for the GPG key, if any.
+        /// The email address for the OpenPGP key, if any.
         email: Option<String>,
-        /// The expiration date for the GPG key. If [`Option::None`], the key does not expire.
+        /// The expiration date for the OpenPGP key. If [`Option::None`], the key does not expire.
         expire_date: Option<String>,
     },
     /// The Elliptic Curve Cryptography key type.

--- a/siguldry/tests/client_v1.rs
+++ b/siguldry/tests/client_v1.rs
@@ -620,7 +620,7 @@ async fn key_modify() -> anyhow::Result<()> {
     Ok(())
 }
 
-/// Test creating and then deleting a GPG key.
+/// Test creating and then deleting a OpenPGP key.
 #[tokio::test]
 async fn key_gpg_create_and_delete() -> anyhow::Result<()> {
     let client = get_client();
@@ -657,7 +657,7 @@ async fn key_gpg_create_and_delete() -> anyhow::Result<()> {
     Ok(())
 }
 
-/// Test creating a GPG key with an expiration date.
+/// Test creating a OpenPGP key with an expiration date.
 ///
 /// The date needs to be in the future so in a few years this test will fail.
 #[tokio::test]
@@ -1063,7 +1063,7 @@ pub async fn key_revoke_user() -> anyhow::Result<()> {
     Ok(())
 }
 
-/// Test key expiration for GPG keys can be altered.
+/// Test key expiration for OpenPGP keys can be altered.
 ///
 /// The test requires dates in the future, so it will fail if run after the expiration date.
 #[tokio::test]

--- a/siguldry/tests/end_to_end.rs
+++ b/siguldry/tests/end_to_end.rs
@@ -6,7 +6,7 @@
 use siguldry::{
     client::{self, ProxyClient},
     error::{ClientError, ConnectionError, ProtocolError, ServerError},
-    protocol::{DigestAlgorithm, GpgSignatureType, KeyAlgorithm},
+    protocol::{DigestAlgorithm, KeyAlgorithm, PgpSignatureType},
 };
 
 use siguldry_test::{InstanceBuilder, create_credentials, keys};
@@ -123,13 +123,13 @@ async fn bridge_rejects_client_cert_empty_common_name() -> anyhow::Result<()> {
 #[tokio::test]
 #[tracing_test::traced_test]
 async fn unlock_gpg_key() -> anyhow::Result<()> {
-    let instance = InstanceBuilder::new().with_gpg_key().build().await?;
+    let instance = InstanceBuilder::new().with_pgp_key().build().await?;
 
     instance
         .client
         .unlock(
-            keys::GPG_KEY_NAME.to_string(),
-            keys::GPG_KEY_PASSWORD.to_string(),
+            keys::PGP_KEY_NAME.to_string(),
+            keys::PGP_KEY_PASSWORD.to_string(),
         )
         .await?;
 
@@ -141,7 +141,7 @@ async fn unlock_gpg_key() -> anyhow::Result<()> {
 #[tracing_test::traced_test]
 async fn client_proxy_unlock_gpg_key() -> anyhow::Result<()> {
     let instance = InstanceBuilder::new()
-        .with_gpg_key()
+        .with_pgp_key()
         .with_client_proxy()
         .build()
         .await?;
@@ -149,8 +149,8 @@ async fn client_proxy_unlock_gpg_key() -> anyhow::Result<()> {
 
     tokio::task::spawn_blocking(move || {
         client_proxy.unlock(
-            keys::GPG_KEY_NAME.to_string(),
-            keys::GPG_KEY_PASSWORD.to_string(),
+            keys::PGP_KEY_NAME.to_string(),
+            keys::PGP_KEY_PASSWORD.to_string(),
         )
     })
     .await??;
@@ -162,11 +162,11 @@ async fn client_proxy_unlock_gpg_key() -> anyhow::Result<()> {
 #[tokio::test]
 #[tracing_test::traced_test]
 async fn wrong_gpg_password() -> anyhow::Result<()> {
-    let instance = InstanceBuilder::new().with_gpg_key().build().await?;
+    let instance = InstanceBuilder::new().with_pgp_key().build().await?;
 
     let result = instance
         .client
-        .unlock(keys::GPG_KEY_NAME.to_string(), "🪿🪿🦆".to_string())
+        .unlock(keys::PGP_KEY_NAME.to_string(), "🪿🪿🦆".to_string())
         .await;
     // TODO: split out server-side errors from client request errors
     assert!(result.is_err_and(|err| matches!(err, ClientError::Server(ServerError::Internal))));
@@ -201,7 +201,7 @@ async fn list_keys() -> anyhow::Result<()> {
     let instance = InstanceBuilder::new().with_all_keys().build().await?;
 
     let keys = instance.client.list_keys().await?;
-    // GPG key + CA key + codesigning key + EC key
+    // OpenPGP key + CA key + codesigning key + EC key
     assert_eq!(4, keys.len());
 
     instance.halt().await?;
@@ -220,7 +220,7 @@ async fn client_proxy_list_keys() -> anyhow::Result<()> {
     let mut client_proxy = ProxyClient::new(instance.client_proxy_socket())?;
 
     let keys = tokio::task::spawn_blocking(move || client_proxy.list_keys()).await??;
-    // GPG key + CA key + codesigning key + EC key
+    // OpenPGP key + CA key + codesigning key + EC key
     assert_eq!(4, keys.len());
 
     instance.halt().await?;
@@ -230,33 +230,33 @@ async fn client_proxy_list_keys() -> anyhow::Result<()> {
 #[tokio::test]
 #[tracing_test::traced_test]
 async fn gpg_sign_inline() -> anyhow::Result<()> {
-    let instance = InstanceBuilder::new().with_gpg_key().build().await?;
+    let instance = InstanceBuilder::new().with_pgp_key().build().await?;
     let data = "🦡🦡🦡🦡🍄🍄".as_bytes();
 
     instance
         .client
         .unlock(
-            keys::GPG_KEY_NAME.to_string(),
-            keys::GPG_KEY_PASSWORD.to_string(),
+            keys::PGP_KEY_NAME.to_string(),
+            keys::PGP_KEY_PASSWORD.to_string(),
         )
         .await?;
     let mut key = instance
         .client
-        .get_key(keys::GPG_KEY_NAME.to_string())
+        .get_key(keys::PGP_KEY_NAME.to_string())
         .await?;
     assert_eq!(1, key.certificates.len());
     let certificate = key.certificates.pop().unwrap();
     let signature = instance
         .client
         .gpg_sign(
-            keys::GPG_KEY_NAME.to_string(),
-            GpgSignatureType::Inline,
+            keys::PGP_KEY_NAME.to_string(),
+            PgpSignatureType::Inline,
             bytes::Bytes::from(data),
         )
         .await?;
 
     match certificate {
-        siguldry::protocol::Certificate::Gpg {
+        siguldry::protocol::Certificate::Pgp {
             version: _version,
             certificate,
             fingerprint,
@@ -281,8 +281,8 @@ async fn gpg_sign_inline() -> anyhow::Result<()> {
             assert!(stderr.contains(&format!(
                 "Authenticated signature made by {} ({} <{}>)",
                 fingerprint,
-                keys::GPG_KEY_NAME,
-                keys::GPG_KEY_EMAIL
+                keys::PGP_KEY_NAME,
+                keys::PGP_KEY_EMAIL
             )));
         }
         _ => panic!("unexpected key type"),
@@ -295,19 +295,19 @@ async fn gpg_sign_inline() -> anyhow::Result<()> {
 #[tokio::test]
 #[tracing_test::traced_test]
 async fn gpg_sign_detached() -> anyhow::Result<()> {
-    let instance = InstanceBuilder::new().with_gpg_key().build().await?;
+    let instance = InstanceBuilder::new().with_pgp_key().build().await?;
     let data = "🦡🦡🦡🦡🍄🍄".as_bytes();
 
     instance
         .client
         .unlock(
-            keys::GPG_KEY_NAME.to_string(),
-            keys::GPG_KEY_PASSWORD.to_string(),
+            keys::PGP_KEY_NAME.to_string(),
+            keys::PGP_KEY_PASSWORD.to_string(),
         )
         .await?;
     let mut key = instance
         .client
-        .get_key(keys::GPG_KEY_NAME.to_string())
+        .get_key(keys::PGP_KEY_NAME.to_string())
         .await?;
     assert!(
         matches!(key.key_algorithm, KeyAlgorithm::Rsa4K),
@@ -319,14 +319,14 @@ async fn gpg_sign_detached() -> anyhow::Result<()> {
     let signature = instance
         .client
         .gpg_sign(
-            keys::GPG_KEY_NAME.to_string(),
-            GpgSignatureType::Detached,
+            keys::PGP_KEY_NAME.to_string(),
+            PgpSignatureType::Detached,
             bytes::Bytes::from(data),
         )
         .await?;
 
     match certificate {
-        siguldry::protocol::Certificate::Gpg {
+        siguldry::protocol::Certificate::Pgp {
             version: _version,
             certificate,
             fingerprint,
@@ -353,8 +353,8 @@ async fn gpg_sign_detached() -> anyhow::Result<()> {
             assert!(stderr.contains(&format!(
                 "Authenticated signature made by {} ({} <{}>)",
                 fingerprint,
-                keys::GPG_KEY_NAME,
-                keys::GPG_KEY_EMAIL
+                keys::PGP_KEY_NAME,
+                keys::PGP_KEY_EMAIL
             )));
         }
         _ => panic!("unexpected key type"),
@@ -368,8 +368,8 @@ async fn gpg_sign_detached() -> anyhow::Result<()> {
 #[tracing_test::traced_test]
 async fn gpg_sign_detached_rfc9580() -> anyhow::Result<()> {
     let instance = InstanceBuilder::new()
-        .use_rfc9580_for_gpg()
-        .with_gpg_ec_key()
+        .use_rfc9580_for_pgp()
+        .with_pgp_ec_key()
         .build()
         .await?;
     let data = "🦡🦡🦡🦡🍄🍄".as_bytes();
@@ -377,13 +377,13 @@ async fn gpg_sign_detached_rfc9580() -> anyhow::Result<()> {
     instance
         .client
         .unlock(
-            keys::GPG_EC_KEY_NAME.to_string(),
-            keys::GPG_EC_KEY_PASSWORD.to_string(),
+            keys::PGP_EC_KEY_NAME.to_string(),
+            keys::PGP_EC_KEY_PASSWORD.to_string(),
         )
         .await?;
     let mut key = instance
         .client
-        .get_key(keys::GPG_EC_KEY_NAME.to_string())
+        .get_key(keys::PGP_EC_KEY_NAME.to_string())
         .await?;
     assert!(
         matches!(key.key_algorithm, KeyAlgorithm::P256),
@@ -395,14 +395,14 @@ async fn gpg_sign_detached_rfc9580() -> anyhow::Result<()> {
     let signature = instance
         .client
         .gpg_sign(
-            keys::GPG_EC_KEY_NAME.to_string(),
-            GpgSignatureType::Detached,
+            keys::PGP_EC_KEY_NAME.to_string(),
+            PgpSignatureType::Detached,
             bytes::Bytes::from(data),
         )
         .await?;
 
     match certificate {
-        siguldry::protocol::Certificate::Gpg {
+        siguldry::protocol::Certificate::Pgp {
             version,
             certificate,
             fingerprint,
@@ -430,8 +430,8 @@ async fn gpg_sign_detached_rfc9580() -> anyhow::Result<()> {
             assert!(stderr.contains(&format!(
                 "Authenticated signature made by {} ({} <{}>)",
                 fingerprint,
-                keys::GPG_EC_KEY_NAME,
-                keys::GPG_EC_KEY_EMAIL
+                keys::PGP_EC_KEY_NAME,
+                keys::PGP_EC_KEY_EMAIL
             )));
             let mut command = tokio::process::Command::new("sq");
             let output = command.arg("inspect").arg(keyring_path).output().await?;
@@ -450,19 +450,19 @@ async fn gpg_sign_detached_rfc9580() -> anyhow::Result<()> {
 #[tokio::test]
 #[tracing_test::traced_test]
 async fn gpg_sign_detached_p256() -> anyhow::Result<()> {
-    let instance = InstanceBuilder::new().with_gpg_ec_key().build().await?;
+    let instance = InstanceBuilder::new().with_pgp_ec_key().build().await?;
     let data = "🦡🦡🦡🦡🍄🍄".as_bytes();
 
     instance
         .client
         .unlock(
-            keys::GPG_EC_KEY_NAME.to_string(),
-            keys::GPG_EC_KEY_PASSWORD.to_string(),
+            keys::PGP_EC_KEY_NAME.to_string(),
+            keys::PGP_EC_KEY_PASSWORD.to_string(),
         )
         .await?;
     let mut key = instance
         .client
-        .get_key(keys::GPG_EC_KEY_NAME.to_string())
+        .get_key(keys::PGP_EC_KEY_NAME.to_string())
         .await?;
     assert!(
         matches!(key.key_algorithm, KeyAlgorithm::P256),
@@ -474,14 +474,14 @@ async fn gpg_sign_detached_p256() -> anyhow::Result<()> {
     let signature = instance
         .client
         .gpg_sign(
-            keys::GPG_EC_KEY_NAME.to_string(),
-            GpgSignatureType::Detached,
+            keys::PGP_EC_KEY_NAME.to_string(),
+            PgpSignatureType::Detached,
             bytes::Bytes::from(data),
         )
         .await?;
 
     match certificate {
-        siguldry::protocol::Certificate::Gpg {
+        siguldry::protocol::Certificate::Pgp {
             version,
             certificate,
             fingerprint,
@@ -509,8 +509,8 @@ async fn gpg_sign_detached_p256() -> anyhow::Result<()> {
             assert!(stderr.contains(&format!(
                 "Authenticated signature made by {} ({} <{}>)",
                 fingerprint,
-                keys::GPG_EC_KEY_NAME,
-                keys::GPG_EC_KEY_EMAIL
+                keys::PGP_EC_KEY_NAME,
+                keys::PGP_EC_KEY_EMAIL
             )));
             let mut command = tokio::process::Command::new("sq");
             let output = command.arg("inspect").arg(keyring_path).output().await?;
@@ -529,19 +529,19 @@ async fn gpg_sign_detached_p256() -> anyhow::Result<()> {
 #[tokio::test]
 #[tracing_test::traced_test]
 async fn gpg_sign_cleartext() -> anyhow::Result<()> {
-    let instance = InstanceBuilder::new().with_gpg_key().build().await?;
+    let instance = InstanceBuilder::new().with_pgp_key().build().await?;
     let data = "🦡🦡🦡🦡🍄🍄".as_bytes();
 
     instance
         .client
         .unlock(
-            keys::GPG_KEY_NAME.to_string(),
-            keys::GPG_KEY_PASSWORD.to_string(),
+            keys::PGP_KEY_NAME.to_string(),
+            keys::PGP_KEY_PASSWORD.to_string(),
         )
         .await?;
     let mut key = instance
         .client
-        .get_key(keys::GPG_KEY_NAME.to_string())
+        .get_key(keys::PGP_KEY_NAME.to_string())
         .await?;
     assert_eq!(1, key.certificates.len());
     let key = key.certificates.pop().unwrap();
@@ -549,8 +549,8 @@ async fn gpg_sign_cleartext() -> anyhow::Result<()> {
     let signature = instance
         .client
         .gpg_sign(
-            keys::GPG_KEY_NAME.to_string(),
-            GpgSignatureType::Cleartext,
+            keys::PGP_KEY_NAME.to_string(),
+            PgpSignatureType::Cleartext,
             bytes::Bytes::from(data),
         )
         .await?;
@@ -564,7 +564,7 @@ Hash: SHA512
     ));
 
     match key {
-        siguldry::protocol::Certificate::Gpg {
+        siguldry::protocol::Certificate::Pgp {
             version: _version,
             certificate,
             fingerprint,
@@ -589,8 +589,8 @@ Hash: SHA512
             assert!(stderr.contains(&format!(
                 "Authenticated signature made by {} ({} <{}>)",
                 fingerprint,
-                keys::GPG_KEY_NAME,
-                keys::GPG_KEY_EMAIL
+                keys::PGP_KEY_NAME,
+                keys::PGP_KEY_EMAIL
             )));
         }
         _ => panic!("unexpected key type"),
@@ -1103,7 +1103,7 @@ async fn hsm_rsa_prehashed_signature_with_pkcs11_binding() -> anyhow::Result<()>
     Ok(())
 }
 
-/// Import data from a sigul database and verify PGP signing works with the imported key.
+/// Import data from a sigul database and verify OpenPGP signing works with the imported key.
 ///
 /// This test requires you to run `cargo xtask generate-sigul-data` and have softhsm2
 #[tokio::test]
@@ -1137,12 +1137,12 @@ async fn import_sigul_and_sign() -> anyhow::Result<()> {
         .client
         .gpg_sign(
             keys::SIGUL_GPG_KEY_NAME.to_string(),
-            GpgSignatureType::Detached,
+            PgpSignatureType::Detached,
             bytes::Bytes::from(data),
         )
         .await?;
     match certificate {
-        siguldry::protocol::Certificate::Gpg {
+        siguldry::protocol::Certificate::Pgp {
             version: _version,
             certificate,
             fingerprint,
@@ -1176,7 +1176,7 @@ async fn import_sigul_and_sign() -> anyhow::Result<()> {
                 "Signature should be from the imported key"
             );
         }
-        _ => panic!("Expected a GPG certificate from the imported key"),
+        _ => panic!("Expected a OpenPGP certificate from the imported key"),
     }
 
     instance.halt().await?;
@@ -1210,7 +1210,7 @@ async fn import_sigul_just_a_user() -> anyhow::Result<()> {
     Ok(())
 }
 
-/// Import a subset of data from a sigul database and verify PGP signing works.
+/// Import a subset of data from a sigul database and verify OpenPGP signing works.
 ///
 /// This test requires you to run `cargo xtask generate-sigul-data` and have softhsm2
 #[tokio::test]
@@ -1253,12 +1253,12 @@ async fn import_sigul_just_gpg_key() -> anyhow::Result<()> {
         .client
         .gpg_sign(
             keys::SIGUL_GPG_KEY_NAME.to_string(),
-            GpgSignatureType::Detached,
+            PgpSignatureType::Detached,
             bytes::Bytes::from(data),
         )
         .await?;
     match certificate {
-        siguldry::protocol::Certificate::Gpg {
+        siguldry::protocol::Certificate::Pgp {
             version: _version,
             certificate,
             fingerprint,
@@ -1292,7 +1292,7 @@ async fn import_sigul_just_gpg_key() -> anyhow::Result<()> {
                 "Signature should be from the imported key"
             );
         }
-        _ => panic!("Expected a GPG certificate from the imported key"),
+        _ => panic!("Expected a OpenPGP certificate from the imported key"),
     }
 
     instance.halt().await?;

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -169,14 +169,14 @@ async fn generate_sigul_data() -> anyhow::Result<()> {
         )
         .await?;
 
-    println!("Creating GPG key 'test-sigul-gpg-key'...");
+    println!("Creating OpenPGP key 'test-sigul-gpg-key'...");
     client
         .new_key(
             ADMIN_PASSPHRASE.into(),
             GPG_PASSPHRASE.into(),
             "test-sigul-gpg-key".to_string(),
             KeyType::GnuPG {
-                real_name: Some("Test GPG Key".to_string()),
+                real_name: Some("Test OpenPGP Key".to_string()),
                 comment: Some("For testing import".to_string()),
                 email: Some("test@example.com".to_string()),
                 expire_date: None,
@@ -293,14 +293,14 @@ async fn generate_sigul_data() -> anyhow::Result<()> {
     //
     // The expected prompts here are
     //   - import sigul-client
-    //     - import its access to the GPG key?
+    //     - import its access to the OpenPGP key?
     //     - import its access to the CA key?
     //     - import its access to the RSA key?
     //     - import its access to the ECC key?
     //   - import autosigner
     //     - import its access to the RSA key?
     //   - import siguldry-client
-    //     - import its access to the GPG key?
+    //     - import its access to the OpenPGP key?
     let import_dialog_answer = format!(
         "y\n\
          y\n\


### PR DESCRIPTION
There's a mixture of GPG and OpenPGP references in the code. Since we're using Sequoia and it's doing OpenPGP, lets be consistent across the code base with the references.