### PR TITLE
siguldry-client: add version to proxy protocol

### DIFF
--- a/siguldry/src/client/proxy.rs
+++ b/siguldry/src/client/proxy.rs
@@ -27,6 +27,28 @@ use crate::{
     protocol::{self, DigestAlgorithm},
 };
 
+const IPC_VERSION: u32 = 1;
+
+/// Every connection starts with the client sending this header to the server,
+/// indicating what version of the API it plans to speak. The server then responds
+/// with its current IPC version. Old handlers should not be removed from the server.
+///
+/// This will allow for graceful migrations in scenarios where the client proxy server version
+/// doesn't align with the client version (e.g. the PKCS #11 module inside a build environment
+/// speaking to a socket from the builder host)
+#[derive(Debug, Clone, Serialize, Deserialize)]
+struct IpcHeader {
+    version: u32,
+}
+
+impl IpcHeader {
+    fn new() -> Self {
+        Self {
+            version: IPC_VERSION,
+        }
+    }
+}
+
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
 enum Request {
@@ -48,10 +70,22 @@ enum Request {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
 enum Response {
-    ListKeys { keys: Vec<Key> },
+    ListKeys {
+        keys: Vec<Key>,
+    },
     Unlock {},
-    IsUnlocked { unlocked: bool },
-    Sign { signature: Signature },
+    IsUnlocked {
+        unlocked: bool,
+    },
+    Sign {
+        signature: Signature,
+    },
+    /// Indicates the server doesn't implement the requested function.
+    ///
+    /// The client can expect this if the server half is running an older
+    /// version and a command has been added. Be mindful to provide a graceful
+    /// upgrade path for such scenarios.
+    Unsupported {},
 }
 
 pub async fn proxy<R: AsyncRead + Unpin, W: AsyncWrite + Unpin>(
@@ -63,6 +97,7 @@ pub async fn proxy<R: AsyncRead + Unpin, W: AsyncWrite + Unpin>(
     tracing::info!("Handling requests");
     let mut requests = BufReader::new(requests).lines();
 
+    let mut ipc_header: Option<IpcHeader> = None;
     loop {
         let line = tokio::select! {
             _ = halt_token.cancelled() => {
@@ -77,26 +112,73 @@ pub async fn proxy<R: AsyncRead + Unpin, W: AsyncWrite + Unpin>(
             }
         };
 
-        let request: Request = serde_json::from_str(&line)?;
-        let response = match request {
-            Request::ListKeys {} => {
-                let keys = client.list_keys().await?;
-                Response::ListKeys { keys }
+        // Currently unused, but if we need to break the API this is helpful to match against
+        let _client_version = if let Some(ipc_header) = ipc_header.as_ref() {
+            ipc_header.version
+        } else {
+            let header: IpcHeader = serde_json::from_str(&line)?;
+            let version = header.version;
+            if version > IPC_VERSION {
+                tracing::error!(
+                    client_version = version,
+                    server_version = IPC_VERSION,
+                    "The IPC client is requesting an unknown protocol version"
+                );
+                return Err(anyhow::anyhow!(
+                    "Unknown protocol version {version} requested by client"
+                ));
             }
-            Request::Unlock { key, password } => {
-                client.unlock(key, password).await?;
-                Response::Unlock {}
-            }
-            Request::IsUnlocked { key } => Response::IsUnlocked {
-                unlocked: client.is_unlocked(key).await,
+            ipc_header = Some(header);
+            let mut response = serde_json::to_string(&IpcHeader::new())?;
+            response.push('\n');
+            responses.write_all(response.as_bytes()).await?;
+            continue;
+        };
+
+        let response = match serde_json::from_str::<Request>(&line) {
+            Ok(request) => match request {
+                Request::ListKeys {} => {
+                    let keys = client.list_keys().await?;
+                    Response::ListKeys { keys }
+                }
+                Request::Unlock { key, password } => {
+                    client.unlock(key, password).await?;
+                    Response::Unlock {}
+                }
+                Request::IsUnlocked { key } => Response::IsUnlocked {
+                    unlocked: client.is_unlocked(key).await,
+                },
+                Request::Sign {
+                    key,
+                    algorithm,
+                    digest,
+                } => {
+                    let signature = client.sign(key, algorithm, digest).await?;
+                    Response::Sign { signature }
+                }
             },
-            Request::Sign {
-                key,
-                algorithm,
-                digest,
-            } => {
-                let signature = client.sign(key, algorithm, digest).await?;
-                Response::Sign { signature }
+            Err(error) => {
+                match error.classify() {
+                    serde_json::error::Category::Io => {
+                        tracing::error!("Failed to read bytes from input stream");
+                        return Err(anyhow::anyhow!("Failed to read bytes from input stream"));
+                    }
+                    serde_json::error::Category::Syntax => {
+                        tracing::error!(column = error.column(), "Client sent invalid JSON");
+                        return Err(anyhow::anyhow!("Client sent invalid JSON"));
+                    }
+                    serde_json::error::Category::Eof => {
+                        tracing::error!("Unexpected end-of-line when deserializing JSON!");
+                        return Err(anyhow::anyhow!(
+                            "Unexpected end-of-line when deserializing JSON!"
+                        ));
+                    }
+                    serde_json::error::Category::Data => tracing::warn!(
+                        "Client sent a request of a type the proxy is not aware of (version mismatch?)"
+                    ),
+                }
+                tracing::warn!("Client sent an unknown request type or invalid JSON");
+                Response::Unsupported {}
             }
         };
         let mut response = serde_json::to_string(&response)?;
@@ -135,8 +217,12 @@ impl ProxyClient {
                 runtime.block_on(async move {
                     let mut client = IpcClient::new(&socket_path).await?;
                     tracing::info!(?socket_path, "Proxy client connected");
+                    // In the future when an version bump occurs we can use this to decide what to send
+                    // and what to expect in response.
+                    let server_ipc_version = client.request(&IpcHeader::new()).await?;
+                    tracing::debug!(?server_ipc_version, "Server IPC header received");
                     while let Some((request, response_tx)) = request_rx.recv().await {
-                        let response = client.request(&request, None).await.and_then(|v| {
+                        let response = client.request(&request).await.and_then(|v| {
                             serde_json::from_value(v)
                                 .map_err(|_| anyhow::anyhow!("Can't deserialize proxy response"))
                         });

--- a/siguldry/src/ipc_common.rs
+++ b/siguldry/src/ipc_common.rs
@@ -38,15 +38,11 @@ impl IpcClient {
     pub async fn request<R: ?Sized + serde::Serialize>(
         &mut self,
         request: &R,
-        bytes: Option<&[u8]>,
     ) -> anyhow::Result<serde_json::Value> {
         let mut request = serde_json::to_string(request)?;
         request.push('\n');
 
         self.writer.write_all(request.as_bytes()).await?;
-        if let Some(bytes) = bytes {
-            self.writer.write_all(bytes).await?;
-        }
         self.writer.flush().await?;
 
         match self.reader.next_line().await {

--- a/siguldry/src/server/ipc.rs
+++ b/siguldry/src/server/ipc.rs
@@ -126,15 +126,12 @@ impl Client {
             .to_string();
         client
             .inner
-            .request(
-                &Request::Config {
-                    user,
-                    database_path,
-                    session_id,
-                    pkcs11_bindings: bindings,
-                },
-                None,
-            )
+            .request(&Request::Config {
+                user,
+                database_path,
+                session_id,
+                pkcs11_bindings: bindings,
+            })
             .await?;
         tracing::trace!("requested signing helper config");
 
@@ -149,7 +146,7 @@ impl Client {
     ) -> Result<protocol::Response, ServerError> {
         let response = self
             .inner
-            .request(&Request::Unlock { key, password }, None)
+            .request(&Request::Unlock { key, password })
             .await?;
         let response = serde_json::from_value(response).map_err(|error| {
             tracing::error!(?error, "helper returned invalid response");
@@ -175,10 +172,7 @@ impl Client {
         key: String,
         digests: Vec<(DigestAlgorithm, String)>,
     ) -> Result<Vec<Signature>, ServerError> {
-        let response = self
-            .inner
-            .request(&Request::Sign { key, digests }, None)
-            .await?;
+        let response = self.inner.request(&Request::Sign { key, digests }).await?;
         let response = serde_json::from_value(response).map_err(|error| {
             tracing::error!(?error, "helper returned invalid response");
             ServerError::Internal


### PR DESCRIPTION
Before we deploy this widely, add a version as the first message sent by the proxy. This will let us change the protocol later gracefully. It also adds an "Unsupported" response so clients can discover if features are available or not.

Although most deployment cases involve the client and the pkcs11 module being the same version on the same host, for cases where content is being signed inside the RPM build, like UEFI applications, the versions may not match (the build host may be running, for example, Fedora 43 while the build is happening for Rawhide).