### PR TITLE
siguldry: fix clippy lints new in 1.95

### DIFF
--- a/siguldry/src/server/crypto/binding.rs
+++ b/siguldry/src/server/crypto/binding.rs
@@ -315,8 +315,7 @@ impl DecryptionHelper for SymmetricHelper {
         for session_key in symmetric_session_keys {
             if session_key
                 .decrypt(&self.password)
-                .map(|(algorithm, session_key)| decrypt(algorithm, &session_key))
-                .unwrap_or(false)
+                .is_ok_and(|(algorithm, session_key)| decrypt(algorithm, &session_key))
             {
                 return Ok(None);
             }

--- a/siguldry/src/server/db.rs
+++ b/siguldry/src/server/db.rs
@@ -282,8 +282,7 @@ impl Pkcs11Token {
             .find(|slot| {
                 pkcs11
                     .get_token_info(*slot)
-                    .map(|info| info.serial_number() == self.serial_number)
-                    .unwrap_or(false)
+                    .is_ok_and(|info| info.serial_number() == self.serial_number)
             })
             .ok_or_else(|| {
                 anyhow::anyhow!(


### PR DESCRIPTION
Replaces map->unwrap_or with is_ok_and