### PR TITLE
siguldry: reject configs with unknown keys

### DIFF
--- a/siguldry/src/bridge.rs
+++ b/siguldry/src/bridge.rs
@@ -26,6 +26,7 @@ use crate::{
 
 /// Configuration for the siguldry bridge.
 #[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
 pub struct Config {
     /// The socket address to listen on for incoming connections from Siguldry servers.
     ///

--- a/siguldry/src/client/config.rs
+++ b/siguldry/src/client/config.rs
@@ -12,6 +12,7 @@ use crate::config::Credentials;
 
 /// Configuration for the siguldry client.
 #[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
 pub struct Config {
     /// The Siguldry server hostname. This is used to validate the server's TLS certificate.
     pub server_hostname: String,
@@ -67,6 +68,7 @@ impl std::fmt::Display for Config {
 
 /// A key to unlock for the client
 #[derive(Debug, Clone, Serialize)]
+#[serde(deny_unknown_fields)]
 pub struct Key {
     /// The name of the key in the Siguldry server.
     pub key_name: String,
@@ -155,6 +157,60 @@ mod tests {
             std::path::PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("client.toml.example");
         let example_conf = std::fs::read_to_string(&example_conf_path)?;
         toml::de::from_str::<super::Config>(&example_conf)?;
+
+        Ok(())
+    }
+
+    #[test]
+    fn config_extra_key() -> anyhow::Result<()> {
+        let config = r#"
+server_hostname = "server.example.com"
+bridge_hostname = "bridge.example.com"
+bridge_port = 44333
+another_key = 42
+
+[request_timeout]
+secs = 30
+nanos = 0
+
+[credentials]
+private_key = "siguldry.client.private_key.pem"
+certificate = "/etc/siguldry/client.cert"
+ca_certificate = "/etc/siguldry/ca.crt"
+        "#;
+
+        if let Err(error) = toml::from_str::<super::Config>(config) {
+            assert!(error.message().contains("unknown field `another_key`"));
+        } else {
+            panic!("Config should fail to load");
+        }
+
+        Ok(())
+    }
+
+    #[test]
+    fn timeout_extra_key() -> anyhow::Result<()> {
+        let config = r#"
+server_hostname = "server.example.com"
+bridge_hostname = "bridge.example.com"
+bridge_port = 44333
+
+[request_timeout]
+secs = 30
+nanos = 0
+another_key = 42
+
+[credentials]
+private_key = "siguldry.client.private_key.pem"
+certificate = "/etc/siguldry/client.cert"
+ca_certificate = "/etc/siguldry/ca.crt"
+        "#;
+
+        if let Err(error) = toml::from_str::<super::Config>(config) {
+            assert!(error.message().contains("unknown field `another_key`"));
+        } else {
+            panic!("Config should fail to load");
+        }
 
         Ok(())
     }

--- a/siguldry/src/config.rs
+++ b/siguldry/src/config.rs
@@ -1,7 +1,8 @@
 // SPDX-License-Identifier: MIT
 // Copyright (c) Microsoft Corporation.
-
-use std::{env, path::PathBuf};
+#[cfg(feature = "cli")]
+use std::env;
+use std::path::PathBuf;
 
 use anyhow::Context;
 use openssl::{
@@ -16,6 +17,7 @@ use serde::{Deserialize, Serialize};
 /// only accessible to the service using it. If the paths provided are relative, it is assumed
 /// to be relative to the `$CREDENTIALS_DIRECTORY` environment variable.
 #[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
 pub struct Credentials {
     /// The systemd credentials ID of the PEM-encoded private key file.
     ///
@@ -191,4 +193,30 @@ where
             private_load_config::<T>(&path)
         },
     )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::Credentials;
+
+    #[test]
+    fn creds_extra_key() -> anyhow::Result<()> {
+        let config = r#"
+private_key = "privkey.pem"
+certificate = "cert.pem"
+ca_certificate = "ca.pem"
+ca_key = "ca_key.pem"
+        "#;
+
+        if let Err(error) = toml::from_str::<Credentials>(config) {
+            assert_eq!(
+                error.message(),
+                "unknown field `ca_key`, expected one of `private_key`, `certificate`, `ca_certificate`"
+            );
+        } else {
+            panic!("Config should fail to load");
+        }
+
+        Ok(())
+    }
 }

--- a/siguldry/src/server/config.rs
+++ b/siguldry/src/server/config.rs
@@ -10,6 +10,7 @@ use crate::config::Credentials;
 
 /// Configuration for the siguldry server.
 #[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
 pub struct Config {
     /// The location where the server should store its state.
     ///
@@ -83,6 +84,7 @@ pub struct Config {
 ///
 /// The user provides the common name to use, all other values are defined here.
 #[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
 pub struct X509SubjectName {
     pub country: String,
     pub state_or_province: String,
@@ -108,6 +110,7 @@ impl Default for X509SubjectName {
 /// The server encrypts the secret needed to use a signing key with a user-provided password. It
 /// then encrypts _that_ with one or more secrets accessible only to the server.
 #[derive(Debug, Clone, Serialize, Deserialize, Default)]
+#[serde(deny_unknown_fields)]
 pub struct Pkcs11Binding {
     /// The PEM-encoded X509 certificate to use to encrypt secrets.
     pub certificate: PathBuf,
@@ -190,6 +193,85 @@ mod tests {
             std::path::PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("server.toml.example");
         let example_conf = std::fs::read_to_string(&example_conf_path)?;
         toml::de::from_str::<super::Config>(&example_conf)?;
+
+        Ok(())
+    }
+
+    #[test]
+    fn pkcs11_bindings_extra_key() -> anyhow::Result<()> {
+        let config = r#"
+certificate = "cert.pem"
+private_key = "pkcs11:token"
+other_key = 42
+        "#;
+
+        if let Err(error) = toml::from_str::<super::Pkcs11Binding>(config) {
+            assert_eq!(
+                error.message(),
+                "unknown field `other_key`, expected `certificate` or `private_key`"
+            );
+        } else {
+            panic!("Config should fail to load");
+        }
+
+        Ok(())
+    }
+
+    #[test]
+    fn x509_subject_name_extra_key() -> anyhow::Result<()> {
+        let config = r#"
+other_key = 42
+country = "US"
+state_or_province = "Maryland"
+locality = "Bethesda"
+organization = "Cat Caretaker"
+organizational_unit = "Primary Cat Scratcher"
+        "#;
+
+        if let Err(error) = toml::from_str::<super::X509SubjectName>(config) {
+            assert_eq!(
+                error.message(),
+                "unknown field `other_key`, expected one of \
+            `country`, `state_or_province`, `locality`, `organization`, `organizational_unit`"
+            );
+        } else {
+            panic!("Config should fail to load");
+        }
+
+        Ok(())
+    }
+
+    #[test]
+    fn config_extra_key() -> anyhow::Result<()> {
+        let config = r#"
+state_directory = "/var/lib/siguldry/"
+bridge_hostname = "bridge.example.com"
+bridge_port = 44333
+connection_pool_size = 16
+user_password_length = 64
+openpgp_user_id = "Fedora <fedora-openpgp@fedoraproject.org>"
+another_key = 42
+
+pkcs11_bindings = []
+
+[credentials]
+private_key = "siguldry.server.private_key.pem"
+certificate = "/etc/siguldry/server.cert"
+ca_certificate = "/etc/siguldry/ca.crt"
+
+[certificate_subject]
+country = "US"
+state_or_province = "Maryland"
+locality = "Bethesda"
+organization = "Cat Caretaker"
+organizational_unit = "Primary Cat Scratcher"
+        "#;
+
+        if let Err(error) = toml::from_str::<super::Config>(config) {
+            assert!(error.message().contains("unknown field `another_key`"));
+        } else {
+            panic!("Config should fail to load");
+        }
 
         Ok(())
     }


### PR DESCRIPTION
Similar to the change in PR #174, reject config files with unknown keys.