### PR TITLE
Fix an assumption that C’s char type is signed

### DIFF
--- a/siguldry-pkcs11/src/lib.rs
+++ b/siguldry-pkcs11/src/lib.rs
@@ -385,7 +385,7 @@ pub unsafe extern "C" fn C_GetInterface(
         // Safety:
         // The pointer is non-NULL, and according to the specification must point to a
         // NULL-terminated string.
-        let interface_name = unsafe { CStr::from_ptr(pInterfaceName as *const i8) };
+        let interface_name = unsafe { CStr::from_ptr(pInterfaceName as *const core::ffi::c_char) };
         if interface_name != interfaces::FUNCTIONS_NAME {
             tracing::warn!("The only supported interface name is PKCS 11");
             return CKR_ARGUMENTS_BAD;


### PR DESCRIPTION
This fixes failure of `siguldry-pkcs11` to build on many 64-bit architectures other than `x86_64`. (32-bit architectures have bigger problems, but thanks to https://fedoraproject.org/wiki/Changes/EncourageI686LeafRemoval we don’t need to care about this in Fedora.)

I’m planning to bring this up in the [downstream package review](https://bugzilla.redhat.com/show_bug.cgi?id=2448376).  I used a scratch build of that submission to confirm that this change fixes failure to build on `aarch64`, `ppc64le`, and `s390x`.