### PR TITLE
siguldry: invert binding order for user passphrases

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -39,14 +39,46 @@ personal access key. This is done using Sequoia OpenPGP using AES-256-GCM. Since
 service is expected to be used by service accounts, there is no key derivation function applied
 to these personal access keys. Fedora uses 64 byte random strings.
 
-Optionally, the server can be configured with "bindings", which are used to encrypt the key
-passphrase and key itself. With this scheme, the passphrase is encrypted using a list of X509
+Optionally, the server can be configured with "bindings". If configured, both the PEM-encoded PKCS#8
+EncryptedPrivateKeyInfo and the user's personal access key are encrypted using a list of X509
 certificates provided in the server configuration. These certificates should correspond to private
-keys stored in a hardware token accessible via PKCS#11. For each certificate in the list, the
-passphrase is encrypted to a [CMS](https://www.rfc-editor.org/rfc/rfc5652) structure using
-AES-256-GCM. The list of encrypted passphrases is then serialized to JSON and the result is
-encrypted with the user's personal access key as described above. The EncryptedPrivateKeyInfo
-structure is encrypted using the same manner.
+keys stored in a hardware token accessible via PKCS#11. For each certificate in the list, the key
+and user personal access key is encrypted to a [CMS](https://www.rfc-editor.org/rfc/rfc5652)
+structure using AES-256-GCM. The list of encrypted keys and user personal access keys passphrases
+are then serialized to JSON and stored in their respective database tables.
+
+For example, the `encrypted_passphrase` column in a `key_accesses` database entry would look like
+this if no bindings are configured:
+
+```json
+[
+  {
+    "None": {
+      "secret": "-----BEGIN PGP MESSAGE-----\n\nw0wGGgkDCwMIKoQnCYAo+p7/ASQVDKXQHsJQgRXYNaxsJFM/aCWdtifXq5ISLQCs\n9Z30Hu9kMijeq0XW0ft/S7o/72kfF46zmtEgt+kl0lsCCQMGAt8yECM9A3CSXQvg\nsO0W6FFwadq+Rop/ltpQvNNnuDv2VIb4PgbZddi6lm9omoCssU8duth2KZiFq7dz\niapgan577BXP86LIMKFka95Hp0eSVpNr/jwk\n-----END PGP MESSAGE-----\n"
+    }
+  }
+]
+```
+
+If bindings are configured, the entry would look like:
+
+```json
+[
+  {
+    "Pkcs11WithCMS": {
+      "fingerprint": "87ACAE45EB6436A78A425389F7925C549CCA33527EB0563CD325D2B180E2E7F2",
+      "secret": "-----BEGIN CMS-----\nMIIC2gYLKoZIhvcNAQkQARegggLJMIICxQIBADGCAVMwggFPAgEAMDcwHzEdMBsG\nA1UEAwwUc2lndWxkcnktYmluZGluZy1rZXkCFFcbvBPbtFsk+9QtrZ7HcyJ96YNJ\nMA0GCSqGSIb3DQEBAQUABIIBADFlQzT9vdoQl0aL0VbAIcn/CljfxxtfYNHZfZBk\ngymO7qt6o8lMqpn4+P1RT0byn3whDF8Zbi+pDjYTBPPug5frfPksrYm5jjGI3Zhe\n/YIGrqdXJl/hQ0ZRcp+SkUdchEjO2dqTlP0SF6jg9OvVMVAE9YNZnNexWOQ3g13q\nyiM8dINe3OP/wnudVo4F1mslCDJshPMIRhSF+CLTZYFE+RNGvgLAG13WUNgl5RY8\nt0oZN7Gk717f1jUQHGrkbelnJad4ajA+EZxR6L0nRJLPeqHd2lf6n70CeKumQjBP\n5LzXavP7hOnYJCqA8Nv2N9rVGvomNPbYh4ryrQE97HgngEYwggFVBgkqhkiG9w0B\nBwEwHgYJYIZIAWUDBAEuMBEEDG6+qCHM6cQ6zhyD9gIBEICCASbMbmqHzUZKtNms\nNmGyr+QNa1+Nm+kEio4zcnfigJZ4bc54Z1hXOGUbtEsYigtZyyyjnHyoot/6bU3+\np7wqMofQMMgZVFnp3DBcfUYUXW3EyEDILOxfNJao6yDl2fwAb2l9x9bzJu7HqkSo\nK1Nplc6mqBtkZmed3CehLHrA80NfysC10jXaSPZul3vyKEzvSyds1dvETpwq8c/V\n4co83bwdrIpSe6IxAtRrz1i2wTEbYHsQcTZ4mnN0kvkaL0yYMW/m+el3isESAM5V\nIPScd45sGmT4ocESKB2AXe6kETorq95zzcEpKsdEhSneOn60zIndsz7sC8NTrZJO\nIgUCUf3EOrun+7bsrKyDKzJrabMne7jwKVl5/O7j8vCPoMnWqaaBYGfwURMEEF7L\njFoHe9PbvoWR0LXx4P4=\n-----END CMS-----\n"
+    }
+  }
+]
+```
+
+To access the password required to decrypt the signing key or access the HSM, the PKCS #11 module
+would need to be present. The server decrypts the value of the "secret" key with the PKCS #11
+module, then decrypts the output with the user-provided passphrase.
+
+The same scheme is used with private keys.
+
 
 #### PKCS#11 Keys
 

--- a/siguldry/src/server/crypto/binding.rs
+++ b/siguldry/src/server/crypto/binding.rs
@@ -128,9 +128,9 @@ impl BoundSecret {
         Ok(bound_secrets)
     }
 
-    pub(crate) fn unbind(&self, bindings: &[Pkcs11Binding]) -> anyhow::Result<Password> {
+    pub(crate) fn unbind(&self, bindings: &[Pkcs11Binding]) -> anyhow::Result<String> {
         match self {
-            BoundSecret::None { secret } => return Ok(Password::from(secret.as_bytes())),
+            BoundSecret::None { secret } => return Ok(secret.clone()),
             BoundSecret::Pkcs11WithCMS {
                 fingerprint,
                 secret,
@@ -138,8 +138,11 @@ impl BoundSecret {
                 for binding in bindings.iter().filter(|binding| binding.can_unbind()) {
                     if let Ok(secret) =
                         binding_decrypt(binding.clone(), secret.clone().into_bytes())
-                            .map(Password::from)
+                            .map(String::from_utf8)
                     {
+                        let secret = secret.map_err(|e| {
+                            anyhow::anyhow!("Unbound key material is not valid UTF-8: {e}")
+                        })?;
                         return Ok(secret);
                     } else {
                         tracing::debug!(
@@ -214,17 +217,20 @@ pub async fn decrypt_key_password(
     user_password: Password,
     data: &[u8],
 ) -> anyhow::Result<Password> {
-    let key_bindings: Vec<BoundSecret> = symmetric_decrypt(user_password, data)
-        .map(|data| serde_json::from_slice(&data))
-        .context("User password is invalid")?
+    let key_bindings: Vec<BoundSecret> = serde_json::from_slice(data)
         .map_err(|_e| anyhow::anyhow!("JSON content in database could not be deserialized!"))?;
-
-    key_bindings
+    let user_encrypted_key_password = key_bindings
         .iter()
         .map(|s| s.unbind(bindings).ok())
         .find(|result| result.is_some())
         .flatten()
-        .ok_or_else(|| anyhow::anyhow!("Unable to unbind key password"))
+        .ok_or_else(|| anyhow::anyhow!("Unable to unbind key password"))?;
+
+    let key_password = symmetric_decrypt(user_password, user_encrypted_key_password.as_bytes())
+        .map(Password::from)
+        .context("User password is invalid")?;
+
+    Ok(key_password)
 }
 
 /// Encrypt a key password for storage.
@@ -233,17 +239,16 @@ pub fn encrypt_key_password(
     user_password: Password,
     key_password: Password,
 ) -> anyhow::Result<Vec<u8>> {
-    let bound_passwords = key_password.map(|password| BoundSecret::bind(bindings, password))?;
+    let encrypted_key_password = key_password
+        .map(|key_password| symmetric_encrypt(user_password.clone(), key_password))
+        .context("Failed to PGP-encrypt the key password")?;
+    let bound_passwords = BoundSecret::bind(bindings, &encrypted_key_password)?;
 
     tracing::debug!(
         tokens_bound = bindings.len(),
         "Key password has been successfully bound"
     );
-    symmetric_encrypt(
-        user_password,
-        serde_json::to_vec(&bound_passwords)?.as_slice(),
-    )
-    .context("Failed to PGP-encrypt the bound password")
+    Ok(serde_json::to_vec(&bound_passwords)?)
 }
 
 /// Bind a string with the provided [`Pkcs11Binding`] and serialize it to JSON for database storage.
@@ -267,11 +272,6 @@ pub(crate) fn unbind_with_pkcs11(
         .iter()
         .find_map(|s| s.unbind(bindings).ok())
         .ok_or_else(|| anyhow::anyhow!("Unable to unbind key material"))
-        .and_then(|password| {
-            password
-                .map(|p| String::from_utf8(p.to_vec()))
-                .map_err(|e| anyhow::anyhow!("Unbound key material is not valid UTF-8: {e}"))
-        })
 }
 
 /// Decrypt a soft key's private key material.
@@ -610,10 +610,8 @@ mod tests {
             ),
             "Expected PKCS11 binding"
         );
-        let decrypted_data = bound_password
-            .unbind(&softhsm.bindings)?
-            .map(|p| p.to_vec());
-        assert_eq!(b"some data".as_slice(), decrypted_data);
+        let decrypted_data = bound_password.unbind(&softhsm.bindings)?;
+        assert_eq!("some data", decrypted_data);
 
         Ok(())
     }
@@ -664,7 +662,7 @@ mod tests {
 
         let key_password = Password::from("a secret that never leaves the server");
         let user_password = Password::from("some long password clients provide");
-        let blob = encrypt_key_password(&softhsm.bindings, user_password, key_password.clone())?;
+        let blob = encrypt_key_password(&[], user_password, key_password.clone())?;
         let user_password = Password::from("the wrong password");
         let result =
             decrypt_key_password(softhsm.bindings.get(1..).unwrap(), user_password, &blob).await;


### PR DESCRIPTION
It occurred to me, rather late in this whole process, that it's better to encrypt the key passphrase with the user passphrase and _then_ bind the result. This allows us to add additional bindings without needing the user's passphrase to do it, just one of the existing binding keys.

This is, unfortunately, a breaking change. In theory we could write a migration script to walk the key accesses, decrypt them, and reencrypt them in the new ordering, but the reality is that no one currently has this running (I assume, complain at me if that's not true).

Last breaking change, I promise.