### PR TITLE
siguldry-client: fix the default client config location

### DIFF
--- a/siguldry/src/bin/siguldry-client/main.rs
+++ b/siguldry/src/bin/siguldry-client/main.rs
@@ -15,8 +15,8 @@ use tokio_util::{sync::CancellationToken, task::TaskTracker};
 use tracing::Instrument;
 use tracing_subscriber::{EnvFilter, fmt::format::FmtSpan, layer::SubscriberExt};
 
-// The path, relative to $XDG_CONFIG_HOME, of the default config file location.
-const DEFAULT_CONFIG: &str = "siguldry/client.toml";
+// The path, relative to $CONFIGURATION_DIRECTORY, of the default config file location.
+const DEFAULT_CONFIG: &str = "client.toml";
 
 /// The siguldry client
 #[derive(Debug, Parser)]


### PR DESCRIPTION
The systemd unit and documentation indicates that it'll use CONFIGURATION_DIRECTORY, which is set by systemd. This is either relative to /etc/ or XDG_CONFIG_HOME, depending on whether it's a system unit or a user unit, and includes the "siguldry" prefix.

Prior to this, when using the systemd unit, it would expect the config at /etc/siguldry/siguldry/client.toml