### PR TITLE
Document Container Signing with Cosign

### DIFF
--- a/siguldry-pkcs11/README.md
+++ b/siguldry-pkcs11/README.md
@@ -141,9 +141,13 @@ $ /usr/lib/systemd/systemd-measure --private-key="pkcs11:token=pcr-signing-key" 
     sign --current --bank=sha256 
 ```
 
-### Cosign
+### Container Signing
 
-You can sign container images using `cosign`, if it was compiled with PKCS#11 support (which is not the default). More information on this can be found in Cosign's documentation [here](https://docs.sigstore.dev/cosign/signing/pkcs11/).
+The recommended method for signing Container Images is using [Cosign](https://github.com/sigstore/cosign). Depending on how you want to manage the `cosign` binary, there are different signing flows which are explained below.
+
+#### Cosign with PKCS#11 Support
+
+You can sign container images directly using `cosign` if it was compiled with PKCS#11 support (which is not the default). More information on this can be found in Cosign's documentation [here](https://docs.sigstore.dev/cosign/signing/pkcs11/).
 
 With the proxy running, you can list keys using the following command. This will output longer-format PKCS#11 URIs, but the `token=` style ones used above should also work (though you may need to append `;object=` with the same key name to the PKCS#11 URI). The certificate must also have a SAN set to an `email:` or `URI:` value.
 
@@ -166,3 +170,30 @@ $ COSIGN_PKCS11_MODULE_PATH=/path/to/libsiguldry_pkcs11.so cosign verify-blob --
 ```
 
 You will need to add `--insecure-ignore-tlog=true` if you didn't upload the certificate transparency log entry.
+
+#### Cosign with OpenSSL Signing
+
+To avoid needing to recompile Cosign with PKCS#11 support, you can also use the OpenSSL CLI to generate a signature and then verify it with Cosign. This is more manual, but may be easier for testing. More information about this flow can be found [here](https://docs.sigstore.dev/cosign/signing/signing_with_containers/#sign-and-upload-a-generated-payload-in-another-format-from-another-tool)
+
+Generate the payload for signing:
+
+```bash
+$ cosign generate <image reference> > payload.json
+```
+
+Then sign the payload with OpenSSL:
+
+```bash
+$ PKCS11_PROVIDER_MODULE=/path/to/libsiguldry_pkcs11.so openssl \
+    pkeyutl -sign -rawin \
+    -provider pkcs11 -inkey 'pkcs11:token=siguldry-key-name' \
+    -in payload.json -digest sha256 | base64 > signature.base64
+```
+
+You can use the same Cosign command as above to verify the signature, and the below command to publish the signed version.
+
+```bash
+$ cosign attach signature --payload payload.json --signature signature.base64 <image reference>
+```
+
+Note that signing using this method will not produce a certificate transparency log entry. Cosign will recognize this and skip the check, but it does result in a less cryptographically-sound verification process.

--- a/siguldry-pkcs11/README.md
+++ b/siguldry-pkcs11/README.md
@@ -140,3 +140,29 @@ $ /usr/lib/systemd/systemd-measure --private-key="pkcs11:token=pcr-signing-key" 
     --certificate=./pcr-signing-cert.pem \
     sign --current --bank=sha256 
 ```
+
+### Cosign
+
+You can sign container images using `cosign`, if it was compiled with PKCS#11 support (which is not the default). More information on this can be found in Cosign's documentation [here](https://docs.sigstore.dev/cosign/signing/pkcs11/).
+
+With the proxy running, you can list keys using the following command. This will output longer-format PKCS#11 URIs, but the `token=` style ones used above should also work (though you may need to append `;object=` with the same key name to the PKCS#11 URI). The certificate must also have a SAN set to an `email:` or `URI:` value.
+
+```bash
+$ COSIGN_PKCS11_MODULE_PATH=/path/to/libsiguldry_pkcs11.so cosign pkcs11-tool list-keys-uris
+```
+
+And then sign an image with:
+
+```bash
+$ COSIGN_PKCS11_MODULE_PATH=/path/to/libsiguldry_pkcs11.so cosign sign --output-signature=signature.base64 --output-payload=payload.json --key 'pkcs11:token=siguldry-key-name;object=siguldry-key-name' <image reference>
+```
+
+When testing, you may want to use `--upload=false --use-signing-config=false --tlog-upload=false` to disable certificate transparency as it will cause issues when repeatedly signing the same payload, or if you don't have permission to push to the registry.
+
+The signature can then be verified with the public key from Siguldry:
+
+```bash
+$ COSIGN_PKCS11_MODULE_PATH=/path/to/libsiguldry_pkcs11.so cosign verify-blob --key "pkcs11:token=siguldry-key-name;object=siguldry-key-name" --signature=signature.base64 payload.json
+```
+
+You will need to add `--insecure-ignore-tlog=true` if you didn't upload the certificate transparency log entry.


### PR DESCRIPTION
As far as I can tell this process works, I've been able to sign an image from Quay and verify the generated signature.

There are still a few blockers to us signing containers in the Fedora infrastructure (not packaging `cosign` being a big one), but if the opportunity exists then I'd be up for helping with that. I've been testing against Siguldry in containers, though I think it'd work against the existing Sigul infrastructure.

Resolves #49

Signed-off-by: Daniel Milnes <daniel@daniel-milnes.uk>
