### PR TITLE
Clarify the design document

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -2,10 +2,11 @@
 
 This is a high-level description of the design of Siguldry.
 
-Siguldry leans heavily on systemd sandboxing and encryption features. In particular, every service
-is expected to use [systemd credentials](https://systemd.io/CREDENTIALS/) for private keys used for
-TLS authentication and for key passwords used by clients. It also makes heavy use of systemd
-sandboxing features.
+Siguldry leans heavily on systemd sandboxing and encryption features, and is not expected to work
+without them. Every service is expected to use [systemd
+credentials](https://systemd.io/CREDENTIALS/) for private keys used for TLS authentication and for
+key passwords used by clients. Socket-activated services are used to isolate client connections from
+each other and to ensure key material is never decrypted in the network-facing service.
 
 ## Server
 
@@ -19,15 +20,17 @@ there's not necessarily any hardware preventing a malicious administrator from e
 database containing signing keys. While the keys are encrypted with per-user credentials, the users
 that are administrating the server may also have access to credentials for a key.
 
-Each client unlocks keys separately, and this is enforced using a systemd-managed process for each
-client connection.
+Each client connection's signing operations are isolated from the main signing service and other
+connections using a systemd-managed socket-activated "helper" service. This helper, running in a
+separate process with additional systemd sandboxing features, is the only place signing keys are
+decrypted.
 
 ### Key Storage
 
 Signing keys are stored either in an SQLite database, or are provided by PKCS#11 tokens that have
 been registered with the service.
 
-#### Database Keys
+#### Database Signing Keys
 
 Private keys in the database are stored as PEM-encoded PKCS#8 EncryptedPrivateKeyInfo structures
 using AES-256-CBC.  The passphrase used to encrypt the key is 128 bytes of cryptographically strong
@@ -40,12 +43,17 @@ service is expected to be used by service accounts, there is no key derivation f
 to these personal access keys. Fedora uses 64 byte random strings.
 
 Optionally, the server can be configured with "bindings". If configured, both the PEM-encoded PKCS#8
-EncryptedPrivateKeyInfo and the user's personal access key are encrypted using a list of X509
+EncryptedPrivateKeyInfo and the user's personal access key are further encrypted using a list of X509
 certificates provided in the server configuration. These certificates should correspond to private
 keys stored in a hardware token accessible via PKCS#11. For each certificate in the list, the key
 and user personal access key is encrypted to a [CMS](https://www.rfc-editor.org/rfc/rfc5652)
 structure using AES-256-GCM. The list of encrypted keys and user personal access keys passphrases
 are then serialized to JSON and stored in their respective database tables.
+
+When configured with bindings, at least one of the configured binding certificates must be
+accompanied with the PKCS #11 URI to the associated private key. On server startup, the system
+administrator provides the user PIN needed to access that private key, which is used to decrypt the
+EncryptedPrivateKeyInfo structures and users personal access keys.
 
 For example, the `encrypted_passphrase` column in a `key_accesses` database entry would look like
 this if no bindings are configured:
@@ -73,23 +81,27 @@ If bindings are configured, the entry would look like:
 ]
 ```
 
-To access the password required to decrypt the signing key or access the HSM, the PKCS #11 module
-would need to be present. The server decrypts the value of the "secret" key with the PKCS #11
-module, then decrypts the output with the user-provided passphrase.
-
-The same scheme is used with private keys.
+With bindings, a malicious actor needs to steal both the SQLite database and the PKCS#11 token used
+for binding to access the keys.
 
 
-#### PKCS#11 Keys
+#### PKCS#11 Signing Keys
 
-For keys stored in a token accessible via PKCS#11, the administrator provides the user PIN to access
-to token. This PIN is then encrypted using the same process used by key passphrases described in the
-Database Keys section above.
+For signing keys stored in a token accessible via PKCS#11, the administrator registers the token
+and, as part of registration, provides the token's user PIN. This PIN is treated in the same manner
+as the server-generated password for a database key: it's encrypted with a user's personal access
+key, and then encrypted with any binding X509 certificates.
 
-Tokens may store multiple key pairs, and there's only one PIN protecting them. Siguldry clients
-never have access to the PIN itself and need to be granted access so the PIN is encrypted by their
-personal access key, but technically if there were a bug in the server, clients _could_ be able to
-sign content with other key pairs in the token.
+Siguldry never stores the actual private key material for signing keys backed by PKCS#11 tokens. At
+this time, administrators must use standard tools like pkcs11-tool to manage the tokens outside of
+Siguldry.
+
+PKCS#11 tokens may store multiple key pairs, and there's only one user PIN protecting them. Siguldry
+clients never have access to the PIN itself. If a client has been granted access to one key in a
+token, the server does not allow the client to perform signing operations with other keys in the
+token. However, this is a server-enforced rule rather than a cryptographically-enforced restriction
+so a flaw in the server could allow clients to perform signatures using other key pairs in a token
+it has been granted access to.
 
 ### Client Access
 

--- a/siguldry/docs/grant-key-access.dot
+++ b/siguldry/docs/grant-key-access.dot
@@ -1,0 +1,60 @@
+digraph grant_key_access {
+    rankdir=TB;
+    fontsize=18;
+    label="Granting a User Access to a Key";
+    labelloc=t;
+    compound=true;
+
+    node [fontsize=14, style=filled];
+    edge [fontsize=12];
+
+    subgraph cluster_decrypt {
+        label="Decrypt - Existing User";
+        labeljust=l;
+        style=dashed;
+        color="#5d0909";
+        fontcolor="#5d0909";
+
+        existing_user_password [label="existing_user_password", shape=box, fillcolor="#f9e79f"];
+
+        read_passphrase [label="SQLite\nkey_accesses.encrypted_passphrase\nexisting user", shape=cylinder, fillcolor="#fdebd0"];
+        unbound_passphrase [label="existing_user_encrypted_key_password\nAES-256-GCM", shape=box, fillcolor="#d5dbdb"];
+        read_passphrase -> unbound_passphrase [label="decrypt with\nbinding private key\nPKCS#11 + PIN"];
+        binding_key_dec [label="PKCS#11 Token\nBinding Private Key\nPIN on startup", shape=box3d, fillcolor="#ff6c6c"];
+        binding_key_dec -> unbound_passphrase [style=dotted, color="#888888"];
+
+        recovered_key_password [label="key_password", shape=box, fillcolor="#a9dfbf"];
+        unbound_passphrase -> recovered_key_password [label="decrypt with\nexisting_user_password"];
+        existing_user_password -> recovered_key_password [style=dashed, color="#888888"];
+    }
+
+    // Step 2: Re-encrypt the key_password for the new user
+    subgraph cluster_encrypt {
+        label="Re-encrypt - New User";
+        labeljust=l;
+        style=dashed;
+        color="#004a99";
+        fontcolor="#004a99";
+
+        new_user_password [label="new_user_password", shape=box, fillcolor="#f9e79f"];
+        reencrypted_key_password [label="key_password", shape=box, fillcolor="#a9dfbf"];
+
+        pgp_encrypted_pw [label="new_user_encrypted_key_password\nAES-256-GCM", shape=box, fillcolor="#d5dbdb"];
+        reencrypted_key_password -> pgp_encrypted_pw [label="encrypt with\nnew_user_password\nsymmetric OpenPGP"];
+        new_user_password -> pgp_encrypted_pw [style=dashed, color="#888888"];
+
+        binding_certs_enc [label="X509 Binding Certificates", shape=box3d, fillcolor="#ff6c6c"];
+        cms_password [label="PEM-encoded CMS\none per binding cert\nAES-256-GCM", shape=box, fillcolor="#d2b4de"];
+        pgp_encrypted_pw -> cms_password [label="encrypt with\neach X509 cert\n"];
+        binding_certs_enc -> cms_password [style=dotted, color="#888888"];
+
+        new_encrypted_passphrase [label="SQLite\nkey_accesses.encrypted_passphrase\nnew user", shape=cylinder, fillcolor="#fdebd0"];
+        cms_password -> new_encrypted_passphrase [label="serialize to JSON"];
+    }
+
+    // Connect the two clusters
+    recovered_key_password -> reencrypted_key_password [
+        style=dashed,
+        color="#2c3e50",
+    ];
+}

--- a/siguldry/docs/key-encrypt-decrypt-bindings.dot
+++ b/siguldry/docs/key-encrypt-decrypt-bindings.dot
@@ -1,0 +1,80 @@
+digraph database_key_encryption {
+    rankdir=TB;
+    fontsize=18;
+    label="Database Key Encryption & Decryption with PKCS#11 Bindings";
+    labelloc=t;
+    compound=true;
+
+    node [fontsize=14, style=filled];
+    edge [fontsize=12];
+
+    // Encryption
+    subgraph cluster_encrypt {
+        label="Encryption - Key Creation";
+        labeljust=l;
+        style=dashed;
+        color="#004a99";
+        fontcolor="#004a99";
+
+        // The key material itself
+        private_key [label="signing_private_key\nserver-generated", shape=box, fillcolor="#aed6f1"];
+        key_password [label="key_password\n128 random bytes\nserver-generated", shape=box, fillcolor="#a9dfbf"];
+        user_password_enc [label="user_password\nclient-provided", shape=box, fillcolor="#f9e79f"];
+
+        encrypted_pem [label="signing_private_key\nPEM-encoded PKCS#8\nAES-256-CBC", shape=box, fillcolor="#d5dbdb"];
+        private_key -> encrypted_pem [label="encrypt with\nkey_password"];
+        key_password -> encrypted_pem [style=dashed, color="#888888"];
+
+        cms_key_material [label="PEM-encoded CMS\none per binding cert\nAES-256-GCM", shape=box, fillcolor="#d2b4de"];
+        encrypted_pem -> cms_key_material [label="encrypt with\neach X509 cert\n"];
+        binding_certs_enc [label="X509 Binding Certificates", shape=box3d, fillcolor="#ff6c6c"];
+        binding_certs_enc -> cms_key_material [style=dotted, color="#888888"];
+
+        key_material_json [label="SQLite\nkeys.key_material\nJSON array of\nPEM-encoded CMS", shape=cylinder, fillcolor="#fdebd0"];
+        cms_key_material -> key_material_json [label="serialize to JSON"];
+
+        // The password used to encrypt the key material above
+        pgp_encrypted_pw [label="user_encrypted_key_password\nAES-256-GCM", shape=box, fillcolor="#d5dbdb"];
+        key_password -> pgp_encrypted_pw [label="encrypt with\nuser password\nsymmetric OpenPGP"];
+        user_password_enc -> pgp_encrypted_pw [style=dashed, color="#888888"];
+
+        cms_password [label="PEM-encoded CMS\none per binding cert\nAES-256-GCM", shape=box, fillcolor="#d2b4de"];
+        pgp_encrypted_pw -> cms_password [label="encrypt with\neach X509 cert\n"];
+        binding_certs_enc -> cms_password [style=dotted, color="#888888"];
+
+        encrypted_passphrase [label="SQLite\nkey_accesses.encrypted_passphrase\nJSON array of\nPEM-encoded CMS", shape=cylinder, fillcolor="#fdebd0"];
+        cms_password -> encrypted_passphrase [label="serialize to JSON"];
+    }
+
+    // Decryption
+    subgraph cluster_decrypt {
+        label="Decryption - User Unlocks Key";
+        labeljust=l;
+        style=dashed;
+        color="#5d0909";
+        fontcolor="#5d0909";
+
+        user_password_dec [label="user_password\nclient-provided", shape=box, fillcolor="#f9e79f"];
+
+        // Key password
+        read_passphrase [label="SQLite\nkey_accesses.encrypted_passphrase\nJSON array of\nPEM-encoded CMS\nfrom database", shape=cylinder, fillcolor="#fdebd0"];
+        unbound_passphrase [label="user_encrypted_key_password\nAES-256-GCM", shape=box, fillcolor="#d5dbdb"];
+        read_passphrase -> unbound_passphrase [label="decrypt with\nbinding private key\nPKCS#11 + PIN"];
+        binding_key_dec [label="PKCS#11 Token\nBinding Private Key\nPIN on startup", shape=box3d, fillcolor="#ff6c6c"];
+        binding_key_dec -> unbound_passphrase [style=dotted, color="#888888"];
+
+        recovered_key_password [label="key_password", shape=box, fillcolor="#a9dfbf"];
+        unbound_passphrase -> recovered_key_password [label="decrypt with\nuser_password"];
+        user_password_dec -> recovered_key_password [style=dashed, color="#888888"];
+
+        // The key material
+        read_key_material [label="SQLite\nkeys.key_material\nJSON array of\nPEM-encoded CMS\nfrom database", shape=cylinder, fillcolor="#fdebd0"];
+        unbound_pem [label="signing_private_key\nPEM-encoded PKCS#8\nAES-256-CBC", shape=box, fillcolor="#d5dbdb"];
+        read_key_material -> unbound_pem [label="decrypt with\nbinding private key\nPKCS#11 + PIN"];
+        binding_key_dec -> unbound_pem [style=dotted, color="#888888"];
+
+        recovered_private_key [label="signing_private_key", shape=box, fillcolor="#aed6f1"];
+        unbound_pem -> recovered_private_key [label="decrypt PKCS#8 PEM\nwith key_password"];
+        recovered_key_password -> recovered_private_key [style=dashed, color="#888888"];
+    }
+}

--- a/siguldry/docs/key-encrypt-decrypt-no-bindings.dot
+++ b/siguldry/docs/key-encrypt-decrypt-no-bindings.dot
@@ -1,0 +1,64 @@
+digraph database_key_encryption {
+    rankdir=TB;
+    fontsize=18;
+    label="Database Key Encryption & Decryption without Bindings";
+    labelloc=t;
+    compound=true;
+
+    node [fontsize=14, style=filled];
+    edge [fontsize=12];
+
+    // Encryption
+    subgraph cluster_encrypt {
+        label="Encryption - Key Creation";
+        labeljust=l;
+        style=dashed;
+        color="#004a99";
+        fontcolor="#004a99";
+
+        // The key material itself
+        private_key [label="signing_private_key\nserver-generated", shape=box, fillcolor="#aed6f1"];
+        key_password [label="key_password\n128 random bytes\nserver-generated", shape=box, fillcolor="#a9dfbf"];
+        user_password_enc [label="user_password\nclient-provided", shape=box, fillcolor="#f9e79f"];
+
+        encrypted_pem [label="signing_private_key\nPEM-encoded PKCS#8\nAES-256-CBC", shape=box, fillcolor="#d5dbdb"];
+        private_key -> encrypted_pem [label="encrypt with\nkey_password"];
+        key_password -> encrypted_pem [style=dashed, color="#888888"];
+
+        key_material_json [label="SQLite\nkeys.key_material\nPEM-encoded PKCS#8", shape=cylinder, fillcolor="#fdebd0"];
+        encrypted_pem -> key_material_json [label="serialize to JSON"];
+
+        // The password used to encrypt the key material above
+        pgp_encrypted_pw [label="user_encrypted_key_password\nAES-256-GCM", shape=box, fillcolor="#d5dbdb"];
+        key_password -> pgp_encrypted_pw [label="encrypt with\nuser password\nsymmetric OpenPGP"];
+        user_password_enc -> pgp_encrypted_pw [style=dashed, color="#888888"];
+
+        encrypted_passphrase [label="SQLite\nkey_accesses.encrypted_passphrase\nASCII-Armored OpenPGP", shape=cylinder, fillcolor="#fdebd0"];
+        pgp_encrypted_pw -> encrypted_passphrase [label="serialize to JSON"];
+    }
+
+    // Decryption
+    subgraph cluster_decrypt {
+        label="Decryption - User Unlocks Key";
+        labeljust=l;
+        style=dashed;
+        color="#5d0909";
+        fontcolor="#5d0909";
+
+        user_password_dec [label="user_password\nclient-provided", shape=box, fillcolor="#f9e79f"];
+
+        // Key password
+        decrypt_encrypted_passphrase [label="SQLite\nkey_accesses.encrypted_passphrase\nASCII-Armored OpenPGP", shape=cylinder, fillcolor="#fdebd0"];
+        recovered_key_password [label="key_password", shape=box, fillcolor="#a9dfbf"];
+        decrypt_encrypted_passphrase -> recovered_key_password [label="decrypt with\nuser_password"];
+
+        user_password_dec -> recovered_key_password [style=dashed, color="#888888"];
+
+        // The key material
+        read_key_material [label="SQLite\nkeys.key_material\nPEM-encoded PKCS#8", shape=cylinder, fillcolor="#fdebd0"];
+        read_key_material -> recovered_private_key [label="decrypt PKCS#8 PEM\nwith key_password"];
+
+        recovered_private_key [label="signing_private_key", shape=box, fillcolor="#aed6f1"];
+        recovered_key_password -> recovered_private_key [style=dashed, color="#888888"];
+    }
+}


### PR DESCRIPTION
Based on feedback from Simo Sorce, attempt to clarify the design document. Notes included:

  - The bindings description was confusing
  - It wasn't clear that the HSM PIN alone was stored, and not a copy of the private key.
  - The interaction of the per-connection service with the main service, and its exact purpose, were unclear.