### PR TITLE
siguldry: use a struct for Certificates in the API

### DIFF
--- a/siguldry-pkcs11/src/objects.rs
+++ b/siguldry-pkcs11/src/objects.rs
@@ -7,7 +7,7 @@ use std::collections::HashMap;
 use asn1::ObjectIdentifier;
 use openssl::hash::MessageDigest;
 use sequoia_openpgp::parse::Parse;
-use siguldry::protocol::{Certificate, Key, KeyAlgorithm};
+use siguldry::protocol::{Certificate, CertificateType, Key, KeyAlgorithm};
 
 use cryptoki_sys::{
     CK_ATTRIBUTE, CK_ATTRIBUTE_TYPE, CK_BBOOL, CK_FALSE, CK_OBJECT_CLASS, CK_OBJECT_HANDLE, CK_RV,
@@ -224,6 +224,7 @@ impl Attribute {
     }
 
     fn from_certificate(key: &Key, cert: &Certificate) -> anyhow::Result<HashMap<u64, Attribute>> {
+        debug_assert!(matches!(cert.certificate_type, CertificateType::X509));
         let mut attrs = Self::common_attributes(key)?;
         let class = (CKO_CERTIFICATE as CK_OBJECT_CLASS).to_ne_bytes().to_vec();
         attrs.insert(
@@ -241,75 +242,73 @@ impl Attribute {
             },
         );
 
-        // This _should_ always be true
-        if let Certificate::X509 { name, certificate } = cert {
-            if let Ok(cert) = openssl::x509::X509::from_pem(certificate.as_bytes()) {
-                let value = cert.to_der()?;
-                let issuer = cert.issuer_name().to_der()?;
-                let subject = cert.subject_name().to_der()?;
-                let serial_number = cert.serial_number().to_bn()?.to_vec();
-                let pubkey_info = cert.public_key()?.public_key_to_der()?;
+        if let Ok(cert) = openssl::x509::X509::from_pem(cert.certificate.as_bytes()) {
+            let value = cert.to_der()?;
+            let issuer = cert.issuer_name().to_der()?;
+            let subject = cert.subject_name().to_der()?;
+            let serial_number = cert.serial_number().to_bn()?.to_vec();
+            let pubkey_info = cert.public_key()?.public_key_to_der()?;
 
+            attrs.insert(
+                CKA_CERTIFICATE_TYPE,
+                Attribute {
+                    attribute_type: CKA_CERTIFICATE_TYPE,
+                    value: CKC_X_509.to_ne_bytes().to_vec(),
+                },
+            );
+            if let Some(check_value) = openssl::hash::hash(MessageDigest::sha1(), &value)?
+                .get(..3)
+                .map(Vec::from)
+            {
                 attrs.insert(
-                    CKA_CERTIFICATE_TYPE,
+                    CKA_CHECK_VALUE,
                     Attribute {
-                        attribute_type: CKA_CERTIFICATE_TYPE,
-                        value: CKC_X_509.to_ne_bytes().to_vec(),
+                        attribute_type: CKA_CHECK_VALUE,
+                        value: check_value,
                     },
-                );
-                if let Some(check_value) = openssl::hash::hash(MessageDigest::sha1(), &value)?
-                    .get(..3)
-                    .map(Vec::from)
-                {
-                    attrs.insert(
-                        CKA_CHECK_VALUE,
-                        Attribute {
-                            attribute_type: CKA_CHECK_VALUE,
-                            value: check_value,
-                        },
-                    );
-                }
-                attrs.insert(
-                    CKA_VALUE,
-                    Attribute {
-                        attribute_type: CKA_VALUE,
-                        value,
-                    },
-                );
-                attrs.insert(
-                    CKA_ISSUER,
-                    Attribute {
-                        attribute_type: CKA_ISSUER,
-                        value: issuer,
-                    },
-                );
-                attrs.insert(
-                    CKA_SUBJECT,
-                    Attribute {
-                        attribute_type: CKA_SUBJECT,
-                        value: subject,
-                    },
-                );
-                attrs.insert(
-                    CKA_SERIAL_NUMBER,
-                    Attribute {
-                        attribute_type: CKA_SERIAL_NUMBER,
-                        value: serial_number,
-                    },
-                );
-                attrs.insert(
-                    CKA_PUBLIC_KEY_INFO,
-                    Attribute {
-                        attribute_type: CKA_PUBLIC_KEY_INFO,
-                        value: pubkey_info,
-                    },
-                );
-            } else {
-                tracing::error!(
-                    cert_name = name,
-                    "Server sent malformed PEM-encoded X509 certificate"
                 );
             }
+            attrs.insert(
+                CKA_VALUE,
+                Attribute {
+                    attribute_type: CKA_VALUE,
+                    value,
+                },
+            );
+            attrs.insert(
+                CKA_ISSUER,
+                Attribute {
+                    attribute_type: CKA_ISSUER,
+                    value: issuer,
+                },
+            );
+            attrs.insert(
+                CKA_SUBJECT,
+                Attribute {
+                    attribute_type: CKA_SUBJECT,
+                    value: subject,
+                },
+            );
+            attrs.insert(
+                CKA_SERIAL_NUMBER,
+                Attribute {
+                    attribute_type: CKA_SERIAL_NUMBER,
+                    value: serial_number,
+                },
+            );
+            attrs.insert(
+                CKA_PUBLIC_KEY_INFO,
+                Attribute {
+                    attribute_type: CKA_PUBLIC_KEY_INFO,
+                    value: pubkey_info,
+                },
+            );
+        } else {
+            tracing::error!(
+                cert_name = cert.name,
+                fingerprint = cert.fingerprint,
+                "Server sent malformed PEM-encoded X509 certificate"
+            );
         }
 
         Ok(attrs)
@@ -318,63 +317,57 @@ impl Attribute {
     fn common_attributes(key: &Key) -> anyhow::Result<HashMap<u64, Attribute>> {
         let mut attrs = HashMap::new();
 
-        match key.openpgp_certificates().first() {
-            Some(Certificate::Pgp {
-                version,
-                certificate,
-                fingerprint,
-            }) => {
-                // sequioa-cryptoki uses the Id attribute to stash various OpenPGP parameters.
-                // Reproduce those here so the cryptoki backend recognizes this as useable for
-                // OpenPGP signatures.
-                //
-                // This format is from sequoia-cryptoki; it may be subject to change.
-                // Id attribute needs to be a UTF-8 encoded string with the following format:
-                //
-                // pgp:v{6|6t|6pq|4|4t|4pq}:{key_algorithm}:{iso8601-1:2019 basic format creation time}
-                //
-                // The v<num> indicates the OpenPGP profile, and hybrid keys expose their traditional
-                // and post-quantum pieces with the t or pq suffix respectively (we don't currently
-                // support this).
-                //
-                // Finally, ECDSA keys are documented as needing the hash algorithm and symmetric encryption
-                // algorithm after the key algorithm (separated by -, e.g. "rsa-sha256-aes128"), but we
-                // don't support that currently either.
-                let cert = sequoia_openpgp::Cert::from_bytes(certificate.as_bytes())?;
-                let pgp_key = cert.primary_key().key();
-                let key_algo = match key.key_algorithm {
-                    KeyAlgorithm::Rsa2K | KeyAlgorithm::Rsa4K => "rsa",
-                    KeyAlgorithm::P256 => "ecdsa",
-                    _ => return Err(anyhow::anyhow!("Unsupported key algorithm")),
-                };
-                let creation_time = chrono::DateTime::<chrono::Utc>::from(pgp_key.creation_time())
-                    .format("%Y%m%dT%H%M%SZ")
-                    .to_string();
-                let id = format!("pgp:v{version}:{key_algo}:{creation_time}:{}", &key.name);
-                tracing::debug!(
-                    fingerprint,
-                    id,
-                    "Exposing OpenPGP key for use via Sequoia's cryptoki backend"
-                );
-                attrs.insert(
-                    CKA_ID,
-                    Attribute {
-                        attribute_type: CKA_ID,
-                        value: id.as_bytes().to_vec(),
-                    },
-                );
-            }
-            _other => {
-                // If there are no OpenPGP certificates, we can use a simple Id; each key is
-                // mapped to a token so we can comfortably use 1 as there's no fear of conflicting
-                attrs.insert(
-                    CKA_ID,
-                    Attribute {
-                        attribute_type: CKA_ID,
-                        value: vec![1_u8],
-                    },
-                );
-            }
+        if let Some(cert) = key.openpgp_certificates().first() {
+            // sequioa-cryptoki uses the Id attribute to stash various OpenPGP parameters.
+            // Reproduce those here so the cryptoki backend recognizes this as useable for
+            // OpenPGP signatures.
+            //
+            // This format is from sequoia-cryptoki; it may be subject to change.
+            // Id attribute needs to be a UTF-8 encoded string with the following format:
+            //
+            // pgp:v{6|6t|6pq|4|4t|4pq}:{key_algorithm}:{iso8601-1:2019 basic format creation time}
+            //
+            // The v<num> indicates the OpenPGP profile, and hybrid keys expose their traditional
+            // and post-quantum pieces with the t or pq suffix respectively (we don't currently
+            // support this).
+            //
+            // Finally, ECDSA keys are documented as needing the hash algorithm and symmetric encryption
+            // algorithm after the key algorithm (separated by -, e.g. "rsa-sha256-aes128"), but we
+            // don't support that currently either.
+            let cert = sequoia_openpgp::Cert::from_bytes(cert.certificate.as_bytes())?;
+            let pgp_key = cert.primary_key().key();
+            let version = pgp_key.version();
+            let key_algo = match key.key_algorithm {
+                KeyAlgorithm::Rsa2K | KeyAlgorithm::Rsa4K => "rsa",
+                KeyAlgorithm::P256 => "ecdsa",
+                _ => return Err(anyhow::anyhow!("Unsupported key algorithm")),
+            };
+            let creation_time = chrono::DateTime::<chrono::Utc>::from(pgp_key.creation_time())
+                .format("%Y%m%dT%H%M%SZ")
+                .to_string();
+            let id = format!("pgp:v{version}:{key_algo}:{creation_time}:{}", &key.name);
+            tracing::debug!(
+                fingerprint = pgp_key.fingerprint().to_hex(),
+                id,
+                "Exposing OpenPGP key for use via Sequoia's cryptoki backend"
+            );
+            attrs.insert(
+                CKA_ID,
+                Attribute {
+                    attribute_type: CKA_ID,
+                    value: id.as_bytes().to_vec(),
+                },
+            );
+        } else {
+            // If there are no OpenPGP certificates, we can use a simple Id; each key is
+            // mapped to a token so we can comfortably use 1 as there's no fear of conflicting
+            attrs.insert(
+                CKA_ID,
+                Attribute {
+                    attribute_type: CKA_ID,
+                    value: vec![1_u8],
+                },
+            );
         }
         attrs.insert(
             CKA_LABEL,

--- a/siguldry-pkcs11/tests/signing.rs
+++ b/siguldry-pkcs11/tests/signing.rs
@@ -588,17 +588,7 @@ async fn sign_rsa4k_gnupg_pkcs11_scd_protected_auth() -> anyhow::Result<()> {
         .first()
         .cloned()
         .unwrap();
-    let _fingerprint = match cert {
-        siguldry::protocol::Certificate::Pgp {
-            version: _,
-            certificate,
-            fingerprint,
-        } => {
-            tokio::fs::write(&certificate_path, certificate.as_bytes()).await?;
-            fingerprint
-        }
-        _ => panic!("was expecting a Pgp cert"),
-    };
+    tokio::fs::write(&certificate_path, cert.certificate.as_bytes()).await?;
     let gnupg_home = instance.state_dir.path().join("gpghome");
     tokio::fs::create_dir(&gnupg_home).await?;
     let gpg_agent_conf = gnupg_home.join("gpg-agent.conf");
@@ -721,17 +711,7 @@ async fn sign_rsa4k_via_sequoia() -> anyhow::Result<()> {
         .first()
         .cloned()
         .unwrap();
-    let fingerprint = match cert {
-        siguldry::protocol::Certificate::Pgp {
-            version: _,
-            certificate,
-            fingerprint,
-        } => {
-            tokio::fs::write(&certificate_path, certificate.as_bytes()).await?;
-            fingerprint
-        }
-        _ => panic!("was expecting a Pgp cert"),
-    };
+    tokio::fs::write(&certificate_path, cert.certificate.as_bytes()).await?;
     let password_path = instance.state_dir.path().join("password");
     tokio::fs::write(&password_path, keys::PGP_KEY_PASSWORD.as_bytes()).await?;
 
@@ -760,14 +740,14 @@ async fn sign_rsa4k_via_sequoia() -> anyhow::Result<()> {
         .arg("pki")
         .arg("link")
         .arg("add")
-        .arg(format!("--cert={}", fingerprint))
+        .arg(format!("--cert={}", cert.fingerprint))
         .arg("--all")
         .output()
         .await?;
     assert!(
         output.status.success(),
         "'sq --batch pki link add --cert={} --all' failed:\nstdout: {}\nstderr: {}",
-        fingerprint,
+        cert.fingerprint,
         String::from_utf8_lossy(&output.stdout),
         String::from_utf8_lossy(&output.stderr),
     );
@@ -793,7 +773,7 @@ async fn sign_rsa4k_via_sequoia() -> anyhow::Result<()> {
         .arg("--batch")
         .arg(format!("--password-file={}", password_path.display()))
         .arg("sign")
-        .arg(format!("--signer={}", fingerprint))
+        .arg(format!("--signer={}", cert.fingerprint))
         .arg(format!("--signature-file={}", sig_path.display()))
         .arg(&data_path)
         .output()
@@ -802,7 +782,7 @@ async fn sign_rsa4k_via_sequoia() -> anyhow::Result<()> {
     assert!(
         output.status.success(),
         "'sq --batch sign --signer={} --signature-file={} {}' failed:\nstdout: {}\nstderr: {}",
-        fingerprint,
+        cert.fingerprint,
         sig_path.display(),
         data_path.display(),
         String::from_utf8_lossy(&output.stdout),

--- a/siguldry-pkcs11/tests/sigul_imported_keys.rs
+++ b/siguldry-pkcs11/tests/sigul_imported_keys.rs
@@ -34,17 +34,7 @@ async fn import_sigul_and_sign() -> anyhow::Result<()> {
         .first()
         .cloned()
         .unwrap();
-    let _fingerprint = match cert {
-        siguldry::protocol::Certificate::Pgp {
-            version: _,
-            certificate,
-            fingerprint,
-        } => {
-            tokio::fs::write(&certificate_path, certificate.as_bytes()).await?;
-            fingerprint
-        }
-        _ => panic!("was expecting a Pgp cert"),
-    };
+    tokio::fs::write(&certificate_path, cert.certificate.as_bytes()).await?;
     let gnupg_home = instance.state_dir.path().join("gpghome");
     tokio::fs::create_dir(&gnupg_home).await?;
     let gpg_agent_conf = gnupg_home.join("gpg-agent.conf");
@@ -175,17 +165,7 @@ async fn import_sigul_just_gpg_key() -> anyhow::Result<()> {
         .first()
         .cloned()
         .unwrap();
-    let _fingerprint = match cert {
-        siguldry::protocol::Certificate::Pgp {
-            version: _,
-            certificate,
-            fingerprint,
-        } => {
-            tokio::fs::write(&certificate_path, certificate.as_bytes()).await?;
-            fingerprint
-        }
-        _ => panic!("was expecting a Pgp cert"),
-    };
+    tokio::fs::write(&certificate_path, cert.certificate.as_bytes()).await?;
     let gnupg_home = instance.state_dir.path().join("gpghome");
     tokio::fs::create_dir(&gnupg_home).await?;
     let gpg_agent_conf = gnupg_home.join("gpg-agent.conf");

--- a/siguldry/src/protocol.rs
+++ b/siguldry/src/protocol.rs
@@ -524,26 +524,27 @@ mod base64 {
 
 /// Describes the public portion of keys managed by Siguldry.
 #[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct Certificate {
+    /// The PEM-encoded or ASCII-armored certificate.
+    pub certificate: String,
+    /// The type of the certificate.
+    pub certificate_type: CertificateType,
+    /// A unique identifier for the certificate.
+    pub fingerprint: String,
+    /// The name of the certificate in Siguldry.
+    ///
+    /// Names are unique per-key.
+    pub name: String,
+}
+
+/// The type of certificate contained in a [`Certificate`].
+#[derive(Debug, Clone, Serialize, Deserialize)]
 #[non_exhaustive]
-pub enum Certificate {
+pub enum CertificateType {
     /// A key pair that can be used for OpenPGP signatures.
-    Pgp {
-        /// The key version; likely either 4 or 6, but refer to RFC 9580 and any superceding RFCs.
-        version: u8,
-        /// The ASCII-armored public key
-        certificate: String,
-        /// The key's fingerprint; the exact format depends on the key version.
-        fingerprint: String,
-    },
+    Pgp,
     /// A key pair with an associated X509 certificate.
-    X509 {
-        /// A user-friendly name that uniquely identifies the certificate
-        /// with respect to a key. Different keys may have certificates with
-        /// the same name.
-        name: String,
-        /// The PEM-encoded certificate.
-        certificate: String,
-    },
+    X509,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -557,22 +558,16 @@ pub struct Key {
     pub handle: String,
     /// The PEM-encoded public key.
     pub public_key: String,
+    /// A list of certificates associated with this key.
     pub certificates: Vec<Certificate>,
 }
 
 impl Key {
+    /// A list of X509 certificates.
     pub fn x509_certificates(&self) -> Vec<Certificate> {
         self.certificates
             .iter()
-            .filter(|c| {
-                matches!(
-                    c,
-                    Certificate::X509 {
-                        name: _,
-                        certificate: _
-                    }
-                )
-            })
+            .filter(|c| matches!(c.certificate_type, CertificateType::X509))
             .cloned()
             .collect()
     }
@@ -580,16 +575,7 @@ impl Key {
     pub fn openpgp_certificates(&self) -> Vec<Certificate> {
         self.certificates
             .iter()
-            .filter(|c| {
-                matches!(
-                    c,
-                    Certificate::Pgp {
-                        version: _,
-                        certificate: _,
-                        fingerprint: _
-                    }
-                )
-            })
+            .filter(|c| matches!(c.certificate_type, CertificateType::Pgp,))
             .cloned()
             .collect()
     }

--- a/siguldry/src/server/handlers.rs
+++ b/siguldry/src/server/handlers.rs
@@ -3,13 +3,14 @@
 
 use std::sync::Arc;
 
+use openssl::{hash::MessageDigest, x509::X509};
 use sequoia_openpgp::parse::Parse;
 use sqlx::SqliteConnection;
 use tracing::instrument;
 use uuid::Uuid;
 
 use crate::{
-    protocol::{self, DigestAlgorithm, Response, ServerError},
+    protocol::{self, Certificate, DigestAlgorithm, Response, ServerError},
     server::{
         Config,
         db::{self, User},
@@ -49,30 +50,7 @@ impl Handler {
     ) -> Result<Response, ServerError> {
         let mut keys = vec![];
         for key in db::Key::list_by_user(conn, user).await? {
-            let certificates = {
-                let x509 = db::PublicKeyMaterial::list(conn, &key, db::PublicKeyMaterialType::X509)
-                    .await?
-                    .into_iter()
-                    .map(|cert| crate::protocol::Certificate::X509 {
-                        name: cert.name,
-                        certificate: cert.data,
-                    });
-                let pgp =
-                    db::PublicKeyMaterial::list(conn, &key, db::PublicKeyMaterialType::OpenPgpCert)
-                        .await?
-                        .into_iter()
-                        .filter_map(|cert| {
-                            sequoia_openpgp::Cert::from_bytes(cert.data.as_bytes())
-                                .ok()
-                                .map(|parsed_cert| crate::protocol::Certificate::Pgp {
-                                    version: parsed_cert.primary_key().key().version(),
-                                    certificate: cert.data,
-                                    fingerprint: parsed_cert.fingerprint().to_hex(),
-                                })
-                        });
-
-                x509.chain(pgp).collect()
-            };
+            let certificates = certs_for_key(conn, &key).await?;
             keys.push(protocol::Key {
                 name: key.name,
                 key_algorithm: key.key_algorithm,
@@ -101,30 +79,7 @@ impl Handler {
         key_name: String,
     ) -> Result<Response, ServerError> {
         let key = db::Key::get(conn, &key_name).await?;
-        let certificates = {
-            let x509 = db::PublicKeyMaterial::list(conn, &key, db::PublicKeyMaterialType::X509)
-                .await?
-                .into_iter()
-                .map(|cert| crate::protocol::Certificate::X509 {
-                    name: cert.name,
-                    certificate: cert.data,
-                });
-            let pgp =
-                db::PublicKeyMaterial::list(conn, &key, db::PublicKeyMaterialType::OpenPgpCert)
-                    .await?
-                    .into_iter()
-                    .filter_map(|cert| {
-                        sequoia_openpgp::Cert::from_bytes(cert.data.as_bytes())
-                            .ok()
-                            .map(|parsed_cert| crate::protocol::Certificate::Pgp {
-                                version: parsed_cert.primary_key().key().version(),
-                                certificate: cert.data,
-                                fingerprint: parsed_cert.fingerprint().to_hex(),
-                            })
-                    });
-
-            x509.chain(pgp).collect()
-        };
+        let certificates = certs_for_key(conn, &key).await?;
 
         Ok(Response::GetKey {
             key: protocol::Key {
@@ -172,4 +127,44 @@ impl Handler {
     pub(crate) async fn shutdown(self) -> anyhow::Result<()> {
         self.ipc_helper.shutdown().await
     }
+}
+
+async fn certs_for_key(
+    conn: &mut SqliteConnection,
+    key: &db::Key,
+) -> anyhow::Result<Vec<Certificate>> {
+    let certificates = {
+        let x509 = db::PublicKeyMaterial::list(conn, key, db::PublicKeyMaterialType::X509)
+            .await?
+            .into_iter()
+            .filter_map(|cert| {
+                X509::from_pem(cert.data.as_bytes())
+                    .ok()
+                    .and_then(|c| c.digest(MessageDigest::sha256()).ok())
+                    .map(hex::encode_upper)
+                    .map(|fingerprint| crate::protocol::Certificate {
+                        name: cert.name,
+                        certificate: cert.data,
+                        certificate_type: crate::protocol::CertificateType::X509,
+                        fingerprint,
+                    })
+            });
+        let pgp = db::PublicKeyMaterial::list(conn, key, db::PublicKeyMaterialType::OpenPgpCert)
+            .await?
+            .into_iter()
+            .filter_map(|cert| {
+                sequoia_openpgp::Cert::from_bytes(cert.data.as_bytes())
+                    .ok()
+                    .map(|parsed_cert| crate::protocol::Certificate {
+                        name: cert.name,
+                        certificate: cert.data,
+                        certificate_type: crate::protocol::CertificateType::Pgp,
+                        fingerprint: parsed_cert.fingerprint().to_hex(),
+                    })
+            });
+
+        x509.chain(pgp).collect()
+    };
+
+    Ok(certificates)
 }

--- a/siguldry/tests/end_to_end.rs
+++ b/siguldry/tests/end_to_end.rs
@@ -243,59 +243,44 @@ async fn check_x509_certs() -> anyhow::Result<()> {
         .client
         .get_key(keys::CODESIGNING_KEY_NAME.to_string())
         .await?;
-    match (
-        ca_key.x509_certificates().pop().unwrap(),
-        codesigning_key.x509_certificates().pop().unwrap(),
-    ) {
-        (
-            siguldry::protocol::Certificate::X509 {
-                name: _,
-                certificate: ca_cert,
-            },
-            siguldry::protocol::Certificate::X509 {
-                name: _,
-                certificate: codesigning_cert,
-            },
-        ) => {
-            let ca_path = instance.state_dir.path().join("ca.pem");
-            std::fs::write(&ca_path, &ca_cert)?;
-            let codesigning_path = instance.state_dir.path().join("codesigning.pem");
-            std::fs::write(&codesigning_path, &codesigning_cert)?;
-            // The CA should be self-signed
-            let mut command = tokio::process::Command::new("openssl");
-            let output = command
-                .arg("verify")
-                .arg("-CAfile")
-                .arg(&ca_path)
-                .arg(&ca_path)
-                .output()
-                .await?;
-            assert!(output.status.success());
+    let ca_cert = ca_key.x509_certificates().pop().unwrap();
+    let codesigning_cert = codesigning_key.x509_certificates().pop().unwrap();
+    let ca_path = instance.state_dir.path().join("ca.pem");
+    std::fs::write(&ca_path, &ca_cert.certificate)?;
+    let codesigning_path = instance.state_dir.path().join("codesigning.pem");
+    std::fs::write(&codesigning_path, &codesigning_cert.certificate)?;
+    // The CA should be self-signed
+    let mut command = tokio::process::Command::new("openssl");
+    let output = command
+        .arg("verify")
+        .arg("-CAfile")
+        .arg(&ca_path)
+        .arg(&ca_path)
+        .output()
+        .await?;
+    assert!(output.status.success());
 
-            // The CA has signed the codesigning certificate
-            let mut command = tokio::process::Command::new("openssl");
-            let output = command
-                .arg("verify")
-                .arg("-CAfile")
-                .arg(&ca_path)
-                .arg(&codesigning_path)
-                .output()
-                .await?;
-            assert!(output.status.success());
+    // The CA has signed the codesigning certificate
+    let mut command = tokio::process::Command::new("openssl");
+    let output = command
+        .arg("verify")
+        .arg("-CAfile")
+        .arg(&ca_path)
+        .arg(&codesigning_path)
+        .output()
+        .await?;
+    assert!(output.status.success());
 
-            // And the CA isn't signed by codesigning
-            let mut invalid_verify = tokio::process::Command::new("openssl");
-            let output = invalid_verify
-                .arg("verify")
-                .arg("-CAfile")
-                .arg(&codesigning_path)
-                .arg(&ca_path)
-                .output()
-                .await?;
-            assert!(!output.status.success());
-        }
-        _ => panic!("unexpected key type"),
-    }
+    // And the CA isn't signed by codesigning
+    let mut invalid_verify = tokio::process::Command::new("openssl");
+    let output = invalid_verify
+        .arg("verify")
+        .arg("-CAfile")
+        .arg(&codesigning_path)
+        .arg(&ca_path)
+        .output()
+        .await?;
+    assert!(!output.status.success());
 
     instance.halt().await?;
     Ok(())
@@ -777,29 +762,21 @@ async fn import_sigul_certificate_names_match() -> anyhow::Result<()> {
         .client
         .get_key(keys::SIGUL_CA_KEY_NAME.to_string())
         .await?;
-    let ca_cert_names = ca_key
-        .certificates
-        .iter()
-        .filter_map(|cert| match cert {
-            siguldry::protocol::Certificate::X509 { name, .. } => Some(name.as_str()),
-            _ => None,
-        })
-        .collect::<Vec<_>>();
-    assert_eq!(vec![keys::SIGUL_CA_CERT_NAME], ca_cert_names);
+    let ca_cert = ca_key
+        .x509_certificates()
+        .into_iter()
+        .find(|c| c.name == keys::SIGUL_CA_CERT_NAME);
+    assert!(ca_cert.is_some());
 
     let rsa_key = instance
         .client
         .get_key(keys::SIGUL_RSA_KEY_NAME.to_string())
         .await?;
-    let rsa_cert_names = rsa_key
-        .certificates
-        .iter()
-        .filter_map(|cert| match cert {
-            siguldry::protocol::Certificate::X509 { name, .. } => Some(name.as_str()),
-            _ => None,
-        })
-        .collect::<Vec<_>>();
-    assert_eq!(vec![keys::SIGUL_RSA_CERT_NAME], rsa_cert_names);
+    let rsa_cert = rsa_key
+        .x509_certificates()
+        .into_iter()
+        .find(|c| c.name == keys::SIGUL_RSA_CERT_NAME);
+    assert!(rsa_cert.is_some());
 
     instance.halt().await?;
     Ok(())


### PR DESCRIPTION
The protocol representation of a certificate was difficult to work with and was missing important details like the name in Siguldry. Just use a struct with a type field.