### PR TITLE
Remove the version specifier for siguldry-test

### DIFF
--- a/siguldry-pkcs11/Cargo.toml
+++ b/siguldry-pkcs11/Cargo.toml
@@ -82,7 +82,6 @@ version = "0.7"
 features = ["io", "rt"]
 
 [dev-dependencies.siguldry-test]
-version = "0.1"
 path = "../siguldry-test"
 
 [dev-dependencies.tracing-test]

--- a/siguldry/Cargo.toml
+++ b/siguldry/Cargo.toml
@@ -130,7 +130,6 @@ criterion = "0.8"
 proptest = "1.6"
 
 [dev-dependencies.siguldry-test]
-version = "0.1"
 path = "../siguldry-test"
 
 [dev-dependencies.tracing-test]


### PR DESCRIPTION
The version isn't actually required, and not including it causes cargo to prune the dependency prior to publishing which is helpful since we aren't publishing siguldry-test and there's a circular dependency between it an siguldry.