### PR TITLE
siguldry: add example config files

### DIFF
--- a/siguldry/Cargo.toml
+++ b/siguldry/Cargo.toml
@@ -128,6 +128,7 @@ anyhow = "1"
 assert_cmd = "2"
 criterion = "0.8"
 proptest = "1.6"
+toml = "1"
 
 [dev-dependencies.siguldry-test]
 path = "../siguldry-test"

--- a/siguldry/bridge.toml.example
+++ b/siguldry/bridge.toml.example
@@ -1,0 +1,20 @@
+# This is an example bridge configuration.
+
+# The socket address to listen on for incoming connections from Siguldry servers.
+#
+# The default is to listen on all interfaces on port 44333.
+server_listening_address = "[::]:44333"
+
+# The socket address to listen on for incoming connections from Siguldry clients.
+#
+# The default is to listen on all interfaces on port 44334.
+client_listening_address = "[::]:44334"
+
+# The TLS credentials for the server and client listeners.
+#
+# Both clients and servers connect to the above addresses and perform mutual TLS.
+# Note that the certificate must have `serverAuth` in its extended key usage extension.
+[credentials]
+private_key = "siguldry.bridge.private_key.pem"
+certificate = "siguldry.bridge.certificate.pem"
+ca_certificate = "siguldry.ca_certificate.pem"

--- a/siguldry/client.toml.example
+++ b/siguldry/client.toml.example
@@ -1,0 +1,43 @@
+# An example client configuration
+
+# The Siguldry server hostname. This is used to validate the server's TLS certificate.
+#
+# However, since the client connects through the bridge, no DNS resolution is performed.
+# This name just needs to match what is in the server's certificate.
+server_hostname = "server.example.com"
+
+# The Siguldry bridge hostname. This is used to validate the bridge's TLS certificate.
+bridge_hostname = "bridge.example.com"
+
+# The port on the Siguldry bridge to connect to; the default is 44334.
+bridge_port = 44334
+
+# A list of keys to unlock for the client.
+#
+# This can be set for users of the client who can't (or don't want to) call unlock or safely
+# store a password. One example would be the PKCS#11 module used inside a build environment.
+#
+# An example entry:
+#
+# [[keys]]
+# key_name = "signing-key"
+# # Store this encrypted in /etc/credstore.encrypted/
+# passphrase_path = "siguldry.signing_key.passphrase"
+keys = []
+
+# The amount of time to wait before giving up on a request and retrying.
+#
+# This covers both sending requests and receiving responses. In other words, the client
+# will retry the request on a new connection if it cannot write the request to the socket
+# within `request_timeout`, *and* it will retry if it fails to read a response to that
+# request from the socket within `request_timeout`.
+[request_timeout]
+secs = 30
+nanos = 0
+
+# The credentials to use when authenticating to the Siguldry bridge and server. Note that
+# the certificate must have the `clientAuth` extended key usage extension.
+[credentials]
+private_key = "siguldry.client.private_key.pem"
+certificate = "siguldry.client.certificate.pem"
+ca_certificate = "siguldry.ca_certificate.pem"

--- a/siguldry/server.toml.example
+++ b/siguldry/server.toml.example
@@ -1,0 +1,74 @@
+# An example server configuration
+
+# The location where the server should store its state.
+#
+# To back up the service, back up this directory.
+state_directory = "/var/lib/siguldry/"
+
+# The hostname of the Sigul bridge; this is used to verify the bridge's
+# TLS certificate.
+bridge_hostname = "bridge.example.com"
+
+# The port to use when connecting to the Siguldry bridge
+bridge_port = 44333
+
+# The number of ready connections to maintain with the bridge. This decreases the latency of
+# responses when multiple client connections are established, at the expense of some idle
+# connections. Be aware that the bridge has its own limits on the allowable number of idle
+# server connections. If you use multiple servers with a single bridge, be sure that the
+# bridge allows enough idle connections to cover each server's pool size. The default is 32.
+connection_pool_size = 32
+
+# The minimum length for user's access password, in *bytes*. For example, the multi-byte
+# UTF-8 character "🪿" counts as 4 bytes.
+user_password_length = 32
+
+# The user ID to use when creating OpenPGP keys.
+#
+# This is typically an email like "Signing Key <signing@example.com>".
+openpgp_user_id = "Test Signing <sign@example.com>"
+
+# The set of certificates to encrypt passwords with.
+#
+# At least one entry should include a PKCS#11 URI for a private key. Signing keys are encrypted
+# using each certificate, so providing more than one binding means *any* of the private keys
+# associated with the certificates will allow you to access the signing key, assuming you have
+# the user-set password for the key as well.
+#
+# When binding is used, the admin needs to unlock the token by entering the PIN using
+# "siguldry-server enter-pin".
+#
+# If no bindings are configured, the keys are protected using only the user-provided
+# password.
+#
+# An example binding entry:
+#
+# [[pkcs11_bindings]]
+# certificate = "/path/to/cert.pem"
+# private_key = "pkcs11:token=some-token;type=private"
+#
+# [[pkcs11_bindings]]
+# certificate = "/path/to/a/second/cert.pem"
+pkcs11_bindings = []
+
+# The credentials to use when connecting to the bridge and when accepting client connections
+# tunneled through the bridge. Note that the certificate must have both `clientAuth` and
+# `serverAuth` in its extended key usage extension.
+#
+# It is expected that you store the private key in /etc/credstore.encrypted/ and the certificates
+# in /etc/credstore/ (no encryption necessary).
+[credentials]
+private_key = "siguldry.server.private_key.pem"
+certificate = "siguldry.server.certificate.pem"
+ca_certificate = "siguldry.ca_certificate.pem"
+
+# Certificates created by Siguldry allow the user to specify the subject's common name.
+#
+# The rest of the certificate's subject is specified here.
+[certificate_subject]
+country = "US"
+state_or_province = "Massachusetts"
+locality = "Cambridge"
+organization = "An Example Organization"
+organizational_unit = "Example Department of the Organization"
+

--- a/siguldry/src/bridge.rs
+++ b/siguldry/src/bridge.rs
@@ -47,9 +47,9 @@ impl Default for Config {
             client_listening_address: SocketAddr::from_str("[::]:44334")
                 .expect("the default should be valid"),
             credentials: Credentials {
-                private_key: "sigul.bridge.private_key.pem".into(),
-                certificate: "sigul.bridge.certificate.pem".into(),
-                ca_certificate: "sigul.ca_certificate.pem".into(),
+                private_key: "siguldry.bridge.private_key.pem".into(),
+                certificate: "siguldry.bridge.certificate.pem".into(),
+                ca_certificate: "siguldry.ca_certificate.pem".into(),
             },
         }
     }
@@ -330,4 +330,17 @@ async fn bridge(
     };
 
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    #[test]
+    fn load_example_config() -> anyhow::Result<()> {
+        let example_conf_path =
+            std::path::PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("bridge.toml.example");
+        let example_conf = std::fs::read_to_string(&example_conf_path)?;
+        toml::de::from_str::<super::Config>(&example_conf)?;
+
+        Ok(())
+    }
 }

--- a/siguldry/src/client/config.rs
+++ b/siguldry/src/client/config.rs
@@ -146,3 +146,16 @@ impl Key {
             .map(|p| String::from_utf8(p.to_vec()).expect("The password deserialized to a string"))
     }
 }
+
+#[cfg(test)]
+mod tests {
+    #[test]
+    fn load_example_config() -> anyhow::Result<()> {
+        let example_conf_path =
+            std::path::PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("client.toml.example");
+        let example_conf = std::fs::read_to_string(&example_conf_path)?;
+        toml::de::from_str::<super::Config>(&example_conf)?;
+
+        Ok(())
+    }
+}

--- a/siguldry/src/server/config.rs
+++ b/siguldry/src/server/config.rs
@@ -181,3 +181,16 @@ fn default_socket_path() -> PathBuf {
 fn default_state_directory() -> PathBuf {
     PathBuf::from("/var/lib/siguldry/")
 }
+
+#[cfg(test)]
+mod tests {
+    #[test]
+    fn load_example_config() -> anyhow::Result<()> {
+        let example_conf_path =
+            std::path::PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("server.toml.example");
+        let example_conf = std::fs::read_to_string(&example_conf_path)?;
+        toml::de::from_str::<super::Config>(&example_conf)?;
+
+        Ok(())
+    }
+}


### PR DESCRIPTION
It's helpful to see examples even if the CLI will also emit the defaults. This includes tests to ensure they remain up-to-date (at least in terms of being valid configs).