### PR TITLE
siguldry: add a comment to the client proxy on socket permissions

### DIFF
--- a/siguldry/siguldry-client-proxy.socket
+++ b/siguldry/siguldry-client-proxy.socket
@@ -7,6 +7,11 @@ SocketUser=siguldry
 SocketGroup=siguldry
 SocketMode=0660
 ListenStream=%t/siguldry-client-proxy/siguldry-client-proxy.socket
+# In the event that you need to provide additional users access to the socket,
+# You can add a unit override snippet that includes one or more post-start
+# commands that are similar to:
+#
+#ExecStartPost=/usr/bin/setfacl -m u:kojibuilder:rwx %t/siguldry-client-proxy/siguldry-client-proxy.socket
 RemoveOnStop=true
 
 [Install]


### PR DESCRIPTION
Unlike sigul-pesign-bridge, the client proxy socket is managed by systemd (this is exclusively because it didn't occur to me, not for any technical reason).

This means that we don't control the creation of the socket, but fortunately systemd lets you run arbitrary commands after the startup. Document how to add file ACLs to the socket, should it be needed.

Related: #163