### PR TITLE
sigul-pesign-bridge: add config for additional socket acls

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -81,6 +81,7 @@ jobs:
       - name: Install test packages
         run: |
           dnf install -y \
+            acl \
             capnproto \
             clang \
             gnupg-pkcs11-scd \
@@ -174,6 +175,7 @@ jobs:
       - name: Install test packages
         run: |
           dnf install -y \
+            acl \
             capnproto \
             clang \
             gnupg-pkcs11-scd \

--- a/sigul-pesign-bridge/src/config.rs
+++ b/sigul-pesign-bridge/src/config.rs
@@ -45,6 +45,18 @@ pub struct Config {
     /// request. If the requested key is not in this list, the request is
     /// rejected.
     pub keys: Vec<Key>,
+
+    /// A list of ACL specifications to apply to the listening socket.
+    ///
+    /// These are in the format described in the setfacl(1) manual, and is achieved by running that
+    /// command, so you will need it available to use this setting. Each entry is applied to the
+    /// socket using the command `setfacl -m {socket_acl} /path/to/socket`.
+    ///
+    /// # Example
+    ///
+    /// An example entry would be `user:kojibuilder:rwx`.
+    #[serde(default)]
+    pub socket_acl: Vec<String>,
 }
 
 /// Configuration to connect to the Sigul server.
@@ -315,6 +327,7 @@ impl Default for Config {
             sigul_request_timeout_secs: NonZeroU64::new(60).expect("Don't set the default to 0"),
             keys: vec![Key::default()],
             sigul: Siguldry::default(),
+            socket_acl: vec![],
         }
     }
 }
@@ -329,4 +342,82 @@ pub(crate) fn load(path: &str) -> anyhow::Result<Config> {
             eprintln!("Example config file:\n\n{}", Config::default());
         })
         .context("configuration file is invalid")
+}
+
+#[cfg(test)]
+mod tests {
+    use rustix::path::Arg;
+
+    #[test]
+    fn load_config_with_no_acls() -> anyhow::Result<()> {
+        let config_file = tempfile::NamedTempFile::new()?;
+        std::fs::write(
+            config_file.path(),
+            r#"
+total_request_timeout_secs = 600
+sigul_request_timeout_secs = 60
+
+[sigul]
+bridge_hostname = "localhost"
+bridge_port = 44334
+server_hostname = "localhost"
+sigul_user_name = "sigul-client"
+private_key = "sigul.client.private_key.pem"
+client_certificate = "sigul.client.certificate.pem"
+ca_certificate = "sigul.ca_certificate.pem"
+
+[[keys]]
+pesign_token_name = "OpenSC Card"
+pesign_certificate_name = "some-signing-certificate"
+key_name = "signing-key"
+certificate_name = "codesigning"
+passphrase_path = "sigul.signing-key-passphrase"
+        "#,
+        )?;
+
+        let config = super::load(config_file.path().as_str()?)?;
+        assert_eq!(
+            config.socket_acl.len(),
+            0,
+            "ACLs should be an empty list by default"
+        );
+
+        Ok(())
+    }
+
+    #[test]
+    fn load_config_with_acls() -> anyhow::Result<()> {
+        let config_file = tempfile::NamedTempFile::new()?;
+        std::fs::write(
+            config_file.path(),
+            r#"
+total_request_timeout_secs = 600
+sigul_request_timeout_secs = 60
+
+socket_acl = ["user:kojibuilder:rwx", "user:nobody:r"]
+
+[sigul]
+bridge_hostname = "localhost"
+bridge_port = 44334
+server_hostname = "localhost"
+sigul_user_name = "sigul-client"
+private_key = "sigul.client.private_key.pem"
+client_certificate = "sigul.client.certificate.pem"
+ca_certificate = "sigul.ca_certificate.pem"
+
+[[keys]]
+pesign_token_name = "OpenSC Card"
+pesign_certificate_name = "some-signing-certificate"
+key_name = "signing-key"
+certificate_name = "codesigning"
+passphrase_path = "sigul.signing-key-passphrase"
+        "#,
+        )?;
+
+        let config = super::load(config_file.path().as_str()?)?;
+        let expected_acls = vec!["user:kojibuilder:rwx", "user:nobody:r"];
+        assert_eq!(config.socket_acl, expected_acls);
+
+        Ok(())
+    }
 }

--- a/sigul-pesign-bridge/src/service.rs
+++ b/sigul-pesign-bridge/src/service.rs
@@ -48,6 +48,32 @@ pub fn listen(
     let socket_path = context.runtime_directory.join("socket");
     let listener = UnixListener::bind(&socket_path)
         .with_context(|| format!("Failed to bind to {}", &socket_path.display()))?;
+    for acl in context.config.socket_acl.iter() {
+        tracing::debug!(acl, "Applying additional access control to socket");
+        let mut command = std::process::Command::new("setfacl");
+        let output = command
+            .arg("-m")
+            .arg(acl)
+            .arg(&socket_path)
+            .output()
+            .context("Failed to execute 'setfacl' command (is it installed?)")?;
+        if !output.status.success() {
+            let exit_code = output.status.code();
+            let stderr = String::from_utf8_lossy(&output.stderr);
+            let stdout = String::from_utf8_lossy(&output.stdout);
+            tracing::error!(
+                ?exit_code,
+                ?stderr,
+                ?stdout,
+                "Executing 'setfacl -m {acl} {}' failed",
+                socket_path.display()
+            );
+            return Err(anyhow::anyhow!(
+                "Executing 'setfacl -m {acl} {}' failed: {stderr:?} (exited {exit_code:?})",
+                socket_path.display()
+            ));
+        }
+    }
     let metadata = std::fs::metadata(&socket_path)?;
     if metadata.permissions().mode() & rustix::fs::Mode::RWXO.bits() != 0 {
         tracing::error!(mode=?metadata.permissions(), "Service socket has dangerous permissions!");
@@ -593,6 +619,41 @@ mod tests {
             .fix_credentials(&outdir)
             .expect("extract CI credentials with 'cargo xtask extract-keys'");
         config
+    }
+
+    // Test that if configured, additional ACLs are configured on the socket.
+    #[tokio::test]
+    #[tracing_test::traced_test]
+    async fn listen_sets_socket_acls() -> Result<()> {
+        set_umask();
+        let socket_dir = tempfile::tempdir()?;
+        let socket_path = socket_dir.path().join("socket");
+        let mut config = config();
+        config.socket_acl = vec!["user:nobody:r-x".to_string()];
+        let context = Context::new(config, socket_dir.path().to_path_buf())?;
+        let cancel_token = CancellationToken::new();
+
+        let server_task = super::listen(context, cancel_token.clone())?;
+
+        let mut command = tokio::process::Command::new("getfacl");
+        let output = command.arg(&socket_path).output().await?;
+
+        assert!(output.status.success());
+        let stdout = String::from_utf8(output.stdout)?;
+        assert!(
+            stdout.contains("user:nobody:r-x"),
+            "Expected 'getfacl {}' to include nobody, but was {}",
+            socket_path.display(),
+            stdout
+        );
+
+        cancel_token.cancel();
+        server_task.await??;
+        assert!(logs_contain(
+            "Applying additional access control to socket acl=\"user:nobody:r-x\"",
+        ));
+
+        Ok(())
     }
 
     // Test that the service waits for existing requests to complete (or timeout) after it


### PR DESCRIPTION
Allow admins to set a new configuration key, socket_acl, which can be a list of strings in the ACL specification format accepted by 'setfacl'. If provided, the socket ACLs will be modified with each entry in the list after it created.

Fixes: #163