### PR TITLE
siguldry: no longer document needing capnproto

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -82,12 +82,10 @@ jobs:
         run: |
           dnf install -y \
             acl \
-            capnproto \
             clang \
             gnupg-pkcs11-scd \
             kryoptic \
             sequoia-sq \
-            sequoia-keystore-server \
             pesign \
             pkcs11-provider \
             pkg-config \
@@ -117,7 +115,6 @@ jobs:
         run: |
           sudo apt-get update
           sudo apt-get install -y \
-            capnproto \
             clang \
             libsqlite3-dev \
             libssl-dev \
@@ -176,12 +173,10 @@ jobs:
         run: |
           dnf install -y \
             acl \
-            capnproto \
             clang \
             gnupg-pkcs11-scd \
             kryoptic \
             sequoia-sq \
-            sequoia-keystore-server \
             pesign \
             pkcs11-provider \
             pkg-config \

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -19,7 +19,6 @@ test suite. This is expected to run on Fedora or RHEL, although it should work e
 
 ```bash
 dnf install -y \
-  capnproto \
   clang \
   kryoptic \
   opensc \
@@ -29,7 +28,6 @@ dnf install -y \
   pkcs11-provider \
   pkg-config \
   python3-devel \
-  sequoia-keystore-server \
   sequoia-sq \
   sqlite-devel
 ```

--- a/README.md
+++ b/README.md
@@ -33,7 +33,6 @@ management of the server, bridge, and client.
 To build all the components, you need the following system dependencies:
 
 - `cargo`
-- `capnproto` for sequoia-keystore
 - `clang` for libsqlite3-sys
 - `openssl` headers (provided by `openssl-devel` in Fedora and `libssl-dev` in Debian)
 - `sqlite` headers (provided by `sqlite-devel` in Fedora and `libsqlite3-dev` in Debian)


### PR DESCRIPTION
We don't use Sequoia's keystore so we don't need capnproto anymore.