### PR TITLE
siguldry: clean up the mixture of sigul/siguldry references

### DIFF
--- a/devel/siguldry_auth_keys.sh
+++ b/devel/siguldry_auth_keys.sh
@@ -12,7 +12,7 @@
 # bridge commonName, and one or more client commonNames.
 #
 # For testing purposes, when all three services run on a single host,
-# "sigul-server", "localhost", and "sigul-client" are recommended.
+# "siguldry-server", "localhost", and "siguldry-client" are recommended.
 
 set -xeuo pipefail
 

--- a/siguldry/Cargo.toml
+++ b/siguldry/Cargo.toml
@@ -6,7 +6,7 @@ rust-version = { workspace = true }
 version = "0.7.0"
 readme = "README.md"
 description = """
-An implementation of the Sigul protocol.
+A signing server and client.
 """
 keywords = ["pesign", "sigul", "fedora"]
 repository = "https://github.com/fedora-infra/siguldry"

--- a/siguldry/src/config.rs
+++ b/siguldry/src/config.rs
@@ -22,8 +22,8 @@ pub struct Credentials {
     /// The systemd credentials ID of the PEM-encoded private key file.
     ///
     /// This private key is the key that matches the `certificate` and is used to authenticate
-    /// with the Sigul bridge. It is expected to be provided by systemd's "ImportCredential" or
-    /// "LoadCredentialEncrypted" option.
+    /// with the Siguldry bridge. It is expected to be provided by systemd's "ImportCredential"
+    /// or "LoadCredentialEncrypted" option.
     ///
     /// # Example
     ///

--- a/siguldry/src/error.rs
+++ b/siguldry/src/error.rs
@@ -29,7 +29,7 @@ pub enum ConnectionError {
     #[error("one or more openssl errors occurred: {0}")]
     SslErrors(#[from] openssl::error::ErrorStack),
 
-    /// The TLS connection to the Sigul bridge or the Sigul server failed.
+    /// The TLS connection to the bridge or server failed.
     ///
     /// This could be due to a protocol level failure, like a handshake failure
     /// due to no common supported versions/ciphers/etc, or because the TLS
@@ -40,7 +40,7 @@ pub enum ConnectionError {
     #[error("an SSL error occurred: {0}")]
     Ssl(#[from] openssl::ssl::Error),
 
-    /// A Sigul protocol violation occurred.
+    /// A protocol violation occurred.
     ///
     /// This occurs if the handshake is malformed, the framing is invalid, etc.
     /// This is almost certainly a bug.
@@ -76,14 +76,14 @@ where
 #[derive(Debug, thiserror::Error)]
 #[non_exhaustive]
 pub enum ClientError {
-    /// Returned in the event that an error occurred while communicating with the Sigul bridge or
-    /// Sigul server. This may be a result of a transient networking problem, or because of a more
+    /// Returned in the event that an error occurred while communicating with the bridge or
+    /// server. This may be a result of a transient networking problem, or because of a more
     /// permanent issue such as invalid configuration, or event a client bug.
     ///
     /// Retrying the operation that led to this error is safe, although whether subsequent
     /// attempts fail or succeed depend on the specific error.  Refer to [`ConnectionError`] for
     /// details on the possible errors and if retrying is advisable.
-    #[error("connection error with Sigul bridge or server: {0}")]
+    #[error("connection error with bridge or server: {0}")]
     Connection(#[from] ConnectionError),
 
     /// A general I/O error occurred, unrelated to the underlying network connection. It is likely

--- a/siguldry/src/nestls.rs
+++ b/siguldry/src/nestls.rs
@@ -19,7 +19,7 @@
 //!
 //! The high-level connection flow is as follows:
 //!
-//! 1. A TLS connection to the Sigul bridge is made and both sides offer x509 certificates to be
+//! 1. A TLS connection to the bridge is made and both sides offer x509 certificates to be
 //!    verified.
 //!
 //! 2. A protocol header is sent which is a magic number, a protocol version, and
@@ -63,7 +63,7 @@ pub struct NestlsBuilder {
 ///
 /// Use [`AsyncRead`] and [`AsyncWrite`] to read and write to the inner TLS session.
 pub struct Nestls {
-    /// The TLS connection to the Sigul server.
+    /// The TLS connection to the Siguldry server.
     inner: SslStream<SslStream<TcpStream>>,
     /// A shared ID between the client and the server identifying this connection.
     session_id: Uuid,

--- a/siguldry/src/protocol.rs
+++ b/siguldry/src/protocol.rs
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: MIT
 // Copyright (c) Microsoft Corporation.
 
-//! The structures used in the Sigul protocol.
+//! The structures used in the Siguldry protocol.
 //!
 //! All structures described in this documenation are to be sent in network byte order (big endian).
 //!
@@ -87,7 +87,7 @@ use crate::error::ConnectionError;
 
 /// Magic number used in the protocol header.
 pub const MAGIC: U64 = U64::from_bytes([83, 73, 71, 85, 76, 68, 82, 89]);
-/// The Sigul wire protocol version this implementation supports
+/// The Siguldry wire protocol version this implementation supports
 pub const PROTOCOL_VERSION: U32 = U32::new(2);
 
 /// The possible roles a connection can have.

--- a/siguldry/src/server/config.rs
+++ b/siguldry/src/server/config.rs
@@ -33,11 +33,11 @@ pub struct Config {
     #[serde(default = "default_socket_path")]
     pub signer_socket_path: PathBuf,
 
-    /// The hostname of the Sigul bridge; this is used to verify the bridge's
+    /// The hostname of the Siguldry bridge; this is used to verify the bridge's
     /// TLS certificate.
     pub bridge_hostname: String,
 
-    /// The port to connect to the Sigul bridge; the default port is 44333 for
+    /// The port to connect to the Siguldry bridge; the default port is 44333 for
     /// the server.
     pub bridge_port: u16,
 

--- a/siguldry/src/server/service.rs
+++ b/siguldry/src/server/service.rs
@@ -28,7 +28,7 @@ use crate::{
 // The maximum request size; this should be configurable.
 const MAX_JSON_SIZE: usize = 1024 * 32;
 
-/// A sigul server.
+/// A server instance.
 pub struct Server {
     config: Arc<Config>,
     db_pool: Pool<Sqlite>,


### PR DESCRIPTION
A number of strings and docblocks used sigul and siguldry interchangeably in a way that might be confusing.