### PR TITLE
siguldry: drop the ListUsers command

### DIFF
--- a/siguldry/src/bin/siguldry-client/main.rs
+++ b/siguldry/src/bin/siguldry-client/main.rs
@@ -80,8 +80,6 @@ struct Cli {
 enum Command {
     /// Attempt to authenticate with the server and print the username of the authenticated user.
     Whoami,
-    /// List the users on the server.
-    ListUsers,
     /// See the current configuration, or the defaults if no configuration file is supplied.
     Config,
     /// Proxy commands from a local process to the server.
@@ -145,11 +143,6 @@ async fn main() -> anyhow::Result<()> {
         Command::Whoami => {
             let user = client.who_am_i().await?;
             println!("Hello, {user}, you can successfully authenticate with the server!");
-        }
-        Command::ListUsers => {
-            let users = client.list_users().await?;
-            let users = users.join("\n");
-            println!("{users}");
         }
         Command::Config => unreachable!("Command handled prior to this match"),
         Command::Proxy { socket } => {

--- a/siguldry/src/client/mod.rs
+++ b/siguldry/src/client/mod.rs
@@ -221,17 +221,6 @@ impl Client {
         }
     }
 
-    pub async fn list_users(&self) -> Result<Vec<String>, ClientError> {
-        let request = protocol::Request::ListUsers {};
-
-        let response = self.reconnecting_send(request).await?;
-        match response {
-            Response::ListUsers { users } => Ok(users),
-            Response::Error { reason } => Err(reason.into()),
-            _other => Err(anyhow::anyhow!("Unexpected response from server").into()),
-        }
-    }
-
     /// List keys that are accessible to the authenticated user.
     pub async fn list_keys(&self) -> Result<Vec<protocol::Key>, ClientError> {
         let request = protocol::Request::ListKeys {};

--- a/siguldry/src/protocol.rs
+++ b/siguldry/src/protocol.rs
@@ -364,7 +364,6 @@ pub(crate) struct OuterResponse {
 #[non_exhaustive]
 pub enum Request {
     WhoAmI {},
-    ListUsers {},
     /// List keys on the server which the current user has access to.
     ListKeys {},
     /// Unlock a key for signing.
@@ -409,9 +408,6 @@ pub enum Request {
 pub enum Response {
     WhoAmI {
         user: String,
-    },
-    ListUsers {
-        users: Vec<String>,
     },
     ListKeys {
         keys: Vec<Key>,

--- a/siguldry/src/server/handlers.rs
+++ b/siguldry/src/server/handlers.rs
@@ -42,20 +42,6 @@ impl Handler {
     }
 
     #[instrument(skip_all, err)]
-    pub(crate) async fn list_users(
-        &self,
-        conn: &mut SqliteConnection,
-    ) -> Result<Response, ServerError> {
-        let users = User::list(conn)
-            .await?
-            .into_iter()
-            .map(|user| user.name)
-            .collect();
-
-        Ok(Response::ListUsers { users })
-    }
-
-    #[instrument(skip_all, err)]
     pub(crate) async fn list_keys(
         &self,
         conn: &mut SqliteConnection,

--- a/siguldry/src/server/service.rs
+++ b/siguldry/src/server/service.rs
@@ -252,7 +252,6 @@ async fn handle(
         let mut db_transaction = db.begin().await?;
         let response = match outer_request.request {
             Request::WhoAmI {} => request_handler.who_am_i(),
-            Request::ListUsers {} => request_handler.list_users(&mut db_transaction).await,
             Request::ListKeys {} => request_handler.list_keys(&mut db_transaction, &user).await,
             Request::Unlock { key, password } => request_handler.unlock(key, password).await,
             Request::Sign {

--- a/siguldry/tests/end_to_end.rs
+++ b/siguldry/tests/end_to_end.rs
@@ -755,8 +755,8 @@ async fn import_sigul_just_a_user() -> anyhow::Result<()> {
         .await?;
     let keys = instance.client.list_keys().await?;
     assert_eq!(keys.len(), 0);
-    let users = instance.client.list_users().await?;
-    assert_eq!(vec!["siguldry-client".to_string()], users);
+    let user = instance.client.who_am_i().await?;
+    assert_eq!("siguldry-client", &user);
 
     instance.halt().await?;
     Ok(())


### PR DESCRIPTION
It doesn't make sense to allow "unprivileged" clients to see all the users. Drop the command; admins can use the server CLI to see all available users.

In the future this could come back behind a remote admin interface, if we decide we want that.