### PR TITLE
siguldry-pkcs11 2.1.0

### DIFF
--- a/siguldry-pkcs11/CHANGELOG.md
+++ b/siguldry-pkcs11/CHANGELOG.md
@@ -5,6 +5,20 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.1.0] - 2026-05-15
+
+### Added
+
+- The module now accepts an environment variable, LIBSIGULDRY_PKCS11_KEYS, to control what
+  keys are exposed as tokens (#201)
+
+### Changed
+
+- The default log level for the module is now WARN, rather than INFO (#201)
+
+- The log level for function instrumentation on most PKCS11 functions has been dropped to
+  DEBUG as it was overly verbose for info-level logs (#201)
+
 ## [2.0.0] - 2026-03-27
 
 ### Changed

--- a/siguldry-pkcs11/Cargo.toml
+++ b/siguldry-pkcs11/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "siguldry-pkcs11"
-version = "2.0.0"
+version = "2.1.0"
 rust-version.workspace = true
 edition.workspace = true
 license.workspace = true

--- a/siguldry-pkcs11/README.md
+++ b/siguldry-pkcs11/README.md
@@ -19,12 +19,15 @@ proxy`.  This socket needs to be configured before using this module.
 To do so, start the systemd socket `siguldry-client-proxy.socket`. Refer to the documentation for
 `siguldry-client proxy` for more details.
 
-The module reads two environment variables:
+The module reads three environment variables:
 
 - `LIBSIGULDRY_PKCS11_PROXY_PATH` - if set, it should contain the absolute path to the Unix socket
   provided by `siguldry-client proxy`. The default is `/run/siguldry-client-proxy/siguldry-client-proxy.socket`, which matches the systemd unit.
 - `LIBSIGULDRY_PKCS11_LOG` - if set, it is used to configure the logging filter via [envfilter
   directives](https://docs.rs/tracing-subscriber/0.3.22/tracing_subscriber/filter/struct.EnvFilter.html#directives)
+- `LIBSIGULDRY_PKCS11_KEYS` - if set, it should contain a comma-separated list of Siguldry key names,
+  any only these keys will be exposed as tokens by the module. The primary use-case is for tools,
+  primarily gnupg-pkcs11-scd, which don't handle multiple tokens well.
 
 ## Example Uses
 

--- a/siguldry-pkcs11/README.md
+++ b/siguldry-pkcs11/README.md
@@ -24,7 +24,8 @@ The module reads three environment variables:
 - `LIBSIGULDRY_PKCS11_PROXY_PATH` - if set, it should contain the absolute path to the Unix socket
   provided by `siguldry-client proxy`. The default is `/run/siguldry-client-proxy/siguldry-client-proxy.socket`, which matches the systemd unit.
 - `LIBSIGULDRY_PKCS11_LOG` - if set, it is used to configure the logging filter via [envfilter
-  directives](https://docs.rs/tracing-subscriber/0.3.22/tracing_subscriber/filter/struct.EnvFilter.html#directives)
+  directives](https://docs.rs/tracing-subscriber/0.3.22/tracing_subscriber/filter/struct.EnvFilter.html#directives).
+  The default log level is `WARN`.
 - `LIBSIGULDRY_PKCS11_KEYS` - if set, it should contain a comma-separated list of Siguldry key names,
   any only these keys will be exposed as tokens by the module. The primary use-case is for tools,
   primarily gnupg-pkcs11-scd, which don't handle multiple tokens well.

--- a/siguldry-pkcs11/src/lib.rs
+++ b/siguldry-pkcs11/src/lib.rs
@@ -82,7 +82,7 @@ const ECDSA_MECHANISMS: [CK_MECHANISM_TYPE; 5] = [
 static LOGGING: LazyLock<()> = LazyLock::new(|| {
     let log_filter = EnvFilter::builder()
         .with_env_var("LIBSIGULDRY_PKCS11_LOG")
-        .with_default_directive(LevelFilter::INFO.into())
+        .with_default_directive(LevelFilter::WARN.into())
         .from_env()
         .expect("Set a valid log filter");
     let stderr_layer = tracing_subscriber::fmt::layer()

--- a/siguldry-pkcs11/src/lib.rs
+++ b/siguldry-pkcs11/src/lib.rs
@@ -185,6 +185,35 @@ extern "C" fn C_Initialize(pInitArgs: *mut ::std::os::raw::c_void) -> CK_RV {
         }
     };
 
+    // Optionally restrict the set of tokens this module exposes to a comma-separated
+    // list of key names provided in the LIBSIGULDRY_PKCS11_KEYS environment variable.
+    //
+    // This is necessary when this module is used through gnupg-pkcs11-scd: that daemon
+    // can only present a single token to gpg-agent at a time, and asks the user (via a
+    // NEEDPIN/NEEDTOKEN callback) to "insert" any other token whenever a key on a
+    // different token is requested. Limiting the visible tokens prevents those prompts
+    // and the resulting hangs in non-interactive contexts.
+    let keys = match std::env::var("LIBSIGULDRY_PKCS11_KEYS") {
+        Ok(filter) => {
+            let allowed: Vec<&str> = filter
+                .split(',')
+                .map(|s| s.trim())
+                .filter(|s| !s.is_empty())
+                .collect();
+            let filtered: Vec<_> = keys
+                .into_iter()
+                .filter(|k| allowed.iter().any(|name| *name == k.name))
+                .collect();
+            tracing::info!(
+                allowed = ?allowed,
+                tokens_exposed = filtered.len(),
+                "Restricting exposed tokens to those listed in LIBSIGULDRY_PKCS11_KEYS"
+            );
+            filtered
+        }
+        Err(_) => keys,
+    };
+
     let mut client = CLIENT.lock().expect("client lock is poisoned");
     if client.is_some() {
         tracing::error!("The module was already initialized");

--- a/siguldry-pkcs11/src/lib.rs
+++ b/siguldry-pkcs11/src/lib.rs
@@ -619,12 +619,19 @@ extern "C" fn C_GetTokenInfo(slotID: CK_SLOT_ID, pInfo: CK_TOKEN_INFO_PTR) -> CK
         .map(|client| client.is_unlocked(token.name.clone()))
     {
         Some(Ok(true)) => {
+            tracing::debug!(
+                token.name,
+                "Token is configured for protected authentication path"
+            );
             CKF_TOKEN_INITIALIZED
                 | CKF_LOGIN_REQUIRED
                 | CKF_USER_PIN_INITIALIZED
                 | CKF_PROTECTED_AUTHENTICATION_PATH
         }
-        Some(Ok(false)) => CKF_TOKEN_INITIALIZED | CKF_LOGIN_REQUIRED | CKF_USER_PIN_INITIALIZED,
+        Some(Ok(false)) => {
+            tracing::debug!(token.name, "Token requires PIN to access the private key");
+            CKF_TOKEN_INITIALIZED | CKF_LOGIN_REQUIRED | CKF_USER_PIN_INITIALIZED
+        }
         Some(Err(error)) => {
             tracing::error!(?error, "Failed to check if the key is unlocked");
             return CKR_FUNCTION_FAILED;
@@ -721,7 +728,7 @@ extern "C" fn C_Login(
                 "Protected authentication path succeeded"
             ),
             Some(Ok(false)) => {
-                tracing::info!(
+                tracing::warn!(
                     key = session.key.name,
                     "Protected authentication path failed; siguldry proxy not configured to auto-unlock key"
                 );
@@ -733,10 +740,6 @@ extern "C" fn C_Login(
             }
             None => return CKR_CRYPTOKI_NOT_INITIALIZED,
         }
-        tracing::info!(
-            key = session.key.name,
-            "Protected authentication path specified; configure the siguldry client to unlock key"
-        );
     }
 
     // The specification states "each of the applications sessions will enter the state" so we

--- a/siguldry-pkcs11/src/lib.rs
+++ b/siguldry-pkcs11/src/lib.rs
@@ -20,7 +20,7 @@ use std::{
 
 use cryptoki::context::CInitializeFlags;
 use siguldry::protocol;
-use tracing::{instrument, level_filters::LevelFilter};
+use tracing::{Level, instrument, level_filters::LevelFilter};
 
 use cryptoki_sys::{
     CK_ATTRIBUTE, CK_BBOOL, CK_C_INITIALIZE_ARGS_PTR, CK_FLAGS, CK_FUNCTION_LIST,
@@ -775,7 +775,7 @@ extern "C" fn C_Logout(hSession: CK_SESSION_HANDLE) -> CK_RV {
     CKR_OK
 }
 
-#[instrument(ret)]
+#[instrument(level = Level::DEBUG, ret)]
 extern "C" fn C_GetMechanismList(
     slotID: CK_SLOT_ID,
     pMechanismList: *mut CK_MECHANISM_TYPE,
@@ -836,7 +836,7 @@ extern "C" fn C_GetMechanismList(
     CKR_OK
 }
 
-#[instrument(ret)]
+#[instrument(level = Level::DEBUG, ret)]
 extern "C" fn C_GetMechanismInfo(
     slotID: CK_SLOT_ID,
     type_: CK_MECHANISM_TYPE,
@@ -901,7 +901,7 @@ extern "C" fn C_GetMechanismInfo(
 /// OR
 ///
 /// ulCount is 0 in which case all objects are returned and the value of pTemplate can be anything.
-#[instrument(ret)]
+#[instrument(level = Level::DEBUG, ret)]
 extern "C" fn C_FindObjectsInit(
     hSession: CK_SESSION_HANDLE,
     pTemplate: *mut CK_ATTRIBUTE,
@@ -950,7 +950,7 @@ extern "C" fn C_FindObjectsInit(
     CKR_OK
 }
 
-#[instrument(ret)]
+#[instrument(level = Level::DEBUG, ret)]
 extern "C" fn C_FindObjects(
     hSession: CK_SESSION_HANDLE,
     phObject: *mut CK_OBJECT_HANDLE,
@@ -991,7 +991,7 @@ extern "C" fn C_FindObjects(
 }
 
 /// Implemented as described in section 5.7.9 of PKCS #11 version 3.2.
-#[instrument(ret)]
+#[instrument(level = Level::DEBUG, ret)]
 extern "C" fn C_FindObjectsFinal(hSession: CK_SESSION_HANDLE) -> CK_RV {
     let mut sessions = SESSIONS.lock().expect("session lock was poisoned");
     let session = if let Some(session) = sessions.get_mut(&hSession) {
@@ -1012,7 +1012,7 @@ extern "C" fn C_FindObjectsFinal(hSession: CK_SESSION_HANDLE) -> CK_RV {
 // - pTemplate is non-NULL and points to a list of valid CK_ATTRIBUTE objects of length ulCount.
 // - The pValue field of the CK_ATTRIBUTE object must either be a NULL pointer, or be a buffer
 //   of length of the pValueLen field of the object.
-#[instrument(ret)]
+#[instrument(level = Level::DEBUG, ret)]
 extern "C" fn C_GetAttributeValue(
     hSession: CK_SESSION_HANDLE,
     hObject: CK_OBJECT_HANDLE,

--- a/siguldry-pkcs11/tests/token_info.rs
+++ b/siguldry-pkcs11/tests/token_info.rs
@@ -208,6 +208,55 @@ async fn enumerate_slots() -> anyhow::Result<()> {
 
 #[tokio::test]
 #[tracing_test::traced_test]
+async fn filter_slots() -> anyhow::Result<()> {
+    // SAFETY: These tests must be run under nextest which ensures no one else
+    // is reading or writing environment variables in this process.
+    unsafe {
+        std::env::set_var("LIBSIGULDRY_PKCS11_KEYS", keys::CODESIGNING_KEY_NAME);
+    }
+
+    // Expose two keys, but filter down to just 1 using the environment variable
+    let _instance = InstanceBuilder::new()
+        .with_codesigning_key()
+        .with_client_proxy()
+        .build()
+        .await?;
+    let mut slot_infos = tokio::task::spawn_blocking(|| {
+        let pkcs11 = initialize_module()?;
+        let slots = pkcs11.get_all_slots()?;
+        assert_eq!(1, slots.len());
+        let slot_infos = slots
+            .into_iter()
+            .map(|slot| pkcs11.get_slot_info(slot))
+            .collect::<Result<Vec<_>, _>>()?;
+        Ok::<_, anyhow::Error>(slot_infos)
+    })
+    .await??;
+    assert_eq!(1, slot_infos.len());
+
+    let mut expected_descriptions = [keys::CODESIGNING_KEY_NAME];
+    expected_descriptions.sort();
+    slot_infos.sort_by(|a, b| a.slot_description().cmp(b.slot_description()));
+    for (expected_description, slot_info) in expected_descriptions
+        .into_iter()
+        .zip(slot_infos.into_iter())
+    {
+        assert!(slot_info.token_present());
+        assert_eq!("Fedora Infrastructure", slot_info.manufacturer_id());
+
+        assert_eq!(1, slot_info.firmware_version().major());
+        assert_eq!(0, slot_info.firmware_version().minor());
+
+        assert_eq!(1, slot_info.hardware_version().major());
+        assert_eq!(0, slot_info.hardware_version().minor());
+        assert_eq!(expected_description, slot_info.slot_description());
+    }
+
+    Ok(())
+}
+
+#[tokio::test]
+#[tracing_test::traced_test]
 async fn mechanism_list_for_rsa_key() -> anyhow::Result<()> {
     let _instance = InstanceBuilder::new()
         .with_codesigning_key()


### PR DESCRIPTION
This series includes some logging adjustments as well as the ability to filter keys; this key filtering is necessary for a robosignatory-like autosigner using gpg.