### PR TITLE
sigul-pesign-bridge: retry all failed requests

### DIFF
--- a/sigul-pesign-bridge/CHANGELOG.md
+++ b/sigul-pesign-bridge/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.10.0] - 2026-04-20
+
+### Changed
+
+- All requests to sigul are retried, rather than just those that fail due  to I/O or timeouts (#195)
+
+
 ## [0.9.0] - 2026-04-06
 
 ### Changed

--- a/sigul-pesign-bridge/Cargo.toml
+++ b/sigul-pesign-bridge/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sigul-pesign-bridge"
-version = "0.9.0"
+version = "0.10.0"
 edition = { workspace = true }
 rust-version = { workspace = true }
 license = "MIT"

--- a/sigul-pesign-bridge/docs/sigul-pesign-bridge.1
+++ b/sigul-pesign-bridge/docs/sigul-pesign-bridge.1
@@ -1,6 +1,6 @@
 .ie \n(.g .ds Aq \(aq
 .el .ds Aq '
-.TH sigul-pesign-bridge 1  "sigul-pesign-bridge 0.9.0" 
+.TH sigul-pesign-bridge 1  "sigul-pesign-bridge 0.10.0" 
 .SH NAME
 sigul\-pesign\-bridge \- An alternative to the pesign daemon interface
 .SH SYNOPSIS
@@ -47,4 +47,4 @@ Print the current service configuration to standard output
 sigul\-pesign\-bridge\-help(1)
 Print this message or the help of the given subcommand(s)
 .SH VERSION
-v0.9.0
+v0.10.0

--- a/sigul-pesign-bridge/src/service.rs
+++ b/sigul-pesign-bridge/src/service.rs
@@ -19,7 +19,6 @@ use std::{
 
 use anyhow::{Context as AnyhowContext, anyhow};
 use bytes::Bytes;
-use siguldry::v1::error::ClientError;
 use tokio::{
     io::{AsyncReadExt, AsyncWriteExt},
     net::{UnixListener, UnixStream},
@@ -467,13 +466,9 @@ async fn sign_attached_with_filetype(
             Ok(Ok(_)) => {
                 break;
             }
-            Ok(Err(ClientError::Connection(error))) => {
-                tracing::warn!(%error, "signing failed; retrying sigul request in 2 seconds");
-                tokio::time::sleep(Duration::from_secs(2)).await;
-            }
             Ok(Err(error)) => {
-                tracing::error!(%error, "signing failed due to an unrecoverable error");
-                return Err(error.into());
+                tracing::error!(%error, "signing failed; retrying sigul request in 2 seconds");
+                tokio::time::sleep(Duration::from_secs(2)).await;
             }
             Err(_error) => {
                 tracing::warn!("Sigul signing request timed out; retrying...");


### PR DESCRIPTION
Previously, we'd only try requests if they failed due to an I/O error or if they timed out. In cases where Sigul returns an error code, we would never retry. Unfortunately, Sigul's error codes are pretty limited and it can return, for example, UNKNOWN_ERROR when a server-side timeout is hit.