### PR TITLE
Implement an AMQP consumer to autosign content

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -62,7 +62,7 @@ jobs:
     name: Code style checks
     runs-on: ubuntu-latest
     container:
-      image: quay.io/fedora/fedora:43
+      image: quay.io/fedora/fedora:44
     steps:
       - uses: actions/checkout@v5
         with:
@@ -80,19 +80,21 @@ jobs:
 
       - name: Install test packages
         run: |
-          dnf install -y \
+          dnf install -y --enablerepo=updates-testing \
             acl \
             clang \
             gnupg-pkcs11-scd \
             kryoptic \
-            sequoia-sq \
+            opensc \
+            openssl \
+            openssl-devel \
+            ostree \
             pesign \
             pkcs11-provider \
             pkg-config \
             python3-devel \
-            opensc \
-            openssl \
-            openssl-devel \
+            sequoia-sq \
+            siguldry-pkcs11 \
             sqlite-devel
 
       - name: cargo clippy
@@ -140,7 +142,7 @@ jobs:
     needs: generate-sigul-data
     runs-on: ubuntu-latest
     container:
-      image: quay.io/fedora/fedora:43
+      image: quay.io/fedora/fedora:44
     strategy:
       matrix:
         # Support current stable and the toolchain that ships with
@@ -171,20 +173,21 @@ jobs:
 
       - name: Install test packages
         run: |
-          dnf install -y \
+          dnf install -y --enablerepo=updates-testing \
             acl \
             clang \
             gnupg-pkcs11-scd \
             kryoptic \
-            sequoia-sq \
+            opensc \
+            openssl \
+            openssl-devel \
+            ostree \
             pesign \
             pkcs11-provider \
             pkg-config \
             python3-devel \
-            opensc \
-            openssl \
-            openssl-devel \
-            softhsm \
+            sequoia-sq \
+            siguldry-pkcs11 \
             sqlite-devel
 
           # pesign-client doesn't let you configure the socket location, so make it available to the world

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,10 +2,11 @@
 resolver = "3"
 members = [
     "sample-uefi",
-    "sigul-pesign-bridge",
     "siguldry",
+    "siguldry-fedora-autopen",
     "siguldry-pkcs11",
     "siguldry-test",
+    "sigul-pesign-bridge",
     "xtask",
 ]
 

--- a/deny.toml
+++ b/deny.toml
@@ -87,17 +87,16 @@ ignore = [
 # This is not a complete list of acceptable licenses for the project, merely the
 # list required by our dependencies.
 allow = [
-    "0BSD",
     "Apache-2.0",
     "Apache-2.0 WITH LLVM-exception",
     "BSD-3-Clause",
+    "BSD-2-Clause",
     "ISC",
     "MIT",
     "Unicode-3.0",
     "Unlicense",
     "Zlib",
     "LGPL-2.0-or-later",
-    "MPL-2.0",
     "BSL-1.0",
 ]
 # The confidence threshold for detecting a license from license text.
@@ -108,9 +107,6 @@ confidence-threshold = 1.0
 # Allow 1 or more licenses on a per-crate basis, so that particular licenses
 # aren't accepted for every possible crate as with the normal allow list
 exceptions = [
-    # Fedora has some restrictions on this license; this is for sequoia which
-    # is already included, so only allow the license for that dependency.
-    { allow = ["CC0-1.0"], crate = "tiny-keccak" },
 ]
 
 # Some crates don't have (easily) machine readable licensing information,

--- a/docs/src/user-guide/administration.md
+++ b/docs/src/user-guide/administration.md
@@ -166,4 +166,6 @@ The server will now connect to the bridge.
 
 ## Client
 
-The client is primarily used via the `libsiguldry_pkcs11.so` PKCS#11 module. In order to isolate the credentials from the PKCS#11 module, the `siguldry-client-proxy.socket` systemd socket is provided. This spawns a `siguldry-client-proxy@.service` instance.
+The client is primarily used via the `libsiguldry_pkcs11.so` PKCS#11 module. In order to isolate the
+credentials from the PKCS#11 module, the `siguldry-client-proxy.socket` systemd socket is provided.
+This spawns a `siguldry-client-proxy@.service` instance.

--- a/docs/src/user-guide/configuration.md
+++ b/docs/src/user-guide/configuration.md
@@ -119,3 +119,18 @@ An example [client configuration](https://docs.rs/siguldry/latest/siguldry/clien
 ```
 
 By default, this is loaded from `/etc/siguldry/client.toml`.
+
+## siguldy-fedora-autopen
+
+If you're looking to automatically sign content from AMQP messages, and you happen to also be using
+Koji, the `siguldry-fedora-autopen` application is what you're looking for. It should be configured
+on a host where a client configuration also exists, and any signing keys it uses must be configured
+to be automatically unlocked by the client.
+
+{{#include ../../../siguldry-fedora-autopen/README.md:9}}
+
+An example configuration:
+
+```toml
+{{#include ../../../siguldry-fedora-autopen/config.toml.example}}
+```

--- a/docs/src/user-guide/signing.md
+++ b/docs/src/user-guide/signing.md
@@ -1,0 +1,28 @@
+# Signing
+
+Once the server, bridge, and client(s) are configured, we can now sign things.
+
+Signing should be done with the Siguldry PKCS #11 module. While it can be used manually, Fedora
+automates signing content using its AMQP message broker that its build services connect to.
+
+## siguldry-pkcs11
+
+First, here's some examples of how various content can be signed using the
+[siguldry-pkcs11](https://crates.io/crates/siguldry-pkcs11) library. This is a [PKCS
+#11](https://docs.oasis-open.org/pkcs11/pkcs11-spec/v3.2/pkcs11-spec-v3.2.html) module, which is an API many popular libraries and tools understand.
+
+
+### Configuration
+
+As a PKCS #11 module is a dynamic library loaded by other programs, the primary way to provide configuration is by environment variable.
+
+{{#include ../../../siguldry-pkcs11/README.md:22:31}}
+
+{{#include ../../../siguldry-pkcs11/README.md:41:}}
+
+
+## siguldry-fedora-autopen
+
+Rather than manually signing every piece of content, you can automate the process.
+
+{{#include ../../../siguldry-fedora-autopen/README.md:5}}

--- a/siguldry-fedora-autopen/CHANGELOG.md
+++ b/siguldry-fedora-autopen/CHANGELOG.md
@@ -1,0 +1,12 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [0.1.0] - 2026-05-26
+
+### Added
+
+- An AMQP consumer to automatically sign Koji-built RPMs, OSTree commits, and CoreOS Artifacts (#202)

--- a/siguldry-fedora-autopen/Cargo.toml
+++ b/siguldry-fedora-autopen/Cargo.toml
@@ -1,0 +1,112 @@
+[package]
+name = "siguldry-fedora-autopen"
+license = "MIT"
+edition = { workspace = true }
+rust-version = { workspace = true }
+version = "0.1.0"
+readme = "README.md"
+description = """
+An AMQP client to auto-sign Fedora build artifacts
+"""
+keywords = ["rpmsign", "amqp", "siguldry", "fedora"]
+repository = "https://github.com/fedora-infra/siguldry"
+
+[dependencies.anyhow]
+version = "1"
+
+[dependencies.clap]
+version = "4.0"
+default-features = false
+features = ["std", "derive", "env", "help", "usage", "error-context"]
+
+[dependencies.hex]
+version = "0.4"
+
+[dependencies.lapin]
+version = "4.4"
+default-features = false
+features = ["tokio", "native-tls"]
+
+[dependencies.metrics]
+version = "0.24"
+
+[dependencies.metrics-exporter-prometheus]
+version = "0.18"
+default-features = false
+features = ["http-listener"]
+
+[dependencies.openssl]
+version = "0.10"
+
+# Used for RPM signing to interact with Koji via its Python library
+[dependencies.pyo3]
+version = "0.28"
+features = ["auto-initialize"]
+
+[dependencies.regex]
+version = "1"
+
+[dependencies.reqwest]
+version = "0.13"
+default-features = false
+features = ["http2", "native-tls"]
+
+[dependencies.serde]
+version = "1.0.145"
+features = ["derive"]
+
+[dependencies.serde_json]
+version = "1"
+
+[dependencies.siguldry]
+path = "../siguldry"
+version = ">=0.6, <0.8"
+default-features = false
+
+[dependencies.tempfile]
+version = "3"
+
+[dependencies.time]
+version = "0.3"
+features = ["formatting"]
+
+[dependencies.tokio]
+version = "1.27"
+features = ["fs", "macros", "net", "process", "rt-multi-thread", "io-std", "signal", "time"]
+
+[dependencies.tokio-util]
+version = "0.7"
+features = ["io", "rt"]
+
+[dependencies.tokio-stream]
+version = "0.1"
+
+[dependencies.toml]
+version = "1.0"
+
+[dependencies.tracing]
+version = "0.1.36"
+
+[dependencies.tracing-subscriber]
+version = "0.3.17"
+default-features = false
+features = ["std", "registry", "fmt", "env-filter"]
+
+[dependencies.uuid]
+version = "1.6"
+features = ["v4", "v7", "serde"]
+
+[dev-dependencies.wiremock]
+version = "0.6"
+
+[dev-dependencies.siguldry-test]
+path = "../siguldry-test"
+
+[dev-dependencies.tracing-test]
+version = "0.2"
+# env filtering breaks usage in integration tests
+features = ["no-env-filter"]
+
+
+[lints]
+workspace = true

--- a/siguldry-fedora-autopen/LICENSE
+++ b/siguldry-fedora-autopen/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Microsoft Corporation.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/siguldry-fedora-autopen/README.md
+++ b/siguldry-fedora-autopen/README.md
@@ -1,0 +1,11 @@
+# siguldry-fedora-autopen
+
+Automatically sign content based on AMQP messages published in Fedora's infrastructure.
+
+`siguldry-fedora-autopen` is a service that connects to an AMQP broker and consumes messages as published by [fedora-messaging](https://fedora-messaging.readthedocs.io/en/stable/index.html). It supports automatically signing RPMs built in Koji when tagging events occur, OSTree repositories, and CoreOS artifacts. It uses the `siguldry-pkcs11` module to perform signing.
+
+## Configuration
+
+The `siguldry-fedora-autopen.service` requires that the `siguldry-client-proxy.socket` systemd socket is active and accessible to the service. Its default configuration file location when running as a system service is `/etc/siguldry/fedora-autopen.toml`. Its configuration is similar, but not identical, to the [robosignatory](https://pagure.io/robosignatory/) service it replaces.
+
+Refer to the included `config.toml.example` file for a detailed explanation of configuration options.

--- a/siguldry-fedora-autopen/config.toml.example
+++ b/siguldry-fedora-autopen/config.toml.example
@@ -1,0 +1,76 @@
+[amqp]
+amqp_url = "amqps://fedora:@rabbitmq.fedoraproject.org/%2Fpublic_pubsub?auth_mechanism=external"
+
+[amqp.tls]
+ca_cert = "/etc/fedora-messaging/cacert.pem"
+keyfile = "/etc/fedora-messaging/fedora-key.pem"
+certfile = "/etc/fedora-messaging/fedora-cert.pem"
+
+[[amqp.bindings]]
+exchange = "amq.topic"
+routing_keys = [
+    "org.fedoraproject.*.buildsys.tag",
+    "org.fedoraproject.*.coreos.build.request.artifacts-sign",
+    "org.fedoraproject.*.pungi.compose.ostree",
+]
+
+[siguldry]
+client_proxy_socket = "/run/siguldry-client-proxy/siguldry-client-proxy.socket"
+concurrency = 128
+
+[koji]
+url = "https://koji.fedoraproject.org/kojihub"
+instance = "primary"
+# Enabling the readonly setting below will turn off any Koji write operations.
+# This is only really useful for local testing against a public Koji instance.
+#readonly = true
+
+[koji.auth]
+authmethod = "kerberos"
+principal = "jcline@FEDORAPROJECT.ORG"
+
+[[koji.tags]]
+from = "f45-signing-pending"
+to = "f45-updates-testing-pending"
+siguldry_key = "fedora-45"
+siguldry_openpgp_cert = "fedora-45-openpgp"
+trusted_taggers = ["bodhi"]
+
+[koji.tags.file_signing_key]
+siguldry_key = "fedora-45-ima"
+siguldry_x509_cert = "fedora-45-ima-x509"
+
+[koji.tags.sidetags]
+from_regex = "(?P<sidetag>f45-build-side-[1-9][0-9]*)-signing-pending"
+to_template = "<sidetag>-testing-pending"
+
+[rpm]
+signing_tool = "gpg"
+with_rpmv4 = true
+
+[[ostree]]
+reference = "fedora/rawhide/x86_64/iot"
+directory = "/mnt/fedora_koji/koji/compose/iot/repo/"
+siguldry_key = "fedora-45"
+siguldry_openpgp_cert = "fedora-45-openpgp"
+
+[[ostree]]
+reference = "fedora/rawhide/aarch64/iot"
+directory = "/mnt/fedora_koji/koji/compose/iot/repo/"
+siguldry_key = "fedora-45"
+siguldry_openpgp_cert = "fedora-45-openpgp"
+
+[coreos]
+aws_region = "us-east-2"
+aws_bucket = "fcos-builds"
+aws_access_key = "some-access-key"
+aws_access_secret = "secret key"
+signing_tool = "gpg"
+
+[[coreos.keys]]
+build_version = 45
+siguldry_key =  "fedora-45"
+siguldry_openpgp_cert = "fedora-45-openpgp"
+
+[metrics]
+http_listener = "127.0.0.1:9000"

--- a/siguldry-fedora-autopen/siguldry-fedora-autopen.service
+++ b/siguldry-fedora-autopen/siguldry-fedora-autopen.service
@@ -1,0 +1,88 @@
+[Unit]
+Description=Siguldry autosigning service
+Requires=siguldry-client-proxy.socket
+After=siguldry-client-proxy.socket
+
+[Service]
+Type=simple
+ExecStart=/usr/bin/siguldry-fedora-autopen consume
+User=siguldry
+Group=siguldry
+Restart=on-failure
+RestartSec=5s
+RestartSteps=3
+RestartMaxDelaySec=60s
+
+# Refer to https://docs.rs/tracing-subscriber/0.3.19/tracing_subscriber/filter/struct.EnvFilter.html#directives
+# for more fine-grain logging output.
+# Environment=SIGULDRY_FEDORA_AUTOPEN_LOG="ERROR,lapin=INFO,siguldry_fedora_autopen=INFO,siguldry=INFO"
+
+# The default configuration location is "siguldry/fedora-autopen.toml" relative to /etc/ for system units
+# and relative to $XDG_CONFIG_HOME for user units. It can be manually specified as an absolute
+# path, for example:
+# Environment=SIGULDRY_FEDORA_AUTOPEN_CONFIG=/etc/siguldry/fedora-autopen.toml
+
+UMask=077
+RuntimeDirectory=siguldry-fedora-autopen
+RuntimeDirectoryPreserve=no
+RuntimeDirectoryMode=750
+ConfigurationDirectory=siguldry
+
+# Opt-in to most systemd sandboxing
+CapabilityBoundingSet=
+LockPersonality=true
+MemoryDenyWriteExecute=true
+NoNewPrivileges=true
+KeyringMode=private
+ProcSubset=pid
+PrivateDevices=true
+PrivateTmp=disconnected
+ProtectClock=true
+ProtectControlGroups=true
+ProtectHome=true
+ProtectHostname=true
+ProtectKernelLogs=true
+ProtectKernelModules=true
+ProtectKernelTunables=true
+ProtectProc=invisible
+ProtectSystem=strict
+RemoveIPC=true
+
+# Restrict write-able and executable filesystem locations
+ReadOnlyPaths=/
+ReadWritePaths=/run/siguldry-client-proxy
+NoExecPaths=/
+# Executables that are always required
+ExecPaths=/usr/bin/siguldry-fedora-autopen /usr/lib /usr/lib64
+
+# Executables needed when performing OpenPGP signing via gpg
+#
+# This applies to, at a minimum, RPM and OSTree signing.
+ExecPaths=/usr/bin/gpg /usr/bin/gpg-agent /usr/bin/gnupg-pkcs11-scd
+
+# Executables needed when performing OpenPGP signing via Sequoia
+#
+# This applies to, at a minimum, RPM signing
+ExecPaths=/usr/bin/sq
+
+# Executables needed when signing RPMs via rpmsign
+ExecPaths=/usr/bin/rpmsign /usr/bin/sh
+
+# Executables needed for OSTree signing
+ExecPaths=/usr/bin/ostree
+
+# The service connects to the siguldry proxy over Unix socket, makes HTTP requests, and binds to
+# a TCP socket when metrics are enabled.
+RestrictAddressFamilies=AF_UNIX AF_INET AF_INET6
+SocketBindDeny=any
+# If non-default metrics port is used, you'll need to adjust this.
+SocketBindAllow=tcp:9000
+RestrictNamespaces=true
+RestrictRealtime=true
+RestrictSUIDSGID=true
+
+# Filter available system calls
+# This can likely be restricted further
+SystemCallFilter=@system-service
+SystemCallArchitectures=native
+SystemCallErrorNumber=EPERM

--- a/siguldry-fedora-autopen/src/amqp.rs
+++ b/siguldry-fedora-autopen/src/amqp.rs
@@ -1,0 +1,580 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) Microsoft Corporation.
+
+use std::{collections::HashMap, sync::Arc, time::Duration};
+
+use anyhow::Context;
+use lapin::{
+    BasicProperties, Channel, Connection, ConnectionProperties,
+    message::Delivery,
+    options::{
+        BasicAckOptions, BasicConsumeOptions, BasicNackOptions, BasicPublishOptions,
+        BasicQosOptions, ConfirmSelectOptions, QueueBindOptions,
+    },
+    tcp::{OwnedIdentity, OwnedTLSConfig},
+    types::{AMQPValue, FieldTable},
+};
+use siguldry::protocol::Key;
+use tokio::{sync::Semaphore, task::JoinSet};
+use tokio_stream::StreamExt;
+use tokio_util::sync::CancellationToken;
+use tracing::{Level, instrument};
+
+use crate::{PgpConfig, config::Config, coreos, koji::KojiOps, ostree, rpmsign};
+
+// Handle a single connection.
+pub async fn connect_and_consume<K: KojiOps>(
+    config: Arc<crate::config::Config>,
+    http_client: reqwest::Client,
+    pgp_home: Arc<PgpConfig>,
+    signing_keys: Arc<HashMap<String, Key>>,
+    koji_handle: K,
+    halt_token: CancellationToken,
+) -> anyhow::Result<()> {
+    let connection = tokio::select! {
+        connection = connect(&config.amqp) => {
+            connection
+        }
+        _ = halt_token.cancelled() => {
+            tracing::info!("Aborting connection attempt and shutting down");
+            return Ok(());
+        }
+    }
+    .context("Failed to connect to the message broker")?;
+
+    let channel = connection
+        .create_channel()
+        .await
+        .context("Failed to create AMQP channel")?;
+    tracing::debug!(channel_id = channel.id(), "Channel established");
+    channel
+        .basic_qos(config.amqp.prefetch_count, BasicQosOptions::default())
+        .await
+        .context("Failed to set channel QoS")?;
+
+    let queue_name = config.amqp.queue_name.clone().unwrap_or_default().into();
+    let queue_options = config.amqp.queue_options.clone().unwrap_or_default().into();
+    let queue = channel
+        .queue_declare(queue_name, queue_options, FieldTable::default())
+        .await
+        .context("Failed to declare queue")?;
+    tracing::info!(queue = queue.name().as_str(), "Queue declared");
+    for binding in &config.amqp.bindings {
+        for routing_key in &binding.routing_keys {
+            channel
+                .queue_bind(
+                    queue.name().to_owned(),
+                    binding.exchange.clone().into(),
+                    routing_key.clone().into(),
+                    QueueBindOptions::default(),
+                    FieldTable::default(),
+                )
+                .await?;
+            tracing::info!(
+                queue = queue.name().as_str(),
+                exchange = binding.exchange,
+                routing_key,
+                "Declared queue binding"
+            );
+        }
+    }
+    tracing::info!("Successfully declared all queue bindings");
+
+    tracing::info!(
+        "Signing will allow at most {} operations concurrently",
+        config.siguldry.concurrency.get()
+    );
+    let concurrency = Arc::new(Semaphore::new(config.siguldry.concurrency.get()));
+    let koji_signer = rpmsign::KojiSigner::new(
+        Arc::clone(&config),
+        Arc::clone(&concurrency),
+        Arc::clone(&pgp_home),
+        Arc::clone(&signing_keys),
+        http_client.clone(),
+        koji_handle.clone(),
+    );
+    let ostree_signer = crate::ostree::OstreeSigner::new(
+        Arc::clone(&config),
+        Arc::clone(&concurrency),
+        Arc::clone(&pgp_home),
+        Arc::clone(&signing_keys),
+    );
+    let coreos_signer = coreos::CoreOsSigner::new(
+        Arc::clone(&config),
+        Arc::clone(&concurrency),
+        http_client.clone(),
+        Arc::clone(&pgp_home),
+        Arc::clone(&signing_keys),
+    )?;
+    let publish_channel = connection
+        .create_channel()
+        .await
+        .context("Failed to allocation channel for message publishing")?;
+    publish_channel
+        .confirm_select(ConfirmSelectOptions { nowait: false })
+        .await
+        .context("Confirm select failed")?;
+    let sign_context = SignContext {
+        config,
+        publish_channel,
+        koji_signer,
+        ostree_signer,
+        coreos_signer,
+    };
+    consume(
+        channel,
+        queue.name().clone().to_string(),
+        halt_token.clone(),
+        sign_context,
+    )
+    .await?;
+
+    Ok(())
+}
+
+#[derive(Clone)]
+struct SignContext<K: KojiOps> {
+    config: Arc<Config>,
+    publish_channel: Channel,
+    koji_signer: rpmsign::KojiSigner<K>,
+    ostree_signer: crate::ostree::OstreeSigner,
+    coreos_signer: coreos::CoreOsSigner,
+}
+
+async fn consume<K: KojiOps>(
+    channel: Channel,
+    queue_name: String,
+    halt_token: CancellationToken,
+    sign_context: SignContext<K>,
+) -> anyhow::Result<()> {
+    let consumer_options = BasicConsumeOptions::default();
+    let mut consumer = channel
+        .basic_consume(
+            queue_name.into(),
+            "siguldry-fedora-autopen".into(),
+            consumer_options,
+            FieldTable::default(),
+        )
+        .await
+        .context("Failed to start basic consumer")?;
+    let received_counter = crate::metrics_utils::messages_received();
+
+    // Note that the channel's prefetch count will ensure this doesn't spawn a million tasks.
+    let mut signing_tasks = tokio::task::JoinSet::new();
+    loop {
+        // Drain any completed tasks before selecting the next message or we'll leak memory
+        drain_tasks(&mut signing_tasks);
+
+        let message = tokio::select! {
+            message = consumer.next() => {
+                message
+            }
+            _ = tokio::time::sleep(Duration::from_secs(15)) => {
+                // Restart the loop occassionally so the active tasks are drained and metrics are accurate.
+                continue;
+            }
+            _ = halt_token.cancelled() => {
+                tracing::info!(pending_tasks=signing_tasks.len(), "Consumer halting, waiting for pending tasks to complete");
+                drain_tasks(&mut signing_tasks);
+
+                if let Err(error) = channel.close(0, "Normal shutdown".into()).await {
+                    tracing::error!(?error, "Failed to gracefully shut down the AMQP channel");
+                }
+                break;
+            }
+        };
+        received_counter.increment(1);
+
+        match message {
+            Some(Ok(delivery)) => {
+                signing_tasks.spawn(process_message(sign_context.clone(), delivery));
+                crate::metrics_utils::messages_active().set(signing_tasks.len() as f64);
+                tracing::debug!(
+                    active_tasks = signing_tasks.len(),
+                    "Dispatched new signing task"
+                );
+            }
+            Some(Err(error)) => {
+                tracing::warn!(
+                    ?error,
+                    "AMQP delivery error occurred; restarting connection..."
+                );
+                signing_tasks.abort_all();
+                signing_tasks
+                    .join_all()
+                    .await
+                    .into_iter()
+                    .for_each(|result| {
+                        if let Err(error) = result {
+                            tracing::info!(
+                                ?error,
+                                "Signing task, cancelled due to a connection error, failed"
+                            );
+                        }
+                    });
+
+                return Err(anyhow::anyhow!("Halting consumer due to AMQP error"));
+            }
+            None => {
+                tracing::info!(
+                    pending_tasks = signing_tasks.len(),
+                    "Consumer stream ended, waiting for pending tasks to complete"
+                );
+                signing_tasks
+                    .join_all()
+                    .await
+                    .into_iter()
+                    .for_each(|result| {
+                        if let Err(error) = result {
+                            tracing::error!(?error, "Signing task failed");
+                        }
+                    });
+                break;
+            }
+        }
+    }
+
+    Ok(())
+}
+
+fn drain_tasks(signing_tasks: &mut JoinSet<anyhow::Result<()>>) {
+    while let Some(task) = signing_tasks.try_join_next() {
+        match task {
+            Ok(Ok(())) => tracing::debug!(
+                pending_tasks = signing_tasks.len(),
+                "Signing task finished successfully"
+            ),
+            Ok(Err(error)) => tracing::warn!(?error, "The message could not be acknowledged"),
+            Err(error) => {
+                if error.is_panic() {
+                    tracing::error!(?error, "The message was not processed because it panicked");
+                } else if error.is_cancelled() {
+                    tracing::info!("The task was cancelled");
+                } else {
+                    tracing::warn!(?error, "The task failed to join for unknown reasons");
+                }
+            }
+        };
+    }
+    crate::metrics_utils::messages_active().set(signing_tasks.len() as f64);
+}
+
+#[instrument(skip_all, err(level =  Level::WARN), name = "message", fields(message_id = tracing::field::Empty))]
+async fn process_message<K: KojiOps>(
+    sign_context: SignContext<K>,
+    delivery: Delivery,
+) -> anyhow::Result<()> {
+    let success_counter = crate::metrics_utils::messages_succeeded();
+    let failed_counter = crate::metrics_utils::messages_failed();
+    let dropped_counter = crate::metrics_utils::messages_dropped();
+
+    let message_id = if let Some(message_id) = delivery.properties.message_id().as_ref() {
+        message_id.as_str()
+    } else {
+        tracing::error!("Message didn't include a message ID!");
+        delivery
+            .nack(BasicNackOptions {
+                multiple: false,
+                requeue: false,
+            })
+            .await?;
+        dropped_counter.increment(1);
+        return Ok(());
+    };
+    tracing::Span::current().record("message_id", message_id);
+
+    if let Some(content_type) = delivery.properties.content_type()
+        && content_type.as_str() != "application/json"
+    {
+        tracing::error!(
+            content_type = content_type.as_str(),
+            "Message with unexpected content type, skipping!"
+        );
+        delivery
+            .nack(BasicNackOptions {
+                multiple: false,
+                requeue: false,
+            })
+            .await?;
+        dropped_counter.increment(1);
+        return Ok(());
+    }
+
+    if let Some(content_encoding) = delivery.properties.content_encoding()
+        && !content_encoding.as_str().eq_ignore_ascii_case("utf-8")
+    {
+        tracing::error!(
+            content_encoding = content_encoding.as_str(),
+            "Message with unexpected content encoding, skipping!"
+        );
+        delivery
+            .nack(BasicNackOptions {
+                multiple: false,
+                requeue: false,
+            })
+            .await?;
+        dropped_counter.increment(1);
+        return Ok(());
+    }
+
+    let headers = if let Some(headers) = delivery.properties.headers() {
+        tracing::trace!(?headers, "message headers found");
+        headers
+    } else {
+        tracing::error!("Message didn't include any headers!");
+        delivery
+            .nack(BasicNackOptions {
+                multiple: false,
+                requeue: false,
+            })
+            .await?;
+        dropped_counter.increment(1);
+        return Ok(());
+    };
+
+    let schema = if let Some(AMQPValue::LongString(schema)) =
+        headers.inner().get("fedora_messaging_schema")
+    {
+        schema.to_string()
+    } else {
+        tracing::error!(
+            ?headers,
+            "Message headers did not include 'fedora_messaging_schema'"
+        );
+        delivery
+            .nack(BasicNackOptions {
+                multiple: false,
+                requeue: false,
+            })
+            .await?;
+        dropped_counter.increment(1);
+        return Ok(());
+    };
+    let topic = delivery.routing_key.as_str();
+    tracing::info!(schema, topic, "New message delivered");
+
+    // For messages we previously requeued, introduce a modest delay to avoid spinning as fast as we can
+    if delivery.redelivered {
+        let delay = Duration::from_secs(sign_context.config.amqp.redelivery_delay);
+        tracing::info!(
+            "Message has been previously delivered; delaying processing by {} seconds",
+            delay.as_secs()
+        );
+        tokio::time::sleep(delay).await;
+    }
+
+    let result = match schema.as_str() {
+        "koji_fedoramessaging.tag.TagV1" => {
+            tracing::trace!("Processing Koji tag event");
+            let tag_event: rpmsign::BuildsysTag = serde_json::from_slice(&delivery.data)
+                .context("Message failed to deserialize to the expected schema")?;
+            tokio::time::timeout(
+                sign_context.config.rpm.timeout,
+                sign_context.koji_signer.sign(tag_event),
+            )
+            .await
+        }
+        schema => {
+            // Annoyingly, some of the messages don't have a schema
+            match topic {
+                topic if topic.ends_with(".pungi.compose.ostree") => {
+                    let event: Result<ostree::OstreeCompose, _> =
+                        serde_json::from_slice(&delivery.data);
+                    let result = match event {
+                        Ok(event) => sign_context.ostree_signer.sign(event).await,
+                        Err(error) => {
+                            tracing::error!(?error, "Message body is not valid; skipping");
+                            Ok(())
+                        }
+                    };
+                    Ok(result)
+                }
+                topic if topic.ends_with(".coreos.build.request.artifacts-sign") => {
+                    let event: Result<coreos::ArtifactSign, _> =
+                        serde_json::from_slice(&delivery.data);
+                    let result = match event {
+                        Ok(event) => {
+                            let mut response_event = event.clone();
+                            match sign_context.coreos_signer.sign(event).await.inspect_err(
+                                |_err| crate::metrics_utils::coreos_failed().increment(1),
+                            )? {
+                                coreos::Status::Failure(reason) => {
+                                    response_event.status = Some("FAILURE".to_string());
+                                    response_event.failure_message = Some(reason);
+                                }
+                                coreos::Status::Success => {
+                                    response_event.status = Some("SUCCESS".to_string());
+                                }
+                            };
+                            let response_data = serde_json::to_vec(&response_event)
+                                .context("Failed to serialize CoreOS AMQP response")?;
+
+                            let publish_topic = format!("{topic}.finished").into();
+                            let mut reply_headers = headers.clone();
+                            let sent_at = time::UtcDateTime::now()
+                                .format(&time::format_description::well_known::Rfc3339)
+                                .context("Failed to format sent-at timestamp")?;
+                            reply_headers
+                                .insert("sent-at".into(), AMQPValue::LongString(sent_at.into()));
+
+                            let properties = BasicProperties::default()
+                                .with_content_type("application/json".into())
+                                .with_content_encoding("utf-8".into())
+                                .with_delivery_mode(2)
+                                .with_message_id(uuid::Uuid::new_v4().to_string().into())
+                                .with_headers(reply_headers)
+                                .with_app_id("fedora-siguldry-autopen".into());
+
+                            // Wrapped in a block to ensure the metrics are recorded properly
+                            async {
+                                let confirm = sign_context
+                                    .publish_channel
+                                    .basic_publish(
+                                        "amq.topic".into(),
+                                        publish_topic,
+                                        BasicPublishOptions::default(),
+                                        &response_data,
+                                        properties,
+                                    )
+                                    .await
+                                    .context("Failed to publish CoreOS finished message")?
+                                    .await
+                                    .context("Failed to receive publish confirmation response")?;
+                                match confirm {
+                                    lapin::Confirmation::Ack(None) => Ok(()),
+                                    lapin::Confirmation::Ack(Some(return_message)) => {
+                                        tracing::warn!(return_message.reply_code, ?return_message.reply_text, "AMQP broker acknowledge, but returned, the CoreOS publish message");
+                                        Err(anyhow::anyhow!(
+                                            "AMQP broker returned the CoreOS publish message"
+                                        ))
+                                    }
+                                    lapin::Confirmation::Nack(return_message) => {
+                                        let reply_code = return_message.as_ref().map(|m| m.reply_code);
+                                        let reply_text = return_message.as_ref().map(|m| &m.reply_text);
+                                        tracing::error!(
+                                            ?reply_code,
+                                            ?reply_text,
+                                            "AMQP broker nacked the CoreOS publish message"
+                                        );
+                                        Err(anyhow::anyhow!(
+                                            "AMQP broker returned the CoreOS publish message"
+                                        ))
+                                    }
+                                    lapin::Confirmation::NotRequested => {
+                                        tracing::error!(
+                                            "Message confirmations are not enabled, this is not good"
+                                        );
+                                        Err(anyhow::anyhow!(
+                                            "AMQP broker reported confirms were not requested! This is a bug!"
+                                        ))
+                                    }
+                                }?;
+
+                                if response_event.failure_message.is_none() {
+                                    crate::metrics_utils::coreos_succeeded().increment(1);
+                                } else {
+                                    crate::metrics_utils::coreos_skipped().increment(1);
+                                }
+                                Ok::<_, anyhow::Error>(())
+                            }.await.inspect_err(
+                                |_err| crate::metrics_utils::coreos_failed().increment(1),
+                            )?;
+
+                            Ok(())
+                        }
+                        Err(error) => {
+                            tracing::error!(?error, topic, "Message body is not valid; skipping");
+                            Ok(())
+                        }
+                    };
+                    Ok(result)
+                }
+                topic => {
+                    tracing::error!(
+                        schema,
+                        topic,
+                        "Message schema is unknown and no topic match exists; skipping"
+                    );
+                    Ok(Ok(()))
+                }
+            }
+        }
+    };
+    match result {
+        Ok(Ok(_)) => {
+            delivery.ack(BasicAckOptions { multiple: false }).await?;
+            success_counter.increment(1);
+            tracing::info!("Message processed");
+        }
+        Ok(Err(error)) => {
+            tracing::warn!(
+                ?error,
+                "Failed to process signing request, requeuing message for later attempt"
+            );
+            delivery
+                .nack(BasicNackOptions {
+                    multiple: false,
+                    requeue: true,
+                })
+                .await?;
+            failed_counter.increment(1);
+        }
+        Err(_elapsed) => {
+            tracing::warn!("Signing request timed out, requeuing message for later attempt");
+            delivery
+                .nack(BasicNackOptions {
+                    multiple: false,
+                    requeue: true,
+                })
+                .await?;
+            failed_counter.increment(1);
+        }
+    };
+
+    Ok(())
+}
+
+#[instrument(skip_all)]
+async fn connect(config: &crate::config::Amqp) -> anyhow::Result<Connection> {
+    tracing::info!("Starting connection to the AMQP broker");
+    let pem = std::fs::read_to_string(&config.tls.certfile)
+        .with_context(|| {
+            format!(
+                "Unable to read client certificate {}",
+                config.tls.certfile.display()
+            )
+        })?
+        .into_bytes();
+    let key = std::fs::read_to_string(&config.tls.keyfile)
+        .with_context(|| {
+            format!(
+                "Unable to read client private key {}",
+                config.tls.keyfile.display()
+            )
+        })?
+        .into_bytes();
+    let cert_chain = std::fs::read_to_string(&config.tls.ca_cert).with_context(|| {
+        format!(
+            "Unable to read certificate authority {}",
+            config.tls.ca_cert.display()
+        )
+    })?;
+    let identity = OwnedIdentity::PKCS8 { pem, key };
+    let tls_config = OwnedTLSConfig {
+        identity: Some(identity),
+        cert_chain: Some(cert_chain),
+    };
+    let properties =
+        ConnectionProperties::default().with_client_property("app".into(), "huh".into());
+    let connection = lapin::ConnectionBuilder::new()
+        .context("Failed to create connection builder")?
+        .with_uri_str(config.amqp_url.clone())
+        .with_tls_config(tls_config)
+        .with_properties(properties)
+        .connect()
+        .await
+        .context("Failed to connect to the AMQP server")?;
+    tracing::info!("Connection established");
+
+    Ok(connection)
+}

--- a/siguldry-fedora-autopen/src/cli.rs
+++ b/siguldry-fedora-autopen/src/cli.rs
@@ -1,0 +1,46 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) Microsoft Corporation.
+
+use std::path::PathBuf;
+
+use clap::{Parser, Subcommand};
+
+/// Automatically sign content when triggered via AMQP messages.
+///
+/// The primary feature of this tool is the 'consume' subcommand, which connects to an AMQP broker
+/// and signs content when messages arrive.
+#[derive(Debug, Parser)]
+#[command(version)]
+pub struct Cli {
+    /// The path to the configuration file.
+    ///
+    /// If no path is provided, the configuration file at $CONFIGURATION_DIRECTORY/fedora-autopen.toml
+    /// is used, if it exists. If it does not exist, the configuration defaults are used.
+    #[arg(long, short, env = "SIGULDRY_FEDORA_AUTOPEN_CONFIG")]
+    pub config: Option<PathBuf>,
+
+    /// A set of one or more comma-separated directives to filter logs.
+    ///
+    /// The general format is "target_name[span_name{field=value}]=level" where level is
+    /// one of TRACE, DEBUG, INFO, WARN, ERROR.
+    ///
+    /// Details: https://docs.rs/tracing-subscriber/0.3.19/tracing_subscriber/filter/struct.EnvFilter.html#directives
+    #[arg(
+        long,
+        env = "SIGULDRY_FEDORA_AUTOPEN_LOG",
+        default_value = "ERROR,lapin=INFO,siguldry_fedora_autopen=INFO,siguldry=INFO"
+    )]
+    pub log_filter: String,
+
+    #[command(subcommand)]
+    pub command: Command,
+}
+
+#[derive(Debug, Subcommand)]
+pub enum Command {
+    /// Consume messages from an AMQP broker
+    Consume,
+
+    /// Process a JSON message
+    Process { file: PathBuf },
+}

--- a/siguldry-fedora-autopen/src/config.rs
+++ b/siguldry-fedora-autopen/src/config.rs
@@ -1,0 +1,738 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) Microsoft Corporation.
+
+use std::{net::SocketAddr, num::NonZeroUsize, path::PathBuf, time::Duration};
+
+use anyhow::Context;
+use regex::Regex;
+use serde::{Deserialize, Deserializer, Serialize, Serializer};
+
+/// Application configuration.
+#[derive(Debug, Default, Clone, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct Config {
+    /// Connection and queue settings for the AMQP consumer.
+    pub amqp: Amqp,
+    /// Settings related to Siguldry.
+    pub siguldry: Siguldry,
+    /// Configuration for both the Koji instance to use, and the tags to sign.
+    #[serde(default)]
+    pub koji: Koji,
+    /// Configuration for how RPMs are signed.
+    #[serde(default)]
+    pub rpm: Rpm,
+    /// Configuration for OSTree references to sign.
+    #[serde(default)]
+    pub ostree: Vec<Ostree>,
+    /// Configuration for CoreOS artifacts to sign.
+    #[serde(default)]
+    pub coreos: CoreOs,
+    /// Configure a Prometheus HTTP exporter.
+    ///
+    /// This section is optional and no exporter is configured if not provided.
+    #[serde(default)]
+    pub metrics: Option<Metrics>,
+}
+
+/// Connection and queue settings for the AMQP consumer.
+///
+/// In addition to configuring the broker location, queue name,
+/// and message topics to ensure are bound to the queue, this includes
+/// settings that impact the concurrency of signing operations.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct Amqp {
+    /// The AMQP URL to connect to.
+    ///
+    /// Note that this expects to authenticate via TLS client credentials, and as such
+    /// the AMQP URL should include the `auth_mechanism=external` query parameter, e.g.
+    /// `amqps://fedora:@rabbitmq.fedoraproject.org/%2Fpublic_pubsub?auth_mechanism=external`
+    pub amqp_url: String,
+    /// The client credentials to use when authenticating with the message broker.
+    pub tls: Credentials,
+    /// The queue name to consume from.
+    ///
+    /// If no queue name is provided, a server-generated queue name is used.
+    pub queue_name: Option<String>,
+    /// Queue options to use when declaring the queue.
+    pub queue_options: Option<QueueDeclareOptions>,
+    /// The bindings to declare for the queue, which controls which messages are delivered
+    /// to the queue.
+    pub bindings: Vec<Binding>,
+    /// The time, in seconds, to wait before processing a message that was previously
+    /// delivered, failed to process, and was requeued. This avoids spinning when a
+    /// message cannot be processed due to external service issues.
+    ///
+    /// The default is 15 seconds.
+    #[serde(default = "default_redelivery_delay")]
+    pub redelivery_delay: u64,
+    /// The number of AMQP messages to process concurrently.
+    ///
+    /// Once this limit is reached, AMQP will not deliver a new message until a
+    /// message is acknowledged. This directly impacts how many signing operations
+    /// happen at once. Each message will trigger _at least_ one signing request.
+    ///
+    /// In the case of Koji, each message is a *build* which contains many RPMs,
+    /// and for each RPM in the build an `rpmsign` subprocess is run. There is a
+    /// separate limit for the number of signing operations to allow. Refer to
+    /// [`Siguldry`] for details.
+    ///
+    /// The default is 128.
+    #[serde(default = "default_amqp_concurreny")]
+    pub prefetch_count: u16,
+}
+
+fn default_redelivery_delay() -> u64 {
+    15
+}
+
+fn default_amqp_concurreny() -> u16 {
+    128
+}
+
+impl Default for Amqp {
+    fn default() -> Self {
+        Self {
+            amqp_url: "amqps://fedora:@rabbitmq.fedoraproject.org/%2Fpublic_pubsub?auth_mechanism=external".to_string(),
+            queue_name: None,
+            queue_options: Default::default(),
+            redelivery_delay: 15,
+            prefetch_count: 128,
+            bindings: vec![Binding::default()],
+            tls: Credentials {
+                ca_cert: PathBuf::from("/etc/fedora-messaging/cacert.pem"),
+                keyfile: PathBuf::from("/etc/fedora-messaging/fedora-key.pem"),
+                certfile: PathBuf::from("/etc/fedora-messaging/fedora-cert.pem"),
+            },
+        }
+    }
+}
+
+/// The set of queue bindings to use.
+///
+/// The defaults are to use the `amq.topic` exchange and the following routing keys:
+///
+///  - `org.fedoraproject.*.buildsys.tag` - Triggers RPM signing from Koji
+///  - `org.fedoraproject.*.coreos.build.request.artifacts-sign` - Triggers CoreOS artifact signing.
+///  - `org.fedoraproject.*.pungi.compose.ostree` - Triggers OSTree commit signing
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct Binding {
+    /// The AMQP exchange to bind to.
+    pub exchange: String,
+    /// The routing keys to use when binding to the exchange.
+    pub routing_keys: Vec<String>,
+}
+
+impl Default for Binding {
+    fn default() -> Self {
+        Self {
+            exchange: "amq.topic".to_string(),
+            routing_keys: vec![
+                "org.fedoraproject.*.buildsys.tag".to_string(),
+                "org.fedoraproject.*.coreos.build.request.artifacts-sign".to_string(),
+                "org.fedoraproject.*.pungi.compose.ostree".to_string(),
+            ],
+        }
+    }
+}
+
+#[derive(Debug, Default, Clone, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct QueueDeclareOptions {
+    pub passive: bool,
+    pub durable: bool,
+    pub exclusive: bool,
+    pub auto_delete: bool,
+    pub nowait: bool,
+}
+
+impl From<QueueDeclareOptions> for lapin::options::QueueDeclareOptions {
+    fn from(value: QueueDeclareOptions) -> lapin::options::QueueDeclareOptions {
+        Self {
+            passive: value.passive,
+            durable: value.durable,
+            exclusive: value.exclusive,
+            auto_delete: value.auto_delete,
+            nowait: value.nowait,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct Credentials {
+    pub ca_cert: PathBuf,
+    pub keyfile: PathBuf,
+    pub certfile: PathBuf,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct Koji {
+    /// The path to the Koji XMLRPC server; for example `https://koji.fedoraproject.org/kojihub`.
+    pub url: String,
+    /// The instance name of this Koji; used to filter out AMQP messages from other Koji instances
+    ///
+    /// For example, koji.fedoraproject.org would use the value "primary".
+    pub instance: String,
+    /// Defines how to authenticate with Koji.
+    pub auth: KojiAuthentication,
+    #[serde(default)]
+    pub readonly: bool,
+    /// A list of tags which we should watch and autosign.
+    pub tags: Vec<Tag>,
+}
+
+impl Default for Koji {
+    fn default() -> Self {
+        Self {
+            url: "https://koji.fedoraproject.org/kojihub".to_string(),
+            instance: "primary".to_string(),
+            readonly: false,
+            auth: Default::default(),
+            tags: Default::default(),
+        }
+    }
+}
+
+impl Koji {
+    /// Find the tag configuration for a source tag name, if it exists.
+    ///
+    /// Build can land in a generic per-release tag (e.g. f45-signing-pending) or
+    /// a user-created side tag configured to merge into a parent tag. This handles
+    /// both cases and returns a reference to the tag with the signing key information
+    /// as well as the tag the build should be moved to when signing is completed.
+    pub fn match_tag(&self, from_tag_name: &str) -> Option<(&Tag, String)> {
+        // The simple case where it's not a side tag
+        if let Some(tag) = self.tags.iter().find(|t| t.from == from_tag_name) {
+            return Some((tag, tag.to.clone()));
+        }
+
+        // Each tag can optionally configure a sidetag pattern to match
+        for tag in self.tags.iter() {
+            if let Some(sidetag) = &tag.sidetags
+                && let Some(to_tag) = sidetag
+                    .from_regex
+                    .captures(from_tag_name)
+                    .and_then(|captures| captures.name("sidetag"))
+                    .map(|m| sidetag.to_template.replace("<sidetag>", m.as_str()))
+            {
+                return Some((tag, to_tag));
+            }
+        }
+        None
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+#[serde(tag = "authmethod")]
+#[serde(rename_all = "lowercase")]
+pub enum KojiAuthentication {
+    Kerberos {
+        /// The kerberos principal to authenticate with; for example someone@EXAMPLE.ORG
+        principal: String,
+        /// Path to the keytab file.
+        keytab: Option<PathBuf>,
+        /// Path to the ccache file/dir.
+        ccache: Option<PathBuf>,
+    },
+}
+
+impl Default for KojiAuthentication {
+    fn default() -> Self {
+        Self::Kerberos {
+            principal: "someone@EXAMPLE.COM".to_string(),
+            keytab: None,
+            ccache: None,
+        }
+    }
+}
+
+/// Define a tag in Koji that we should auto-sign when packages are added.
+///
+/// When a build is tagged into the "from" tag, we will sign it using the configured
+/// key, then move the build to the "to" tag.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct Tag {
+    /// The name of the source tag in koji
+    pub from: String,
+    /// The name of the destination tag in koji
+    pub to: String,
+    /// The name of the key in Siguldry to sign with
+    pub siguldry_key: String,
+    /// The name of the OpenPGP certificate associated with the key that
+    /// should be used when signing.
+    pub siguldry_openpgp_cert: String,
+    /// The PKCS #11 URI to use for IMA signatures.
+    ///
+    /// If not set, the RPM will not be signed for IMA. Requires RPM 6.1+.
+    pub file_signing_key: Option<Ima>,
+    /// List of usernames who are allowed to apply a tag for signing;
+    /// if a user not on this list applies the tag, it will not be signed.
+    pub trusted_taggers: Vec<String>,
+    /// An optional side tag definition.
+    ///
+    /// Builds that match the side tag pattern will also be signed by the key
+    /// used for this tag.
+    pub sidetags: Option<SideTag>,
+}
+
+/// IMA signing configuration.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct Ima {
+    /// The name of the key in Siguldry to use for IMA signatures
+    pub siguldry_key: String,
+    /// The name of the X.509 certificate associated with the key to use.
+    ///
+    /// The Subject Key ID from this certificate is embedded in the IMA structure
+    /// users
+    pub siguldry_x509_cert: String,
+}
+
+/// Sidetags are build tags branched off a base tag.
+///
+/// This configuration allows the admin to define a regular expression to match
+/// tag names, which will be signed using the key configured on the parent tag.
+///
+/// Side tags contain the base tag's name and the sequence ID of the side tag.
+/// Koji allows these to be prefixed, suffixed, and split with arbitrary strings.
+/// The typical format used in Fedora is in the form:
+///
+/// `<basetag>-side-<seq_id>`
+///
+/// This tag is where developers perform their builds. When they submit the tag to
+/// Bodhi as an update, Bodhi tags the builds into a tag in the format:
+///
+/// `<basetag>-side-<seq_id>-signing-pending`
+///
+/// These are the tags this service responds to; once every build is signed, we tag
+/// the builds into:
+///
+/// `<basetag>-side-<seq_id>-testing-pending`
+///
+/// An example tag heirarchy would be an `f44-build` base tag, so a sidetag would look
+/// like `f44-build-side-42`.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct SideTag {
+    /// A regular expression that matches the side tag name to auto-sign.
+    ///
+    /// The regular expression provided *MUST* have a capture group named "sidetag".
+    /// The value matched by this group is used in the destination sidetag template.
+    ///
+    /// An example would be "(?P<sidetag>f44-build-side-[1-9][0-9]*)-signing-pending"
+    #[serde(
+        serialize_with = "serialize_regex",
+        deserialize_with = "deserialize_regex"
+    )]
+    pub from_regex: Regex,
+    /// The suffix to append to the above regular expression when moving signed builds
+    /// from the source tag to the destination tag.
+    ///
+    /// For example, setting this to `-testing-pending` would, assuming the example
+    /// regex is used, move the build from `f44-build-side-42-signing-pending` to
+    /// `f44-build-side-42-testing-pending`.
+    ///
+    /// A template for the destination tag.
+    ///
+    /// The template should contain a `<sidetag>` variable which is replaced with the
+    /// value matched by the `sidetag` group in the `from_regex` setting. For example:
+    ///
+    /// ```toml
+    /// from_regex = "(?P<sidetag>f44-build-side-[1-9][0-9]*)-signing-pending"
+    /// to_template = "<sidetag>-testing-pending"
+    /// ```
+    ///
+    /// Will move a build from `f44-build-side-42-signing-pending` to
+    /// `f44-build-side-42-testing-pending`.
+    pub to_template: String,
+}
+
+fn serialize_regex<S>(regex: &Regex, serializer: S) -> Result<S::Ok, S::Error>
+where
+    S: Serializer,
+{
+    serializer.serialize_str(regex.as_str())
+}
+
+fn deserialize_regex<'de, D>(deserializer: D) -> Result<Regex, D::Error>
+where
+    D: Deserializer<'de>,
+{
+    let regex = Regex::new(String::deserialize(deserializer)?.as_str())
+        .map_err(serde::de::Error::custom)?;
+    if !regex
+        .capture_names()
+        .any(|capture| matches!(capture, Some("sidetag")))
+    {
+        Err(serde::de::Error::custom(
+            "The regular expression MUST contain a 'sidetag' group (e.g. (?P<sidetag>...)",
+        ))
+    } else {
+        Ok(regex)
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct Rpm {
+    pub signing_tool: SigningTool,
+    pub with_rpmv4: bool,
+
+    /// The amount of time to wait for a build to be signed successfully; if a timeout is hit
+    /// the message is requeued and attempted later. Note that when using IMA signing, the time
+    /// it takes to sign scales proportionally with the number of files in the RPM.
+    ///
+    /// Defaults to 1 hour.
+    #[serde(default = "default_rpm_timeout")]
+    pub timeout: Duration,
+}
+
+fn default_rpm_timeout() -> Duration {
+    Duration::from_secs(60 * 60)
+}
+
+#[derive(Debug, Default, Clone, Copy, Serialize, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum SigningTool {
+    Sq,
+    #[default]
+    Gpg,
+}
+
+impl Default for Rpm {
+    fn default() -> Self {
+        Self {
+            signing_tool: Default::default(),
+            with_rpmv4: true,
+            timeout: default_rpm_timeout(),
+        }
+    }
+}
+
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct CoreOs {
+    pub aws_region: String,
+    pub aws_bucket: String,
+    pub aws_access_key: String,
+    pub aws_access_secret: String,
+    pub signing_tool: SigningTool,
+    pub keys: Vec<CoreOsKey>,
+}
+
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct CoreOsKey {
+    /// The major build version (45, 46, etc.)
+    pub build_version: usize,
+    /// The Siguldry key to sign with
+    pub siguldry_key: String,
+    /// The name of the associated OpenPGP certificate to use.
+    pub siguldry_openpgp_cert: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct Siguldry {
+    pub client_proxy_socket: PathBuf,
+    /// Limit the number of concurrent connections to the Siguldry client proxy.
+    ///
+    /// This limit should match, or be slightly less than, the `MaxConnections` setting on the
+    /// `siguldry-client-proxy.socket` systemd socket unit to ensure the service doesn't repeatedly
+    /// try to start new connections that systemd will reject, which leads to processing delays and
+    /// unnecessary message requeuing.
+    ///
+    /// The other setting that impacts concurrency is the [`Amqp::prefetch_count`] option. Signing
+    /// tasks are spawned for each message, and each signing task results in one or more connections
+    /// to the Siguldry client proxy.
+    #[serde(default = "default_signing_concurreny")]
+    pub concurrency: NonZeroUsize,
+}
+
+fn default_signing_concurreny() -> NonZeroUsize {
+    NonZeroUsize::new(1024).expect("Set a non-zero default")
+}
+
+impl Default for Siguldry {
+    fn default() -> Self {
+        Self {
+            client_proxy_socket: PathBuf::from(
+                "/run/siguldry-client-proxy/siguldry-client-proxy.socket",
+            ),
+            concurrency: default_signing_concurreny(),
+        }
+    }
+}
+
+impl std::fmt::Display for Config {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(
+            f,
+            "{}",
+            toml::ser::to_string_pretty(&self).unwrap_or_default()
+        )
+    }
+}
+
+fn private_load_config<T>(path: &std::path::Path) -> anyhow::Result<T>
+where
+    T: Default + std::fmt::Display + serde::de::DeserializeOwned,
+{
+    let config = std::fs::read_to_string(path)
+        .with_context(|| format!("failed to read from path {path:?}"))?;
+    tracing::info!(path=%path.display(), "Read from configuration file");
+    toml::from_str(&config)
+        .inspect_err(|error| {
+            eprintln!("Failed to parse configuration loaded from {path:?}:\n{error}");
+            eprintln!("Example config file:\n\n{}", T::default());
+        })
+        .context("configuration file is invalid")
+}
+
+/// Load the configuration with fallback options.
+///
+/// If `path` is [`None`], the `default` path, which should be relative to CONFIGURATION_DIRECTORY, is
+/// checked.  If the default config doesn't exist, the [`Default`] implementation is returned. It's
+/// expected that CONFIGURATION_DIRECTORY is set via systemd.
+///
+/// # Errors
+///
+/// In the event that one of the config files exists, but is invalid, an error is returned.
+pub fn load_config<T>(path: Option<PathBuf>, default: &std::path::Path) -> anyhow::Result<T>
+where
+    T: Default + std::fmt::Display + serde::de::DeserializeOwned,
+{
+    path.or_else(|| {
+        std::env::var("CONFIGURATION_DIRECTORY")
+            .inspect_err(|error| {
+                tracing::warn!(
+                    ?error,
+                    "CONFIGURATION_DIRECTORY environment variable isn't readable"
+                );
+            })
+            .map(PathBuf::from)
+            .ok()
+            .map(|base_path| base_path.join(default))
+            .filter(|path| path.is_file())
+    })
+    .map_or_else(
+        || {
+            tracing::warn!("No configuration file found; using defaults");
+            Ok(T::default())
+        },
+        |path| {
+            tracing::info!(?path, "Attempting to load configuration");
+            private_load_config::<T>(&path)
+        },
+    )
+}
+
+#[derive(Debug, Default, Clone, Serialize, Deserialize)]
+pub struct Ostree {
+    /// The OSTree ref this configuration is for.
+    pub reference: String,
+    /// The directory containing the ostree.
+    pub directory: PathBuf,
+    /// The name of the key in Siguldry to sign with.
+    pub siguldry_key: String,
+    /// The name of the OpenPGP certificate associated with the key that
+    /// should be used when signing.
+    pub siguldry_openpgp_cert: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct Metrics {
+    /// The interface and port to serve Prometheus metrics from.
+    ///
+    /// By default, this is the IPv6 loopback address on port 9000, "::1:9000".
+    pub http_listener: SocketAddr,
+}
+
+impl Default for Metrics {
+    fn default() -> Self {
+        Self {
+            http_listener: "::1:9000"
+                .parse()
+                .expect("Default listen address must be valid"),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn sample_tag(from: &str, to: &str) -> Tag {
+        Tag {
+            from: from.to_string(),
+            to: to.to_string(),
+            siguldry_key: "demo".to_string(),
+            siguldry_openpgp_cert: "demo-openpgp".to_string(),
+            file_signing_key: None,
+            trusted_taggers: vec!["bodhi".to_string()],
+            sidetags: None,
+        }
+    }
+
+    fn sample_sidetag_tag(from: &str, to: &str, regex: &str, template: &str) -> Tag {
+        let mut t = sample_tag(from, to);
+        t.sidetags = Some(SideTag {
+            from_regex: Regex::new(regex).unwrap(),
+            to_template: template.to_string(),
+        });
+        t
+    }
+
+    // Assert the internal tagging for the structure matches robosignatory
+    #[test]
+    fn kerberos_authmethod_deserializes() {
+        let toml_str = r#"
+            authmethod = "kerberos"
+            principal = "someone@EXAMPLE.ORG"
+        "#;
+        let parsed: KojiAuthentication = toml::from_str(toml_str).unwrap();
+        match parsed {
+            KojiAuthentication::Kerberos {
+                principal,
+                keytab,
+                ccache,
+            } => {
+                assert_eq!(principal, "someone@EXAMPLE.ORG");
+                assert!(keytab.is_none());
+                assert!(ccache.is_none());
+            }
+        }
+    }
+
+    #[test]
+    fn unknown_authmethod_is_rejected() {
+        let toml_str = r#"
+            authmethod = "anonymous"
+        "#;
+        let err = toml::from_str::<KojiAuthentication>(toml_str).unwrap_err();
+        assert!(
+            err.to_string().contains("anonymous") || err.to_string().contains("variant"),
+            "unexpected error: {err}"
+        );
+    }
+
+    // We reject unknown keys in the config
+    #[test]
+    fn unknown_keys_in_koji_are_rejected() {
+        let toml_str = r#"
+            url = "https://example.com/kojihub"
+            instance = "primary"
+            tags = []
+            inquisition = "nobody"
+
+            [auth]
+            authmethod = "kerberos"
+            principal = "someone@EXAMPLE.ORG"
+        "#;
+        let err = toml::from_str::<Koji>(toml_str).unwrap_err();
+        assert!(
+            err.to_string().contains("inquisition"),
+            "unexpected error: {err}"
+        );
+    }
+
+    // We reject regex in sidetags without the necessary named group
+    #[test]
+    fn sidetag_regex_without_named_group_is_rejected() {
+        let toml_str = r#"
+            from_regex = "f44-build-side-[1-9][0-9]*-signing-pending"
+            to_template = "<sidetag>-testing-pending"
+        "#;
+        let err = toml::from_str::<SideTag>(toml_str).unwrap_err();
+        assert!(
+            err.to_string().contains("sidetag"),
+            "expected error to mention the missing 'sidetag' group: {err}"
+        );
+    }
+
+    #[test]
+    fn sidetag_regex_with_named_group_is_accepted() {
+        let toml_str = r#"
+            from_regex = "(?P<sidetag>f44-build-side-[1-9][0-9]*)-signing-pending"
+            to_template = "<sidetag>-testing-pending"
+        "#;
+        let parsed: SideTag = toml::from_str(toml_str).unwrap();
+        assert_eq!(parsed.to_template, "<sidetag>-testing-pending");
+        assert!(
+            parsed
+                .from_regex
+                .is_match("f44-build-side-9-signing-pending")
+        );
+    }
+
+    // Invalid regex gets caught when parsing the config
+    #[test]
+    fn invalid_regex_syntax_is_rejected() {
+        let toml_str = r#"
+            from_regex = "(?P<sidetag>"
+            to_template = "<sidetag>-testing-pending"
+        "#;
+        let err = toml::from_str::<SideTag>(toml_str).unwrap_err();
+        assert!(err.to_string().contains("regex parse error"));
+    }
+
+    #[test]
+    fn koji_match_tag_returns_none_when_no_rule_matches() {
+        let koji_config = Koji {
+            tags: vec![sample_tag(
+                "f45-signing-pending",
+                "f45-updates-testing-pending",
+            )],
+            ..Default::default()
+        };
+        assert!(koji_config.match_tag("rawhide-build").is_none());
+    }
+
+    #[test]
+    fn koji_match_tag_direct_match_returns_configured_destination() {
+        let koji_config = Koji {
+            tags: vec![sample_tag(
+                "f45-signing-pending",
+                "f45-updates-testing-pending",
+            )],
+            ..Default::default()
+        };
+        let (matched, tag_to) = koji_config.match_tag("f45-signing-pending").unwrap();
+        assert_eq!(matched.from, "f45-signing-pending");
+        assert_eq!(tag_to, "f45-updates-testing-pending");
+    }
+
+    #[test]
+    fn koji_match_tag_sidetag_substitutes_template() {
+        let koji_config = Koji {
+            tags: vec![sample_sidetag_tag(
+                "f45-signing-pending",
+                "f45-updates-testing-pending",
+                "(?P<sidetag>f45-build-side-[1-9][0-9]*)-signing-pending",
+                "<sidetag>-testing-pending",
+            )],
+            ..Default::default()
+        };
+
+        let (_matched, tag_to) = koji_config
+            .match_tag("f45-build-side-42-signing-pending")
+            .unwrap();
+        assert_eq!(tag_to, "f45-build-side-42-testing-pending");
+    }
+
+    #[test]
+    fn load_example_config() -> anyhow::Result<()> {
+        let example_conf_path =
+            std::path::PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("config.toml.example");
+        let example_conf = std::fs::read_to_string(&example_conf_path)?;
+        toml::de::from_str::<super::Config>(&example_conf)?;
+
+        Ok(())
+    }
+}

--- a/siguldry-fedora-autopen/src/coreos.py
+++ b/siguldry-fedora-autopen/src/coreos.py
@@ -1,0 +1,49 @@
+# SPDX-License-Identifier: MIT
+# Copyright (c) Microsoft Corporation.
+
+"""
+A small shim to deal with CoreOS and S3.
+
+Fedora doesn't package AWS's Rust SDK and I cannot be bothered since I would
+like to migrate the CoreOS folks away from this workflow that requires AWS credentials.
+"""
+
+import boto3
+from botocore import exceptions as boto_exceptions
+from botocore.config import Config as BotoConfig
+
+
+class S3Client:
+
+    def __init__(self, region: str, bucket: str, access_key: str, access_secret: str):
+        config = BotoConfig(
+            connect_timeout=30,
+            read_timeout=60,
+            retries={
+                "max_attempts": 10,
+                "mode": "standard",
+            },
+        )
+        self.bucket = bucket
+        self.s3_client = boto3.client(
+            "s3",
+            region_name=region,
+            aws_access_key_id=access_key,
+            aws_secret_access_key=access_secret,
+            config=config,
+        )
+
+    def upload(self, object_key: str, data: bytes):
+        """
+        Upload a (small) object to the given key.
+
+        If the object exists, do nothing. There's no point checking the digest since
+        OpenPGP can salt the signature and it'll be different every time.
+        """
+        try:
+            self.s3_client.head_object(Bucket=self.bucket, Key=object_key)
+            return
+        except boto_exceptions.ClientError as e:
+            if e.response.get("Error", {}).get("Code") not in ("404", "NoSuchKey"):
+                raise
+        self.s3_client.put_object(Bucket=self.bucket, Key=object_key, Body=data)

--- a/siguldry-fedora-autopen/src/coreos.rs
+++ b/siguldry-fedora-autopen/src/coreos.rs
@@ -1,0 +1,402 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) Microsoft Corporation.
+
+//! Handler for CoreOS artifacts.
+//!
+//! This matches robosignatory, but is not ideal. It fetches artifacts from an S3 bucket, produces
+//! an OpenPGP signature, and then pushes that signature to the S3 bucket.
+
+use std::{
+    collections::HashMap,
+    ffi::CStr,
+    process::Stdio,
+    sync::Arc,
+    time::{Duration, Instant},
+};
+
+use anyhow::Context;
+use pyo3::{
+    Py, PyAny, Python,
+    types::{PyAnyMethods, PyModule},
+};
+use serde::{Deserialize, Serialize};
+use siguldry::protocol::Key;
+use tokio::{io::AsyncWriteExt, sync::Semaphore};
+use tracing::{Level, instrument};
+
+use crate::{PgpConfig, config::Config};
+
+const COREOS: &CStr = pyo3::ffi::c_str!(include_str!("coreos.py"));
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub(crate) struct ArtifactSign {
+    /// The CoreOS stream this artifact belongs to, like "testing-devel"
+    stream: String,
+    /// Some CoreOS-generated UUID.
+    request_id: String,
+    /// The build version, like "44.20260521.20.1".
+    build_id: String,
+    /// The architecture of the artifact
+    basearch: String,
+    /// List of artifacts to sign.
+    artifacts: Vec<Artifact>,
+    /// This field is set by us in the response
+    pub status: Option<String>,
+    /// This field is set by us in the response
+    #[serde(rename = "failure-message")]
+    pub failure_message: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub(crate) struct Artifact {
+    // The digest algorithm and hex-encoded digest, separated by ":"
+    //
+    // For example, "sha256:e9c1786057d1efaf233fbffc2e464ce0803590efbb85023ef5a9d1124a7ae6e9".
+    checksum: String,
+    // The S3 URL for the artifact
+    //
+    // For example, "s3://fcos-builds/prod/signatures/oci/staging/testing-devel/4250693625056566298".
+    file: String,
+}
+
+#[derive(Clone)]
+pub(crate) struct CoreOsSigner {
+    config: Arc<Config>,
+    concurrency: Arc<Semaphore>,
+    http_client: reqwest::Client,
+    pgp_home: Arc<PgpConfig>,
+    signing_keys: Arc<HashMap<String, Key>>,
+    s3_client: Arc<Py<PyAny>>,
+}
+
+// Maps to the pre-existing AMQP response additions the robosignatory CoreOS handler has
+pub(crate) enum Status {
+    Failure(String),
+    Success,
+}
+
+impl CoreOsSigner {
+    pub fn new(
+        config: Arc<Config>,
+        concurrency: Arc<Semaphore>,
+        http_client: reqwest::Client,
+        pgp_home: Arc<PgpConfig>,
+        signing_keys: Arc<HashMap<String, Key>>,
+    ) -> anyhow::Result<Self> {
+        // yes this is gross, but it's short term (I hope); we have no business writing
+        // to an S3 bucket
+        let s3_client = Python::attach(|py| {
+            let module = PyModule::from_code(py, COREOS, c"coreos.py", c"")
+                .context("Failed to initialize Python helper; is boto3 installed?")?;
+            let client = module
+                .getattr("S3Client")?
+                .call(
+                    (
+                        &config.coreos.aws_region,
+                        &config.coreos.aws_bucket,
+                        &config.coreos.aws_access_key,
+                        &config.coreos.aws_access_secret,
+                    ),
+                    None,
+                )
+                .context("Failed to initialize S3Client")
+                .map(|obj| Arc::new(obj.unbind()))?;
+            Ok::<_, anyhow::Error>(client)
+        })?;
+
+        Ok(Self {
+            config,
+            concurrency,
+            http_client,
+            pgp_home,
+            signing_keys,
+            s3_client,
+        })
+    }
+
+    #[instrument(skip_all, err(level = Level::WARN), fields(build.id = request.build_id, build.stream = request.stream, build.arch = request.basearch))]
+    pub async fn sign(&self, request: ArtifactSign) -> anyhow::Result<Status> {
+        // Find the proper signing key
+        let build_major = match request
+            .build_id
+            .split('.')
+            .next()
+            .map(|v| v.parse::<usize>())
+        {
+            Some(Ok(version)) => version,
+            Some(Err(error)) => {
+                tracing::error!(
+                    ?error,
+                    "Request included a build ID that doesn't start with a valid integer"
+                );
+                return Ok(Status::Failure(
+                    "Request included a build ID that doesn't start with a valid integer"
+                        .to_string(),
+                ));
+            }
+            None => {
+                tracing::error!("Request included a build ID that is not in the expected format");
+                return Ok(Status::Failure(
+                    "Request included a build ID that is not in the expected format".to_string(),
+                ));
+            }
+        };
+        let key = if let Some(key) = self
+            .config
+            .coreos
+            .keys
+            .iter()
+            .find(|key| key.build_version == build_major)
+        {
+            key
+        } else {
+            tracing::error!(
+                version = build_major,
+                "The request was for a build version that isn't configured to be signed"
+            );
+            return Err(anyhow::anyhow!(
+                "Missing signing key configuration for CoreOS {build_major} builds"
+            ));
+        };
+        let siguldry_key = if let Some(k) = self.signing_keys.get(&key.siguldry_key) {
+            k
+        } else {
+            tracing::error!(
+                ?key,
+                "The configured signing key doesn't exist in siguldry, or isn't accessible to the user"
+            );
+            return Err(anyhow::anyhow!(
+                "User cannot access signing key for CoreOS {build_major} builds"
+            ));
+        };
+        let siguldry_cert = if let Some(cert) = siguldry_key
+            .certificates
+            .iter()
+            .find(|cert| cert.name == key.siguldry_openpgp_cert)
+        {
+            cert
+        } else {
+            let available_certs = siguldry_key
+                .certificates
+                .iter()
+                .map(|c| c.name.as_str())
+                .collect::<Vec<_>>();
+            tracing::error!(
+                requested_cert = key.siguldry_openpgp_cert,
+                ?available_certs,
+                "The configured signing certificate doesn't exist in Siguldry"
+            );
+            return Err(anyhow::anyhow!(
+                "Missing certificate for CoreOS {build_major} builds"
+            ));
+        };
+        let gpg_home = self
+            .pgp_home
+            .gpg_homedirs
+            .get(&siguldry_cert.fingerprint)
+            .ok_or_else(|| {
+                anyhow::anyhow!(
+                    "OpenPGP fingerprint {} missing from gpg homedirs!",
+                    siguldry_cert.fingerprint
+                )
+            })?
+            .to_owned();
+
+        let expected_prefix = format!("s3://{}/", self.config.coreos.aws_bucket);
+        let base_url =
+            reqwest::Url::parse("https://s3.amazonaws.com/").expect("Set a valid base URL");
+        for artifact in request.artifacts {
+            // Check message validity
+            let (digest_algorithm, digest) = if let Some(split) = artifact.checksum.split_once(':')
+            {
+                split
+            } else {
+                tracing::error!(
+                    artifact.checksum,
+                    "Checksum should be in the format algo:hex; skipping request!"
+                );
+                return Ok(Status::Failure(
+                    "Checksum should be in the format algo:hex; skipping request!".to_string(),
+                ));
+            };
+            let algorithm = if let Some(algorithm) =
+                openssl::hash::MessageDigest::from_name(digest_algorithm)
+            {
+                algorithm
+            } else {
+                tracing::error!(digest_algorithm, "Unsupported digest algorithm");
+                return Ok(Status::Failure(format!(
+                    "Unsupported digest algorithm '{digest_algorithm}'"
+                )));
+            };
+            let mut hasher =
+                openssl::hash::Hasher::new(algorithm).context("Failed to create openssl hasher")?;
+            let expected_digest = match hex::decode(digest) {
+                Ok(digest) => digest,
+                Err(error) => {
+                    tracing::error!(
+                        ?error,
+                        "Message digest was not a hex string; skipping request"
+                    );
+                    return Ok(Status::Failure(
+                        "Message digest was not a hex string; skipping request".to_string(),
+                    ));
+                }
+            };
+            let path = if let Some(path) = artifact.file.strip_prefix(&expected_prefix) {
+                path
+            } else {
+                tracing::error!(
+                    expected_prefix,
+                    artifact.file,
+                    "Requested file was not in the expected AWS bucket"
+                );
+                return Ok(Status::Failure(
+                    "Requested file was not in the expected AWS bucket".to_string(),
+                ));
+            };
+
+            // Download the thingy
+            let mut url = base_url.clone();
+            url.set_path(format!("{}/{path}", self.config.coreos.aws_bucket).as_str());
+            let signing_permit = self
+                .concurrency
+                .acquire()
+                .await
+                .context("Concurrency semaphore is closed")?;
+            let sign_start_time = Instant::now();
+            tracing::debug!(?url, "Attempting to download artifact");
+            let mut response = self
+                .http_client
+                .get(url.clone())
+                .send()
+                .await?
+                .error_for_status()?;
+
+            // Spawn the signing command, streaming the downloaded bytes to its stdin.
+            let mut command = match self.config.coreos.signing_tool {
+                crate::config::SigningTool::Sq => {
+                    let mut command = tokio::process::Command::new("sq");
+                    command
+                        .kill_on_drop(true)
+                        .env_clear()
+                        .env("SEQUOIA_HOME", &self.pgp_home.sq_homedir)
+                        .arg("--batch")
+                        .arg("sign")
+                        .arg("--binary")
+                        .arg("--signature-file")
+                        .arg("-")
+                        .arg(format!("--signer={}", siguldry_cert.fingerprint));
+                    command
+                }
+                crate::config::SigningTool::Gpg => {
+                    let mut command = tokio::process::Command::new("gpg");
+                    command
+                        .kill_on_drop(true)
+                        .env_clear()
+                        .env("GNUPGHOME", &gpg_home)
+                        .env("SEQUOIA_HOME", &self.pgp_home.sq_homedir)
+                        .arg("--batch")
+                        .arg("--pinentry-mode cancel")
+                        .arg("--detach-sign")
+                        .arg("--output")
+                        .arg("-");
+                    command
+                }
+            };
+            command
+                .stdin(Stdio::piped())
+                .stdout(Stdio::piped())
+                .stderr(Stdio::piped());
+            let mut child = command
+                .spawn()
+                .context("Failed to spawn signing command; make sure gpg/sq is installed")?;
+            let mut stdin = child
+                .stdin
+                .take()
+                .expect("stdin must be configured as piped");
+
+            let stream_result = tokio::spawn(async move {
+                // More than enough for streaming to stdin; the HTTP client has a global read
+                // timeout and doesn't need to be wrapped in a timeout here.
+                let write_timeout = Duration::from_secs(10);
+                while let Some(chunk) = response.chunk().await? {
+                    let chunk_size = chunk.len();
+                    tracing::trace!(chunk_size, "Streaming chunk to signing command");
+                    tokio::time::timeout(write_timeout, stdin.write_all(&chunk))
+                        .await
+                        .context("Timed out writing to signing tool stdin")?
+                        .context("IO error writing to signing tool stdin")?;
+                    hasher.update(&chunk)?;
+                }
+                tokio::time::timeout(write_timeout, stdin.shutdown())
+                    .await
+                    .context("Timed out flushing stdin")??;
+                let digest = hasher
+                    .finish()
+                    .context("Failed to complete message digest")?;
+                Ok::<_, anyhow::Error>(digest)
+            });
+
+            let (download_task, output_task) =
+                tokio::join!(stream_result, child.wait_with_output());
+            let output = output_task.context("Failed to wait for the child process output")?;
+            if !output.status.success() {
+                tracing::error!(
+                    exit_code = ?output.status.code(),
+                    stdout = %String::from_utf8_lossy(&output.stdout),
+                    stderr = %String::from_utf8_lossy(&output.stderr),
+                    "Signing command failed: '{command:?}'",
+                );
+                return Err(anyhow::anyhow!("Failed to run signing command"));
+            }
+            tracing::debug!(
+                signing_command = ?command,
+                "Successfully ran signing command"
+            );
+            drop(signing_permit);
+
+            // Since we're streaming into the signing tool and not buffering anything,
+            // this is where we confirm the file matches the advertised checksum.
+            // If the digest doesn't match, we discard the signature and try again later.
+            let actual_digest = download_task
+                .context("Failed to join the task writing to stdin")?
+                .context("Failed to download and digest file")?;
+            if expected_digest.as_slice() != actual_digest.as_ref() {
+                tracing::error!(
+                    artifact.checksum,
+                    actual_digest = hex::encode(actual_digest),
+                    "Artifact checksum mismatch"
+                );
+                return Err(anyhow::anyhow!("Artifact checksum mismatch"));
+            } else {
+                tracing::info!(
+                    artifact.checksum,
+                    artifact.file,
+                    "Successfully signed artifact"
+                );
+                let signature = output.stdout;
+                let s3_client = Arc::clone(&self.s3_client);
+
+                // If uploading fails, it should return an error and we'll retry later.
+                tokio::task::spawn_blocking(move || {
+                    Python::attach(|py| {
+                        let client = s3_client.bind(py);
+                        client
+                            .call_method1("upload", ("key", signature))
+                            .context("Failed to upload signature to S3 bucket")?;
+
+                        Ok::<_, anyhow::Error>(())
+                    })
+                })
+                .await
+                .context("Thread calling Python S3Client panicked")??;
+                crate::metrics_utils::coreos_sign_time()
+                    .record(sign_start_time.elapsed().as_secs_f64());
+                crate::metrics_utils::coreos_artifacts_signed().increment(1);
+            }
+        }
+
+        Ok(Status::Success)
+    }
+}

--- a/siguldry-fedora-autopen/src/koji.rs
+++ b/siguldry-fedora-autopen/src/koji.rs
@@ -1,0 +1,336 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) Microsoft Corporation.
+
+//! Utilities to work with Koji for RPM signing.
+
+use std::{
+    ffi::CStr,
+    path::PathBuf,
+    thread::{self, JoinHandle},
+};
+
+use anyhow::Context;
+use pyo3::{
+    FromPyObject, Python,
+    types::{PyAnyMethods, PyModule},
+};
+use tokio::sync::{mpsc, oneshot};
+use tracing::instrument;
+
+use crate::config::Koji;
+
+const KOJI: &CStr = pyo3::ffi::c_str!(include_str!("koji_utils.py"));
+
+/// Operations performed against Koji.
+///
+/// This trait abstracts away the Python actor so testing is easier.
+pub trait KojiOps: Clone + Send + Sync + 'static {
+    /// Retrieve the details for all the RPMs within a build.
+    fn build_info(
+        &self,
+        build_id: i64,
+    ) -> impl std::future::Future<Output = anyhow::Result<Build>> + Send;
+
+    /// Add a signature header to the RPM in Koji.
+    fn add_signature(
+        &self,
+        rpm_id: i64,
+        expected_sigkey: String,
+        signed_package: PathBuf,
+    ) -> impl std::future::Future<Output = anyhow::Result<()>> + Send;
+
+    /// Move the build from one tag to another.
+    ///
+    /// Returns the task ID of the move operation.
+    fn move_build(
+        &self,
+        build_id: i64,
+        expected_sigkey: String,
+        tag_from: String,
+        tag_to: String,
+    ) -> impl std::future::Future<Output = anyhow::Result<i64>> + Send;
+}
+
+/// An RPM that is part of a build.
+#[derive(Debug, Clone, Default, FromPyObject)]
+pub struct Rpm {
+    pub id: i64,
+    pub draft: bool,
+    pub epoch: Option<i64>,
+    pub name: String,
+    pub version: String,
+    pub release: String,
+    pub size: u64,
+    pub url: String,
+    pub sha256sum: String,
+    pub existing_sigkeys: Vec<String>,
+}
+
+#[derive(Debug, Clone, Default, FromPyObject)]
+pub struct TagEvent {
+    pub create_event: i64,
+    pub creator_name: String,
+    pub tag_name: String,
+}
+
+/// A build in Koji.
+///
+/// A single build can have many RPMs, and we have to sign all of them before moving the build
+/// from one tag to another.
+#[derive(Debug, Clone, Default, FromPyObject)]
+pub struct Build {
+    pub id: i64,
+    pub tag_history: Vec<TagEvent>,
+    pub rpms: Vec<Rpm>,
+}
+
+impl Build {
+    pub(crate) fn active_tag(&self) -> Option<TagEvent> {
+        self.tag_history
+            .iter()
+            .max_by_key(|e| e.create_event)
+            .cloned()
+    }
+}
+
+#[derive(Debug)]
+enum KojiRequest {
+    BuildInfo {
+        build_id: i64,
+    },
+    AddSignature {
+        rpm_id: i64,
+        expected_sigkey: String,
+        signed_package: PathBuf,
+    },
+    MoveBuild {
+        build_id: i64,
+        expected_sigkey: String,
+        tag_from: String,
+        tag_to: String,
+    },
+}
+
+#[derive(Debug)]
+enum KojiResponse {
+    BuildInfo(anyhow::Result<Build>),
+    AddSignature(anyhow::Result<()>),
+    /// Returns the task ID of the move task
+    MoveBuild(anyhow::Result<i64>),
+}
+
+#[derive(Debug)]
+pub struct KojiActor {
+    python_thread: JoinHandle<Result<(), anyhow::Error>>,
+    request_tx: mpsc::Sender<(KojiRequest, oneshot::Sender<KojiResponse>)>,
+    readonly: bool,
+}
+
+impl KojiActor {
+    pub fn new(config: Koji) -> anyhow::Result<Self> {
+        let (request_tx, mut rx) = mpsc::channel::<(KojiRequest, oneshot::Sender<KojiResponse>)>(2);
+        let client = Python::attach(|py| {
+            let module = PyModule::from_code(py, KOJI, c"koji_utils.py", c"")?;
+            match &config.auth {
+                crate::config::KojiAuthentication::Kerberos {
+                    principal,
+                    keytab,
+                    ccache,
+                } => module
+                    .getattr("Client")?
+                    .call(
+                        (
+                            &config.url,
+                            principal,
+                            keytab.as_ref(),
+                            ccache.as_ref(),
+                            config.readonly,
+                        ),
+                        None,
+                    )
+                    .context("Failed to create Koji client")
+                    .map(|obj| obj.unbind()),
+            }
+        })?;
+
+        if config.readonly {
+            tracing::info!(
+                config.readonly,
+                "All Koji operations will be read-only and no authentication will be attempted"
+            );
+        }
+
+        let python_thread = thread::Builder::new()
+            .spawn(move || {
+                while let Some((request, respond_to)) = rx.blocking_recv() {
+                    let response = Python::attach(|py| {
+                        // Be careful to not break out of this receive loop on errors.
+                        let bound_client = client.bind(py);
+                        match request {
+                            KojiRequest::BuildInfo { build_id } => {
+                                let result = bound_client
+                                    .call_method1("build_info", (build_id,))
+                                    .context("Koji build_info call failed")
+                                    .and_then(|obj| {
+                                        obj.extract::<Build>()
+                                            .context("Failed to extract Koji Build")
+                                    });
+                                KojiResponse::BuildInfo(result)
+                            }
+                            KojiRequest::AddSignature {
+                                rpm_id,
+                                expected_sigkey,
+                                signed_package,
+                            } => {
+                                let result = bound_client
+                                    .call_method1(
+                                        "add_signature",
+                                        (rpm_id, expected_sigkey, signed_package),
+                                    )
+                                    .context("Koji add_signature call failed")
+                                    .map(|_| ());
+                                KojiResponse::AddSignature(result)
+                            }
+                            KojiRequest::MoveBuild {
+                                build_id,
+                                expected_sigkey,
+                                tag_from,
+                                tag_to,
+                            } => {
+                                let result = bound_client
+                                    .call_method1(
+                                        "move_build",
+                                        (build_id, expected_sigkey, tag_from, tag_to),
+                                    )
+                                    .context("Koji move_build call failed")
+                                    .and_then(|obj| {
+                                        obj.extract::<i64>()
+                                            .context("Failed to extract move_build task ID")
+                                    });
+                                KojiResponse::MoveBuild(result)
+                            }
+                        }
+                    });
+
+                    let _ = respond_to.send(response);
+                }
+                Ok::<_, anyhow::Error>(())
+            })
+            .context("Failed to spawn Koji request thread")?;
+
+        Ok(Self {
+            python_thread,
+            request_tx,
+            readonly: config.readonly,
+        })
+    }
+
+    pub fn handle(&self) -> impl KojiOps {
+        KojiHandle {
+            inner: self.request_tx.clone(),
+            readonly: self.readonly,
+        }
+    }
+
+    pub fn shutdown(self) -> anyhow::Result<()> {
+        let thread = self.python_thread;
+
+        // Drop our handle; the thread won't join until all other handles are also dropped.
+        let handle = self.request_tx;
+        drop(handle);
+
+        thread
+            .join()
+            .map_err(|error| anyhow::anyhow!("Unable to join python thread: {error:?}"))?
+            .context("Python thread did not shut down cleanly")?;
+        Ok(())
+    }
+}
+
+#[derive(Clone, Debug)]
+pub struct KojiHandle {
+    inner: mpsc::Sender<(KojiRequest, oneshot::Sender<KojiResponse>)>,
+    readonly: bool,
+}
+
+impl KojiOps for KojiHandle {
+    #[instrument(skip(self), err)]
+    async fn build_info(&self, build_id: i64) -> anyhow::Result<Build> {
+        let (tx, rx) = oneshot::channel();
+        self.inner
+            .send((KojiRequest::BuildInfo { build_id }, tx))
+            .await?;
+
+        match rx.await.context("Python actor failed to respond")? {
+            KojiResponse::BuildInfo(response) => response,
+            other => panic!("Programming error; actor responded with the wrong call: {other:?}"),
+        }
+    }
+
+    #[instrument(skip(self), err)]
+    async fn add_signature(
+        &self,
+        rpm_id: i64,
+        expected_sigkey: String,
+        signed_package: PathBuf,
+    ) -> anyhow::Result<()> {
+        let (tx, rx) = oneshot::channel();
+        self.inner
+            .send((
+                KojiRequest::AddSignature {
+                    rpm_id,
+                    expected_sigkey,
+                    signed_package,
+                },
+                tx,
+            ))
+            .await?;
+
+        match rx.await.context("Python actor failed to respond")? {
+            KojiResponse::AddSignature(response) => {
+                if self.readonly {
+                    tracing::info!(
+                        ?response,
+                        "Completed Koji add_signature() call, but operating in read-only mode"
+                    );
+                }
+                response
+            }
+            other => panic!("Programming error; actor responded with the wrong call: {other:?}"),
+        }
+    }
+
+    #[instrument(skip(self), err)]
+    async fn move_build(
+        &self,
+        build_id: i64,
+        expected_sigkey: String,
+        tag_from: String,
+        tag_to: String,
+    ) -> anyhow::Result<i64> {
+        let (tx, rx) = oneshot::channel();
+        self.inner
+            .send((
+                KojiRequest::MoveBuild {
+                    build_id,
+                    expected_sigkey,
+                    tag_from,
+                    tag_to,
+                },
+                tx,
+            ))
+            .await?;
+
+        match rx.await.context("Python actor failed to respond")? {
+            KojiResponse::MoveBuild(response) => {
+                if self.readonly {
+                    tracing::info!(
+                        "Completed Koji move_build() call, but operating in read-only mode"
+                    );
+                }
+                response
+            }
+            other => panic!("Programming error; actor responded with the wrong call: {other:?}"),
+        }
+    }
+}

--- a/siguldry-fedora-autopen/src/koji_utils.py
+++ b/siguldry-fedora-autopen/src/koji_utils.py
@@ -1,0 +1,213 @@
+# SPDX-License-Identifier: MIT
+# Copyright (c) Microsoft Corporation.
+
+"""
+A small shim to deal with Koji from Rust.
+
+Koji's XMLRPC API with Kerberos authentication seem like a bit of a headache to deal with
+from Rust, so (for now) we will just use the Python implementation. This module is intended
+to be limited to operations that would be otherwise a hassle to do in Rust.
+"""
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Optional
+from urllib.parse import urlsplit, urlunsplit
+import base64
+
+import koji
+
+
+class MissingSignaturesError(Exception):
+    """Raised when a build has RPMs missing required signatures."""
+
+    def __init__(self, build_id: int, sigkey: str, missing: list[dict]):
+        self.build_id = build_id
+        self.sigkey = sigkey
+        self.missing = missing
+        super().__init__(
+            f"Build {build_id} has {len(missing)} RPM(s) missing signature from key '{sigkey}'"
+        )
+
+
+@dataclass
+class TagEvent:
+    # The username that caused the tag event.
+    creator_name: str
+    # The name of the tag the event happened to.
+    tag_name: str
+    # The event ID?
+    create_event: int
+
+
+@dataclass
+class Rpm:
+    id: int
+    draft: bool
+    epoch: Optional[int]
+    name: str
+    version: str
+    release: str
+    size: int
+    # The download URL for the RPM
+    url: str
+    # The SHA256 as a hex string of the unsigned RPM.
+    sha256sum: str
+    # The key IDs for which a signature already exists in Koji.
+    # In most cases this will be empty, but if we get interrupted partway
+    # through signing a build, we can use this to skip over ones we've already
+    # signed.
+    existing_sigkeys: list[str]
+
+
+@dataclass
+class Build:
+    # The build ID in Koji.
+    id: int
+    tag_history: list[TagEvent]
+    # The list of RPMs in this build.
+    rpms: list[Rpm]
+
+
+class Client:
+    """A thin Koji client wrapper that exposes the functions Rust needs"""
+
+    def __init__(
+        self,
+        hub_url: str,
+        principal: Optional[str] = None,
+        keytab: Optional[Path] = None,
+        ccache: Optional[Path] = None,
+        readonly: bool = False,
+    ):
+        """
+        Initialize a new client and attempts to authenticate.
+
+        In the event that authentication fails, Koji raises koji.GSSAPIAuthError
+        """
+        self.hub_url = hub_url
+        self.principal = principal
+        self.keytab = keytab
+        self.ccache = ccache
+        self.readonly = readonly
+
+        split_url = urlsplit(self.hub_url)
+        self.pathinfo = koji.PathInfo(
+            urlunsplit((split_url.scheme, split_url.netloc, "", "", ""))
+        )
+
+        # Koji sets the default request timeout to 12 hours, and will retry 30 times.
+        # For larger outages, we'll retry at the Rust layer and, failing that, when
+        # the AMQP message is re-delivered.
+        client_opts = {
+            "auth_timeout": 15,
+            "timeout": 15,
+            "max_retries": 10,
+            "retry_interval": 5,
+        }
+        self.client = koji.ClientSession(self.hub_url, opts=client_opts)
+        if self.readonly is False:
+            self.client.gssapi_login(
+                principal=self.principal, keytab=self.keytab, ccache=self.ccache
+            )
+
+    def build_info(self, build_id: int) -> Build:
+        # Query the history of the tag_listing table for the build, filtering to the active (latest) event
+        # TODO can have multiple results return active, sort by event_id? return all results?
+        tag_history = self.client.queryHistory(
+            tables=["tag_listing"], build=build_id, active=True
+        )
+        tag_history = [
+            TagEvent(
+                create_event=e["create_event"],
+                creator_name=e["creator_name"],
+                tag_name=e["tag.name"],
+            )
+            for e in tag_history.get("tag_listing", [])
+        ]
+        koji_build = self.client.getBuild(build_id)
+        rpms = []
+        for rpm in self.client.listRPMs(build_id):
+            # Empty string means unsigned
+            existing_sigkeys = [
+                sig["sigkey"]
+                for sig in self.client.queryRPMSigs(rpm_id=rpm["id"])
+                if sig["sigkey"]
+            ]
+            rpm_checksums = self.client.getRPMChecksums(
+                rpm["id"], checksum_types=["sha256"], cacheonly=False
+            )
+            rpm_download_url = (
+                self.pathinfo.build(koji_build) + "/" + self.pathinfo.rpm(rpm)
+            )
+            rpm_info = Rpm(
+                id=rpm["id"],
+                draft=rpm["draft"],
+                epoch=rpm["epoch"],
+                name=rpm["name"],
+                version=rpm["version"],
+                release=rpm["release"],
+                size=rpm["size"],
+                url=rpm_download_url,
+                sha256sum=rpm_checksums[""]["sha256"],
+                existing_sigkeys=existing_sigkeys,
+            )
+            rpms.append(rpm_info)
+
+        build = Build(
+            id=build_id,
+            tag_history=tag_history,
+            rpms=rpms,
+        )
+        return build
+
+    def add_signature(self, rpm_id: int, expected_sigkey: str, signed_package: Path):
+        """
+        Submit a new signature header for the given RPM.
+
+        In the event that a signature already exists for that sigkey, Koji raises, I think,
+        GenericError. TODO: This exception is also raised if it can't rip out the key header.
+
+        Args:
+            rpm_id: The Koji RPM ID
+            expected_sigkey: The hex string ID of the key that's expected to to have signed the RPM.
+            signed_package: Path to the signed package.
+        """
+        # Probably should replace this with real bindings to librpm
+        # Need to string-ify the path because Koji has a "isinstance" check on it for string types
+        # and it utterly fails to handle Python Path objects, which it treats as file objects. Duck
+        # typing.
+        sighdr = koji.rip_rpm_sighdr(str(signed_package))
+        sigkey = koji.get_sighdr_key(sighdr)
+        if sigkey != expected_sigkey:
+            raise ValueError(
+                f"Expected signature with keyid '{expected_sigkey}', but got '{sigkey}'"
+            )
+
+        if self.readonly:
+            return
+
+        self.client.addRPMSig(rpm_id, base64.b64encode(sighdr).decode(encoding="utf-8"))
+
+    def move_build(
+        self, build_id: int, expected_sigkey: str, tag_from: str, tag_to: str
+    ) -> int:
+        """
+        Move a build from one tag to another.
+
+        This should be called after all the RPMs in the build have been signed.
+        """
+        # Double check all the signatures are present before we move it over.
+        sigs_missing = []
+        for rpm in self.client.listRPMs(build_id):
+            sigs = self.client.queryRPMSigs(rpm_id=rpm["id"], sigkey=expected_sigkey)
+            if len(sigs) == 0:
+                sigs_missing.append(rpm)
+
+        if self.readonly:
+            return 0
+
+        if sigs_missing:
+            raise MissingSignaturesError(build_id, expected_sigkey, sigs_missing)
+
+        task_id = self.client.tagBuild(tag_to, build_id, False, tag_from)
+        return task_id

--- a/siguldry-fedora-autopen/src/main.rs
+++ b/siguldry-fedora-autopen/src/main.rs
@@ -1,0 +1,604 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) Microsoft Corporation.
+
+use std::{
+    collections::HashMap,
+    fs::Permissions,
+    os::unix::fs::PermissionsExt,
+    path::{Path, PathBuf},
+    process::exit,
+    sync::Arc,
+    time::Duration,
+};
+
+use anyhow::Context;
+use clap::Parser;
+use siguldry::protocol::{CertificateType, Key};
+use tokio::{
+    io::AsyncWriteExt,
+    signal::unix::{SignalKind, signal},
+    sync::Semaphore,
+};
+use tokio_util::sync::CancellationToken;
+use tracing::instrument;
+use tracing_subscriber::{EnvFilter, layer::SubscriberExt};
+
+mod amqp;
+mod cli;
+mod config;
+mod coreos;
+mod koji;
+mod metrics_utils;
+mod ostree;
+mod rpmsign;
+
+// The path, relative to $CONFIGURATION_DIRECTORY, of the default config file location.
+const DEFAULT_CONFIG: &str = "fedora-autopen.toml";
+const USER_AGENT: &str = concat!(env!("CARGO_PKG_NAME"), "/", env!("CARGO_PKG_VERSION"),);
+
+#[tokio::main]
+async fn main() -> anyhow::Result<()> {
+    let opts = cli::Cli::parse();
+
+    let log_filter = EnvFilter::builder().parse(&opts.log_filter).context(
+        "SIGULDRY_FEDORA_AUTOPEN_LOG contains an invalid log directive; refer to \
+            https://docs.rs/tracing-subscriber/0.3.19/tracing_subscriber/\
+            filter/struct.EnvFilter.html#directives for format details.",
+    )?;
+    let stderr_layer = tracing_subscriber::fmt::layer()
+        .without_time()
+        .with_writer(std::io::stderr);
+    let registry = tracing_subscriber::registry()
+        .with(stderr_layer)
+        .with(log_filter);
+    tracing::subscriber::set_global_default(registry)
+        .expect("Programming error: set_global_default should only be called once.");
+
+    let config: config::Config = config::load_config(opts.config, &PathBuf::from(DEFAULT_CONFIG))?;
+
+    // Spawns the HTTP server onto the current Tokio runtime.
+    if let Some(metrics) = &config.metrics {
+        crate::metrics_utils::init(metrics)?;
+    }
+
+    let halt_token = CancellationToken::new();
+    tokio::spawn(signal_handler(halt_token.clone()));
+
+    let temp_dir_root = std::env::temp_dir();
+    let pgp_dir = tempfile::Builder::new()
+        .permissions(Permissions::from_mode(0o700))
+        .prefix("pgp-keys-")
+        .tempdir_in(&temp_dir_root)
+        .inspect_err(|error| {
+            tracing::error!(
+                ?error,
+                "Failed to make temporary directory inside {temp_dir_root:?}"
+            );
+        })?;
+
+    let signing_keys = Arc::new(
+        signing_keys(&config)
+            .await
+            .context("Failed to load available signing keys from Siguldry")?,
+    );
+    let key_list = signing_keys.values().collect::<Vec<_>>();
+    let pgp_home = setup_pgp(&config, pgp_dir.path(), key_list.as_slice())
+        .await
+        .context("Failed to load OpenPGP certificates")?;
+    drop(key_list);
+    let pgp_home = Arc::new(pgp_home);
+    let config = Arc::new(config);
+
+    match opts.command {
+        cli::Command::Consume => run_consumer(config, pgp_home, signing_keys, halt_token).await,
+        cli::Command::Process { file } => {
+            process_message(config, pgp_home, signing_keys, file).await
+        }
+    }
+}
+
+async fn run_consumer(
+    config: Arc<config::Config>,
+    pgp_home: Arc<PgpConfig>,
+    signing_keys: Arc<HashMap<String, Key>>,
+    halt_token: CancellationToken,
+) -> anyhow::Result<()> {
+    let koji_actor = koji::KojiActor::new(config.koji.clone())?;
+
+    let koji_url = reqwest::Url::parse(&config.koji.url)?;
+    let koji_host = koji_url.host_str().unwrap().to_string();
+    let retry_policy = reqwest::retry::for_host(koji_host).classify_fn(|request| {
+        if request.error().is_some() {
+            request.retryable()
+        } else {
+            match request.status() {
+                Some(status)
+                    if status.is_server_error() && request.method() == reqwest::Method::GET =>
+                {
+                    request.retryable()
+                }
+                _ => request.success(),
+            }
+        }
+    });
+    let http_client = reqwest::Client::builder()
+        .https_only(true)
+        .connect_timeout(Duration::from_secs(30))
+        .read_timeout(Duration::from_secs(30))
+        .timeout(Duration::from_secs(30 * 60))
+        .pool_idle_timeout(Duration::from_secs(120))
+        .pool_max_idle_per_host(128)
+        .user_agent(USER_AGENT)
+        .retry(retry_policy)
+        .build()?;
+
+    loop {
+        if let Err(error) = amqp::connect_and_consume(
+            config.clone(),
+            http_client.clone(),
+            pgp_home.clone(),
+            signing_keys.clone(),
+            koji_actor.handle(),
+            halt_token.clone(),
+        )
+        .await
+        {
+            tracing::warn!(?error, "Restarting AMQP broker connection in 15 seconds...");
+            tokio::time::sleep(Duration::from_secs(15)).await;
+        } else {
+            tracing::info!("Consumer completed");
+            break;
+        }
+
+        crate::metrics_utils::amqp_reconnects().increment(1);
+    }
+
+    koji_actor.shutdown()?;
+
+    Ok(())
+}
+
+// Process a JSON-formatted AMQP-like message
+async fn process_message(
+    config: Arc<config::Config>,
+    pgp_home: Arc<PgpConfig>,
+    signing_keys: Arc<HashMap<String, Key>>,
+    file: PathBuf,
+) -> anyhow::Result<()> {
+    use tokio::io::AsyncReadExt;
+
+    let bytes = if file.as_os_str() == "-" {
+        let mut buf = Vec::new();
+        tokio::io::stdin()
+            .read_to_end(&mut buf)
+            .await
+            .context("Failed to read message JSON from stdin")?;
+        buf
+    } else {
+        tokio::fs::read(&file)
+            .await
+            .with_context(|| format!("Failed to read message JSON from {}", file.display()))?
+    };
+
+    #[derive(serde::Deserialize)]
+    struct Message {
+        topic: String,
+        body: serde_json::Value,
+    }
+
+    let message: Message =
+        serde_json::from_slice(&bytes).context("Message JSON did not match the expected format")?;
+    let topic = message.topic.as_str();
+    tracing::info!(topic, "Processing single message from file");
+
+    if topic.ends_with(".pungi.compose.ostree") {
+        let event: ostree::OstreeCompose = serde_json::from_value(message.body)
+            .context("Message body is not a valid OSTree compose payload")?;
+        let signer =
+            ostree::OstreeSigner::new(config, Arc::new(Semaphore::new(16)), pgp_home, signing_keys);
+        signer
+            .sign(event)
+            .await
+            .with_context(|| format!("Failed to sign OSTree compose for topic {topic}"))?;
+        Ok(())
+    } else {
+        Err(anyhow::anyhow!("Unsupported topic {topic}"))
+    }
+}
+
+/// Check that all keys in the configuration are present on the signing
+/// server and accessible to the user.
+///
+/// Return the associated public keys, X.509 certificates, and OpenPGP certificates
+/// as they are needed for various signing operations.
+#[instrument(skip_all)]
+async fn signing_keys(config: &config::Config) -> anyhow::Result<HashMap<String, Key>> {
+    let socket = config.siguldry.client_proxy_socket.clone();
+    let keys = tokio::task::spawn_blocking(move || {
+        let mut client = siguldry::client::ProxyClient::new(socket)
+            .context("Failed to create a connection to the Siguldry client proxy")?;
+        let keys = client
+            .list_keys()
+            .context("Failed to list available keys in Siguldry via the client proxy")?;
+
+        for key in keys.iter() {
+            let is_unlocked = client
+                .is_unlocked(key.name.clone())
+                .with_context(|| format!("Failed to check if the {} key is unlocked", &key.name))?;
+            if is_unlocked {
+                tracing::info!(
+                    key.name,
+                    "Signing key is unlocked by the siguldry-client-proxy"
+                );
+            } else {
+                tracing::debug!(
+                    key.name,
+                    "Siguldry client has access to a signing key, but it is not unlocked"
+                );
+            }
+        }
+        client.shutdown()?;
+        Ok::<_, anyhow::Error>(keys)
+    })
+    .await??;
+
+    // Key names are unique and it's more convenient to work from a map
+    let keys = keys
+        .into_iter()
+        .map(|k| (k.name.clone(), k))
+        .collect::<HashMap<_, _>>();
+
+    // Collect all known missing keys and certs before reporting the error
+    let mut missing_keys = vec![];
+    let mut missing_certs = vec![];
+
+    // Check RPM signing keys
+    for tag in config.koji.tags.iter() {
+        if let Some(key) = keys.get(&tag.siguldry_key) {
+            if let Some(cert) = key
+                .certificates
+                .iter()
+                .find(|c| c.name == tag.siguldry_openpgp_cert)
+            {
+                if !matches!(cert.certificate_type, CertificateType::Pgp) {
+                    tracing::error!(key.name, cert.name, ?cert.certificate_type, "The certificate referenced by 'siguldry_openpgp_cert' must be an OpenPGP certificate");
+                    missing_certs.push(tag.siguldry_openpgp_cert.clone());
+                }
+            } else {
+                tracing::error!(
+                    tag.from,
+                    tag.to,
+                    key.name,
+                    tag.siguldry_openpgp_cert,
+                    "The key does not have a certificate with that name"
+                );
+                missing_certs.push(tag.siguldry_openpgp_cert.clone());
+            }
+        } else {
+            tracing::error!(
+                tag.from,
+                tag.to,
+                tag.siguldry_key,
+                "The key referenced cannot be found in Siguldry (does this user have access?)"
+            );
+            missing_keys.push(tag.siguldry_key.clone());
+        }
+
+        // Check IMA keys
+        if let Some(file_signing_key) = &tag.file_signing_key {
+            tracing::debug!(?file_signing_key, "Checking validity of IMA key");
+            if let Some(key) = keys.get(&file_signing_key.siguldry_key) {
+                if let Some(cert) = key
+                    .certificates
+                    .iter()
+                    .find(|c| c.name == file_signing_key.siguldry_x509_cert)
+                {
+                    if !matches!(cert.certificate_type, CertificateType::X509) {
+                        tracing::error!(key.name, cert.name, ?cert.certificate_type, "The certificate referenced by 'siguldry_x509_cert' must be an X.509 certificate");
+                        missing_certs.push(file_signing_key.siguldry_x509_cert.clone());
+                    }
+                } else {
+                    let available_certs = key
+                        .certificates
+                        .iter()
+                        .map(|c| c.name.as_str())
+                        .collect::<Vec<_>>();
+                    tracing::error!(
+                        tag.from,
+                        tag.to,
+                        ?available_certs,
+                        file_signing_key.siguldry_key,
+                        file_signing_key.siguldry_x509_cert,
+                        "The key does not have a certificate with that name"
+                    );
+                    missing_certs.push(file_signing_key.siguldry_x509_cert.clone());
+                }
+            } else {
+                tracing::error!(
+                    tag.from,
+                    tag.to,
+                    tag.siguldry_key,
+                    "The key referenced cannot be found in Siguldry (does this user have access?)"
+                );
+                missing_keys.push(tag.siguldry_key.clone());
+            }
+        }
+    }
+
+    Ok(keys)
+}
+
+#[derive(Clone)]
+struct PgpConfig {
+    openssl_config: PathBuf,
+    sq_homedir: PathBuf,
+    // Maps certificate fingerprints to their homedirs
+    gpg_homedirs: HashMap<String, PathBuf>,
+}
+
+async fn setup_pgp(
+    config: &config::Config,
+    homedir: &Path,
+    keys: &[&Key],
+) -> anyhow::Result<PgpConfig> {
+    // For IMA we need to configure OpenSSL to load the PKCS #11 provider
+    let openssl_config = homedir.join("openssl.cnf");
+    let mut openssl_cnf = tokio::fs::OpenOptions::new()
+        .mode(0o600)
+        .create_new(true)
+        .write(true)
+        .open(&openssl_config)
+        .await?;
+
+    openssl_cnf
+        .write_all(
+            "
+openssl_conf = openssl_init
+
+[openssl_init]
+providers = providers
+
+[providers]
+default = default_provider
+pkcs11 = pkcs11_provider
+
+[default_provider]
+activate = 1
+
+[pkcs11_provider]
+module = /usr/lib64/ossl-modules/pkcs11.so
+activate = 1\n"
+                .as_bytes(),
+        )
+        .await?;
+
+    let pgp_certificates = homedir.join("openpgp_certificates");
+    tokio::fs::DirBuilder::new()
+        .mode(0o700)
+        .recursive(true)
+        .create(&pgp_certificates)
+        .await?;
+
+    let sq_homedir = homedir.join("sq_config");
+    let sq_cryptoki = sq_homedir.join("config/keystore/cryptoki");
+    tokio::fs::DirBuilder::new()
+        .mode(0o700)
+        .recursive(true)
+        .create(&sq_cryptoki)
+        .await?;
+    let mut config_file = tokio::fs::OpenOptions::new()
+        .mode(0o600)
+        .create_new(true)
+        .write(true)
+        .open(sq_cryptoki.join("config.toml"))
+        .await?;
+    config_file
+        .write_all("[[modules]]\npath = \"/usr/lib64/pkcs11/libsiguldry_pkcs11.so\"\n".as_bytes())
+        .await?;
+    config_file.shutdown().await?;
+    drop(config_file);
+
+    let pgp_cert_names = config
+        .koji
+        .tags
+        .iter()
+        .map(|tag| tag.siguldry_openpgp_cert.as_str())
+        .chain(
+            config
+                .ostree
+                .iter()
+                .map(|o| o.siguldry_openpgp_cert.as_str()),
+        )
+        .chain(
+            config
+                .coreos
+                .keys
+                .iter()
+                .map(|k| k.siguldry_openpgp_cert.as_str()),
+        )
+        .collect::<Vec<_>>();
+    let mut gpg_homedirs = HashMap::new();
+    for key in keys {
+        for cert in key
+            .certificates
+            .iter()
+            .filter(|c| matches!(c.certificate_type, CertificateType::Pgp))
+        {
+            // If we're not using the cert, don't bother importing it.
+            if !pgp_cert_names.contains(&cert.name.as_str()) {
+                continue;
+            }
+
+            tracing::info!(
+                key.name,
+                cert.name,
+                cert.fingerprint,
+                "Importing OpenPGP certificate"
+            );
+            let cert_path = pgp_certificates.join(format!("{}.pgp", cert.fingerprint));
+            let mut cert_file = tokio::fs::OpenOptions::new()
+                .mode(0o644)
+                .create_new(true)
+                .write(true)
+                .open(&cert_path)
+                .await?;
+            cert_file.write_all(cert.certificate.as_bytes()).await?;
+            cert_file.shutdown().await?;
+
+            let mut command = tokio::process::Command::new("sq");
+            let output = command
+                .kill_on_drop(true)
+                .env_clear()
+                .env(
+                    "LIBSIGULDRY_PKCS11_PROXY_PATH",
+                    &config.siguldry.client_proxy_socket,
+                )
+                .env("SEQUOIA_HOME", &sq_homedir)
+                .arg("--batch")
+                .arg("cert")
+                .arg("import")
+                .arg(&cert_path)
+                .output()
+                .await?;
+            if !output.status.success() {
+                return Err(anyhow::anyhow!("Failed to import OpenPGP certificate"));
+            }
+
+            // GPG can't handle more than 1 token without weird things happening
+            // The simplest (weird) solution is to create a homedir per key.
+            let gpg_homedir = homedir.join(format!("gpg_configs/{}", cert.fingerprint));
+            gpg_homedirs.insert(cert.fingerprint.clone(), gpg_homedir.clone());
+            tokio::fs::DirBuilder::new()
+                .mode(0o700)
+                .recursive(true)
+                .create(&gpg_homedir)
+                .await?;
+            let mut gpg_agent_file = tokio::fs::OpenOptions::new()
+                .mode(0o600)
+                .create_new(true)
+                .write(true)
+                .open(gpg_homedir.join("gpg-agent.conf"))
+                .await?;
+            gpg_agent_file
+                .write_all("scdaemon-program /usr/bin/gnupg-pkcs11-scd\n".as_bytes())
+                .await?;
+            gpg_agent_file.shutdown().await?;
+            drop(gpg_agent_file);
+            let mut gpg_pkcs11_scd_file = tokio::fs::OpenOptions::new()
+                .mode(0o600)
+                .create_new(true)
+                .write(true)
+                .open(gpg_homedir.join("gnupg-pkcs11-scd.conf"))
+                .await?;
+            gpg_pkcs11_scd_file.write_all("providers siguldry\nprovider-siguldry-library /usr/lib64/pkcs11/libsiguldry_pkcs11.so\nprovider-siguldry-allow-protected-auth\n".as_bytes()).await?;
+            gpg_pkcs11_scd_file.shutdown().await?;
+            drop(gpg_pkcs11_scd_file);
+
+            let mut command = tokio::process::Command::new("gpg");
+            let output = command
+                .kill_on_drop(true)
+                .env_clear()
+                .env("GNUPGHOME", &gpg_homedir)
+                .env("LIBSIGULDRY_PKCS11_KEYS", &key.name)
+                .env(
+                    "LIBSIGULDRY_PKCS11_PROXY_PATH",
+                    &config.siguldry.client_proxy_socket,
+                )
+                .arg("--batch")
+                .arg("--import")
+                .arg(&cert_path)
+                .output()
+                .await?;
+            if !output.status.success() {
+                tracing::error!(
+                    ?command,
+                    exit_code = ?output.status.code(),
+                    stdout = %String::from_utf8_lossy(&output.stdout),
+                    stderr = %String::from_utf8_lossy(&output.stderr),
+                    "Failed to import OpenPGP certificate"
+                );
+                return Err(anyhow::anyhow!("Failed to import OpenPGP certificate"));
+            } else {
+                tracing::debug!(
+                    key.name,
+                    cert.name,
+                    cert.fingerprint,
+                    "Successfully imported OpenPGP certificate"
+                );
+            }
+
+            // Required to have gpg find the private keys backed by PKCS#11.
+            //
+            // We also have to apply a filter to the keys exposed by PKCS#11 because, due
+            // to gpg limitations, gnupg-pkcs11-scd can only expose a single token. Its
+            // work-arounds for that problem leads to prompts, so we have to be careful to
+            // ensure each instance only sees one token.
+            let mut command = tokio::process::Command::new("gpg");
+            let output = command
+                .kill_on_drop(true)
+                .env_clear()
+                .env("GNUPGHOME", &gpg_homedir)
+                .env("LIBSIGULDRY_PKCS11_KEYS", &key.name)
+                .env(
+                    "LIBSIGULDRY_PKCS11_PROXY_PATH",
+                    &config.siguldry.client_proxy_socket,
+                )
+                .arg("--card-status")
+                .output()
+                .await?;
+            if !output.status.success() {
+                tracing::error!(
+                    ?command,
+                    exit_code = ?output.status.code(),
+                    stdout = %String::from_utf8_lossy(&output.stdout),
+                    stderr = %String::from_utf8_lossy(&output.stderr),
+                    "Failed to discover secret key from PKCS#11 token"
+                );
+                return Err(anyhow::anyhow!(
+                    "Failed to discover PKCS#11 keys with 'gpg --card-status' "
+                ));
+            }
+            tracing::debug!(
+                ?command,
+                stdout = %String::from_utf8_lossy(&output.stdout),
+                "'gpg --card-status' succeeded"
+            );
+        }
+    }
+
+    Ok(PgpConfig {
+        openssl_config,
+        sq_homedir,
+        gpg_homedirs,
+    })
+}
+
+// Repeated requests to terminate should exit immediately.
+#[allow(clippy::exit)]
+async fn signal_handler(halt_token: CancellationToken) -> Result<(), anyhow::Error> {
+    let mut sigterm_stream = signal(SignalKind::terminate()).inspect_err(|error| {
+        tracing::error!(?error, "Failed to register a SIGTERM signal handler");
+    })?;
+    let mut sigint_stream = signal(SignalKind::interrupt()).inspect_err(|error| {
+        tracing::error!(?error, "Failed to register a SIGINT signal handler");
+    })?;
+
+    let mut signaled = false;
+    loop {
+        tokio::select! {
+            _ = sigterm_stream.recv() => {
+                halt_token.cancel();
+            }
+            _ = sigint_stream.recv() => {
+                halt_token.cancel();
+            }
+        }
+        if !signaled {
+            tracing::info!("Shutdown signal received; beginning service shutdown");
+            signaled = true;
+        } else {
+            tracing::error!("Giving up waiting for graceful shutdown; exiting now!");
+            exit(1);
+        }
+    }
+}

--- a/siguldry-fedora-autopen/src/metrics_utils.rs
+++ b/siguldry-fedora-autopen/src/metrics_utils.rs
@@ -1,0 +1,254 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) Microsoft Corporation.
+
+//! Metrics definitions and various utilities.
+//!
+//! All Prometheus metrics exported are defined here. Convenience functions to retrieve the correct
+//! name/type combination are provided.
+
+use std::time::Duration;
+
+use anyhow::Context;
+use metrics::{Counter, Gauge, Histogram};
+use metrics_exporter_prometheus::PrometheusBuilder;
+
+const AMQP_RECONNECTS: &str = "amqp_reconnects";
+const MESSAGES_RECEIVED: &str = "messages_received";
+const MESSAGES_ACTIVE: &str = "messages_active";
+const MESSAGES_SUCCEEDED: &str = "messages_succeeded";
+const MESSAGES_FAILED: &str = "messages_failed";
+const MESSAGES_DROPPED: &str = "messages_dropped";
+
+const RPMS_ACTIVE: &str = "rpms_active";
+const RPMS_SIGNED: &str = "rpms_signed";
+const RPMS_FAILED: &str = "rpms_failed";
+const RPMS_STORAGE: &str = "rpms_artifact_size";
+const RPMS_SIGN_TIME: &str = "rpms_sign_duration";
+
+const OSTREE_SIGN_TIME: &str = "ostree_sign_duration";
+const OSTREE_SIGNED: &str = "ostree_signed";
+const OSTREE_FAILED: &str = "ostree_failed";
+const OSTREE_SKIPPED: &str = "ostree_skipped";
+
+const COREOS_ARTIFACTS_SIGNED: &str = "coreos_artifacts_signed";
+const COREOS_SUCCEEDED: &str = "coreos_succeeded";
+const COREOS_FAILED: &str = "coreos_failed";
+const COREOS_SKIPPED: &str = "coreos_skipped";
+const COREOS_SIGN_TIME: &str = "coreos_sign_duration";
+
+pub(crate) fn amqp_reconnects() -> Counter {
+    metrics::counter!(AMQP_RECONNECTS)
+}
+
+pub(crate) fn messages_received() -> Counter {
+    metrics::counter!(MESSAGES_RECEIVED)
+}
+
+pub(crate) fn messages_active() -> Gauge {
+    metrics::gauge!(MESSAGES_ACTIVE)
+}
+
+pub(crate) fn messages_succeeded() -> Counter {
+    metrics::counter!(MESSAGES_SUCCEEDED)
+}
+
+pub(crate) fn messages_failed() -> Counter {
+    metrics::counter!(MESSAGES_FAILED)
+}
+
+pub(crate) fn messages_dropped() -> Counter {
+    metrics::counter!(MESSAGES_DROPPED)
+}
+
+pub(crate) fn rpms_active() -> Gauge {
+    metrics::gauge!(RPMS_ACTIVE)
+}
+
+pub(crate) fn rpms_signed() -> Counter {
+    metrics::counter!(RPMS_SIGNED)
+}
+
+pub(crate) fn rpms_failed() -> Counter {
+    metrics::counter!(RPMS_FAILED)
+}
+
+pub(crate) fn rpms_storage() -> Gauge {
+    metrics::gauge!(RPMS_STORAGE)
+}
+
+pub(crate) fn rpms_sign_time() -> Histogram {
+    metrics::histogram!(RPMS_SIGN_TIME)
+}
+
+pub(crate) fn ostree_sign_time() -> Histogram {
+    metrics::histogram!(OSTREE_SIGN_TIME)
+}
+
+pub(crate) fn ostree_signed(reference: String) -> Counter {
+    metrics::counter!(OSTREE_SIGNED, "ref" => reference)
+}
+
+pub(crate) fn ostree_failed() -> Counter {
+    metrics::counter!(OSTREE_FAILED)
+}
+
+pub(crate) fn ostree_skipped() -> Counter {
+    metrics::counter!(OSTREE_SKIPPED)
+}
+
+pub(crate) fn coreos_artifacts_signed() -> Counter {
+    metrics::counter!(COREOS_ARTIFACTS_SIGNED)
+}
+
+pub(crate) fn coreos_succeeded() -> Counter {
+    metrics::counter!(COREOS_SUCCEEDED)
+}
+
+pub(crate) fn coreos_failed() -> Counter {
+    metrics::counter!(COREOS_FAILED)
+}
+
+pub(crate) fn coreos_skipped() -> Counter {
+    metrics::counter!(COREOS_SKIPPED)
+}
+
+pub(crate) fn coreos_sign_time() -> Histogram {
+    metrics::histogram!(COREOS_SIGN_TIME)
+}
+
+/// Declare the counters, gauges, and histograms used in metrics.
+pub(crate) fn init(config: &crate::config::Metrics) -> anyhow::Result<()> {
+    PrometheusBuilder::new()
+        .with_http_listener(config.http_listener)
+        .with_recommended_naming(true)
+        .upkeep_timeout(Duration::from_secs(15))
+        .install()
+        .context("Unable to configure Prometheus endpoint")?;
+    tracing::info!(http_listener=?config.http_listener, "Prometheus HTTP exporter configured");
+
+    metrics::counter!(
+        description: "Count of times the AMQP connection has needed to be re-established",
+        unit: metrics::Unit::Count,
+        AMQP_RECONNECTS,
+    )
+    .absolute(0);
+
+    // General message metrics
+    metrics::counter!(
+        description: "Count of AMQP messages received; this includes re-deliveries from requeued messages",
+        unit: metrics::Unit::Count,
+        MESSAGES_RECEIVED,
+    ).absolute(0);
+    metrics::gauge!(
+        description: "The number of AMQP messages currently being processed",
+        unit: metrics::Unit::Count,
+        MESSAGES_ACTIVE,
+    )
+    .set(0);
+    metrics::counter!(
+        description: "Count of AMQP messages successfully processed",
+        unit: metrics::Unit::Count,
+        MESSAGES_SUCCEEDED,
+    )
+    .absolute(0);
+    metrics::counter!(
+        description: "Count of AMQP messages that were not processed successfully and requeued",
+        unit: metrics::Unit::Count,
+        MESSAGES_FAILED,
+    )
+    .absolute(0);
+    metrics::counter!(
+        description: "Count of AMQP messages that were dropped because they were invalid",
+        unit: metrics::Unit::Count,
+        MESSAGES_DROPPED,
+    )
+    .absolute(0);
+
+    // RPM metrics
+    metrics::gauge!(
+        description: "The number of RPMs currently being signed",
+        unit: metrics::Unit::Count,
+        RPMS_ACTIVE,
+    )
+    .set(0);
+    metrics::counter!(
+        description: "The total number of RPMs that have been signed since the service started",
+        unit: metrics::Unit::Count,
+        RPMS_SIGNED,
+    )
+    .absolute(0);
+    metrics::counter!(
+        description: "The total number of RPM signing failures that occurred for any reason",
+        unit: metrics::Unit::Count,
+        RPMS_FAILED,
+    )
+    .absolute(0);
+    metrics::gauge!(
+        description: "The size, in bytes, of the RPMs being actively signed",
+        unit: metrics::Unit::Bytes,
+        RPMS_STORAGE,
+    )
+    .set(0);
+    metrics::describe_histogram!(
+        RPMS_SIGN_TIME,
+        metrics::Unit::Seconds,
+        "The time it took to run rpmsign",
+    );
+
+    // OSTree metrics
+    metrics::describe_histogram!(
+        OSTREE_SIGN_TIME,
+        metrics::Unit::Seconds,
+        "The time it took to run ostree gpg-sign",
+    );
+    metrics::describe_counter!(
+        OSTREE_SIGNED,
+        metrics::Unit::Count,
+        "The count of OSTree commits signed",
+    );
+    metrics::counter!(
+        description: "The total number of OSTree sign requests that failed and will be retried",
+        unit: metrics::Unit::Count,
+        OSTREE_FAILED,
+    )
+    .absolute(0);
+    metrics::counter!(
+        description: "The total number of OSTree sign requests that were skipped because they were invalid or not configured",
+        unit: metrics::Unit::Count,
+        OSTREE_SKIPPED,
+    )
+    .absolute(0);
+
+    // CoreOS metrics
+    metrics::counter!(
+        description: "The total number of CoreOS artifacts that have been signed",
+        unit: metrics::Unit::Count,
+        COREOS_ARTIFACTS_SIGNED,
+    )
+    .absolute(0);
+    metrics::counter!(
+        description: "The total number of CoreOS sign requests that succeeded",
+        unit: metrics::Unit::Count,
+        COREOS_SUCCEEDED,
+    )
+    .absolute(0);
+    metrics::counter!(
+        description: "The total number of CoreOS sign requests that failed and will be retried",
+        unit: metrics::Unit::Count,
+        COREOS_FAILED,
+    )
+    .absolute(0);
+    metrics::counter!(
+        description: "The total number of CoreOS sign requests that were skipped because they were invalid",
+        unit: metrics::Unit::Count,
+        COREOS_SKIPPED,
+    )
+    .absolute(0);
+    metrics::describe_histogram!(
+        COREOS_SIGN_TIME,
+        metrics::Unit::Seconds,
+        "The time it took to sign a CoreOS artifact",
+    );
+
+    Ok(())
+}

--- a/siguldry-fedora-autopen/src/ostree.rs
+++ b/siguldry-fedora-autopen/src/ostree.rs
@@ -1,0 +1,192 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) Microsoft Corporation.
+
+//! Signs OSTree commits.
+//!
+//! This assumes the message references an ostree and commit that is available on the local
+//! filesystem. Fedora runs the auto-signing service on a host that has write access to an
+//! NFS share with all the ostrees.
+
+use std::{collections::HashMap, sync::Arc};
+
+use anyhow::Context;
+use serde::{Deserialize, Serialize};
+use siguldry::protocol::Key;
+use tokio::sync::Semaphore;
+use tracing::{Level, instrument};
+
+use crate::{PgpConfig, config::Config};
+
+/// Message sent after a Pungi OSTree compose.
+///
+/// This message, sadly, doesn't include a schema. It is sent on
+/// "org.fedoraproject.*.pungi.compose.ostree". The message does include
+/// additional fields, but we will only reference the ones we need.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub(crate) struct OstreeCompose {
+    /// The OSTree reference name.
+    #[serde(rename = "ref")]
+    reference: String,
+    /// The commit ID in that reference to sign.
+    commitid: String,
+}
+
+#[derive(Clone)]
+pub(crate) struct OstreeSigner {
+    config: Arc<Config>,
+    concurrency: Arc<Semaphore>,
+    pgp_home: Arc<PgpConfig>,
+    signing_keys: Arc<HashMap<String, Key>>,
+}
+
+impl OstreeSigner {
+    pub fn new(
+        config: Arc<Config>,
+        concurrency: Arc<Semaphore>,
+        pgp_home: Arc<PgpConfig>,
+        signing_keys: Arc<HashMap<String, Key>>,
+    ) -> Self {
+        Self {
+            config,
+            concurrency,
+            pgp_home,
+            signing_keys,
+        }
+    }
+
+    // Sign an OSTree reference.
+    //
+    // For OSTree signing, we expect the tree to be a local directory which
+    // is updated by something else and which we have write access to. In Fedora
+    // this is an NFS share with Koji.
+    #[instrument(skip_all,  err(level = Level::WARN), fields(ostree.reference = ostree.reference, ostree.commitid = ostree.commitid.chars().take(12).collect::<String>()))]
+    pub async fn sign(&self, ostree: OstreeCompose) -> anyhow::Result<()> {
+        let ref_config = if let Some(ref_config) = self
+            .config
+            .ostree
+            .iter()
+            .find(|config| config.reference == ostree.reference)
+        {
+            tracing::info!(
+                key = ref_config.siguldry_key,
+                cert = ref_config.siguldry_openpgp_cert,
+                "OSTree ref configured for signing"
+            );
+            ref_config
+        } else {
+            tracing::info!("OSTree ref is not configured for auto-signing");
+            crate::metrics_utils::ostree_skipped().increment(1);
+            return Ok(());
+        };
+
+        let signing_cert = self
+            .signing_keys
+            .get(&ref_config.siguldry_key)
+            .and_then(|key| {
+                key.certificates
+                    .iter()
+                    .find(|cert| cert.name == ref_config.siguldry_openpgp_cert)
+            })
+            .ok_or_else(|| {
+                anyhow::anyhow!(
+                    "Failed to find the OpenPGP certificate {} for signing key {}",
+                    ref_config.siguldry_openpgp_cert,
+                    ref_config.siguldry_key
+                )
+            })?;
+        let gpg_homedir = self
+            .pgp_home
+            .gpg_homedirs
+            .get(&signing_cert.fingerprint)
+            .ok_or_else(|| {
+                anyhow::anyhow!(
+                    "OpenPGP fingerprint {} missing from gpg homedirs!",
+                    &signing_cert.fingerprint
+                )
+            })?;
+
+        if !ostree.commitid.chars().all(|c| c.is_ascii_hexdigit()) {
+            tracing::error!("Commit ID is not a valid hex string");
+            crate::metrics_utils::ostree_skipped().increment(1);
+            return Ok(());
+        }
+        // It's probably always going to be SHA-256, but let's be reasonable here.
+        if ostree.commitid.len() > 128 {
+            tracing::error!("Commit ID is unreasonably long");
+            crate::metrics_utils::ostree_skipped().increment(1);
+            return Ok(());
+        }
+
+        // We first sign the commit ID, then update the reference to point to that commit ID.
+        let mut sign_command = tokio::process::Command::new("ostree");
+        sign_command
+            .kill_on_drop(true)
+            .env_clear()
+            .arg("gpg-sign")
+            .arg(format!("--repo={}", ref_config.directory.display()))
+            .arg(format!("--gpg-homedir={}", gpg_homedir.display()))
+            .arg(&ostree.commitid)
+            .arg(&signing_cert.fingerprint);
+        let signing_permit = self
+            .concurrency
+            .acquire()
+            .await
+            .context("Concurrency semaphore is closed")?;
+        let sign_start_time = std::time::Instant::now();
+        let output = sign_command
+            .output()
+            .await
+            .context("Failed to spawn ostree; is it installed?")?;
+        crate::metrics_utils::ostree_sign_time().record(sign_start_time.elapsed().as_secs() as f64);
+        drop(signing_permit);
+
+        if !output.status.success() {
+            tracing::error!(
+                exit_code = ?output.status.code(),
+                stdout = %String::from_utf8_lossy(&output.stdout),
+                stderr = %String::from_utf8_lossy(&output.stderr),
+                "Signing command failed: '{sign_command:?}'",
+            );
+
+            crate::metrics_utils::ostree_failed().increment(1);
+            return Err(anyhow::anyhow!("Failed to run ostree gpg-sign"));
+        } else {
+            tracing::debug!(?sign_command, "Successfully ran signing command");
+            tracing::info!(
+                siguldry_key = ref_config.siguldry_key,
+                "Successfully signed OSTree commit"
+            );
+        }
+
+        let mut ref_command = tokio::process::Command::new("ostree");
+        ref_command
+            .kill_on_drop(true)
+            .env_clear()
+            .arg("refs")
+            .arg(format!("--repo={}", ref_config.directory.display()))
+            .arg("--force")
+            .arg(format!("--create={}", &ref_config.reference))
+            .arg(&ostree.commitid);
+
+        let output = ref_command
+            .output()
+            .await
+            .context("Failed to spawn ostree; is it installed?")?;
+        if !output.status.success() {
+            tracing::error!(
+                exit_code = ?output.status.code(),
+                stdout = %String::from_utf8_lossy(&output.stdout),
+                stderr = %String::from_utf8_lossy(&output.stderr),
+                "Signing command failed: '{ref_command:?}'",
+            );
+
+            crate::metrics_utils::ostree_failed().increment(1);
+            return Err(anyhow::anyhow!("Failed to run ostree gpg-sign"));
+        }
+        tracing::debug!(?ref_command, "Successfully ran reference update command");
+        tracing::info!("Successfully updated OSTree reference to the signed commit");
+        crate::metrics_utils::ostree_signed(ostree.reference).increment(1);
+
+        Ok(())
+    }
+}

--- a/siguldry-fedora-autopen/src/rpmsign.rs
+++ b/siguldry-fedora-autopen/src/rpmsign.rs
@@ -1,0 +1,846 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) Microsoft Corporation.
+
+//! Handler for RPM signing.
+
+use std::{
+    collections::HashMap, fs::Permissions, os::unix::fs::PermissionsExt, path::PathBuf, sync::Arc,
+};
+
+use anyhow::Context;
+use openssl::hash::{Hasher, MessageDigest};
+use serde::{Deserialize, Serialize};
+use siguldry::protocol::{Certificate, Key};
+use tokio::{
+    io::{AsyncWriteExt, BufWriter},
+    process::Command,
+    sync::Semaphore,
+};
+use tracing::{Instrument, Level, instrument};
+use uuid::Uuid;
+
+use crate::{
+    PgpConfig,
+    config::{Config, SigningTool},
+    koji::{KojiHandle, KojiOps, Rpm},
+};
+
+/// Derive the Koji "sigkey" from the signing certificate
+///
+/// Koji identifies signing keys by the last 4 bytes of the OpenPGP Key ID, hex-encoded,
+/// which is just the last 8 characters of the fingerprint.
+fn koji_sigkey(cert: &Certificate) -> String {
+    cert.fingerprint
+        .chars()
+        .skip(cert.fingerprint.chars().count() - 8)
+        .map(|c| c.to_ascii_lowercase())
+        .collect()
+}
+
+/// This is the koji_fedoramessaging.tag.TagV1 schema sent by Koji.
+///
+/// This message is emitted when Koji tags a build.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub(crate) struct BuildsysTag {
+    /// The build ID
+    build_id: i64,
+    /// The package name
+    name: String,
+    /// The tag ID
+    tag_id: i64,
+    /// Distinguish between messages from primary and secondary koji
+    instance: String,
+    /// Name of the tag, if it has one.
+    ///
+    /// The schema indicates this can be null, but since we require a tag
+    /// name to operate, this isn't an optional field.
+    tag: String,
+    /// The name of the user that triggered the build.
+    user: String,
+    /// The version of the build.
+    version: String,
+    /// The name of the package owner.
+    owner: String,
+    /// The release number of the package.
+    release: String,
+}
+
+#[derive(Clone)]
+pub struct KojiSigner<K: KojiOps = KojiHandle> {
+    config: Arc<Config>,
+    pgp_home: Arc<PgpConfig>,
+    signing_keys: Arc<HashMap<String, Key>>,
+    http_client: reqwest::Client,
+    koji: K,
+    concurrency: Arc<Semaphore>,
+}
+
+impl<K: KojiOps> KojiSigner<K> {
+    pub fn new(
+        config: Arc<Config>,
+        concurrency: Arc<Semaphore>,
+        pgp_home: Arc<PgpConfig>,
+        signing_keys: Arc<HashMap<String, Key>>,
+        http_client: reqwest::Client,
+        koji: K,
+    ) -> Self {
+        Self {
+            config,
+            pgp_home,
+            signing_keys,
+            http_client,
+            koji,
+            concurrency,
+        }
+    }
+
+    #[instrument(skip(self, build), err(level = Level::WARN), fields(build.id = build.build_id, tag.id = build.tag_id))]
+    pub async fn sign(&self, build: BuildsysTag) -> anyhow::Result<()> {
+        // Skip any Koji messages from instances other than the configured one, and if the
+        // message references a tag we aren't configured for.
+        if self.config.koji.instance != build.instance {
+            tracing::info!(
+                "Skipping message from Koji instance {}; we only sign {}",
+                &build.instance,
+                &self.config.koji.instance
+            );
+            return Ok(());
+        }
+        if self.config.koji.match_tag(&build.tag).is_none() {
+            tracing::info!(build.tag, "Build tag is not configured for auto-signing");
+            return Ok(());
+        }
+
+        let koji_build = self.koji.build_info(build.build_id).await?;
+        let latest_event = if let Some(event) = koji_build.active_tag() {
+            event
+        } else {
+            tracing::error!("The tag_listing for the build contained no events");
+            // TODO: is this normal, do we retry or skip?
+            return Err(anyhow::anyhow!("Failed to find tag history for the build"));
+        };
+
+        // Look up the tag rule for this event. If none matches, this isn't a
+        // build we autosign. We've checked above against the tag in the message, but
+        // we double check here after querying Koji on the current state of the build.
+        let (tag, tag_to) =
+            if let Some(matched) = self.config.koji.match_tag(&latest_event.tag_name) {
+                matched
+            } else {
+                tracing::error!(
+                    build.tag,
+                    latest_event.tag_name,
+                    "The build's latest event tag is not configured for auto-signing"
+                );
+                return Ok(());
+            };
+        let tag_from = latest_event.tag_name.clone();
+        if !tag
+            .trusted_taggers
+            .iter()
+            .any(|trusted| trusted == &latest_event.creator_name)
+        {
+            tracing::warn!(
+                trusted_taggers=?tag.trusted_taggers,
+                tagger=latest_event.creator_name,
+                "Build tag is configure for auto-signing, but build was tagged by an untrusted user: skipping"
+            );
+            return Ok(());
+        }
+
+        tracing::info!(
+            build.name,
+            build.version,
+            build.release,
+            rpms_in_build = koji_build.rpms.len(),
+            tag_event_creator = latest_event.creator_name,
+            "Signing build {} tagged into tag {} on koji instance {}",
+            koji_build.id,
+            build.tag,
+            build.instance
+        );
+
+        // All permissions checks are done; set up the signing environment
+        let temp_dir_root = std::env::temp_dir();
+        let temp_dir = tempfile::Builder::new()
+            .permissions(Permissions::from_mode(0o700))
+            .prefix(&format!("rpm-build-{}-", build.build_id))
+            .rand_bytes(16)
+            .tempdir_in(&temp_dir_root)
+            .inspect_err(|error| {
+                tracing::error!(
+                    ?error,
+                    "Failed to make temporary directory inside {temp_dir_root:?}"
+                );
+            })?;
+
+        let cert = self
+            .signing_keys
+            .get(&tag.siguldry_key)
+            .and_then(|key| {
+                key.certificates
+                    .iter()
+                    .find(|cert| cert.name == tag.siguldry_openpgp_cert)
+            })
+            .ok_or_else(|| {
+                anyhow::anyhow!(
+                    "Failed to find the OpenPGP certificate {} for signing key {}",
+                    tag.siguldry_openpgp_cert,
+                    tag.siguldry_key
+                )
+            })?;
+
+        let sigkey = koji_sigkey(cert);
+        let mut signing_tasks = tokio::task::JoinSet::new();
+        for rpm in koji_build.rpms.into_iter().filter(|rpm| {
+            if rpm.existing_sigkeys.contains(&sigkey) {
+                // In the event this build has been partially signed, only process ones without
+                // a signature from the configured key ID.
+                tracing::debug!(
+                    sigkey,
+                    rpm.id,
+                    rpm.draft,
+                    rpm.name,
+                    rpm.epoch,
+                    rpm.version,
+                    rpm.release,
+                    "Skipping RPM since it's already been signed by this key"
+                );
+                false
+            } else {
+                true
+            }
+        }) {
+            let task_signer = self.clone();
+            let fingerprint = cert.fingerprint.clone();
+            let target_dir = temp_dir.path().to_path_buf();
+            let expected_sigkey = sigkey.clone();
+            let file_signing_key = tag.file_signing_key.clone();
+            let siguldry_key = tag.siguldry_key.clone();
+            let gpg_home = self
+                .pgp_home
+                .gpg_homedirs
+                .get(&fingerprint)
+                .ok_or_else(|| {
+                    anyhow::anyhow!("OpenPGP fingerprint {fingerprint} missing from gpg homedirs!")
+                })?
+                .to_owned();
+            let ima_certificate = file_signing_key
+                .as_ref()
+                .map(|ima| {
+                    self.signing_keys.get(&ima.siguldry_key).and_then(|k| {
+                        k.certificates
+                            .iter()
+                            .find(|c| c.name == ima.siguldry_x509_cert)
+                    })
+                })
+                .ok_or_else(|| anyhow::anyhow!("The referenced IMA key couldn't be found!"))?
+                .cloned();
+
+            if file_signing_key.is_some() && ima_certificate.is_none() {
+                return Err(anyhow::anyhow!(
+                    "The referenced IMA certificate couldn't be found!"
+                ));
+            }
+            let rpm_span = tracing::info_span!("rpm", rpm.id);
+            signing_tasks.spawn(
+                async move {
+                    // Hold a permit until we've finished signing.
+                    // We do this inside the spawned task so that each build gets its RPMs in line for permits
+                    // around the same time. We may want to consider a different strategy in the future if we
+                    // would prefer huge builds to be interleaved with other signing tasks.
+                    let signing_permit = task_signer.concurrency.acquire().await?;
+                    let _active_guard =
+                        Gauge::increment(crate::metrics_utils::rpms_active(), 1_f64);
+                    let path = download(&task_signer.http_client, target_dir, &rpm).await?;
+                    let _storage_guard =
+                        Gauge::from_gauge(crate::metrics_utils::rpms_storage(), rpm.size as f64);
+
+                    let mut command = Command::new("rpmsign");
+                    command
+                        .kill_on_drop(true)
+                        .env_clear()
+                        .env("OPENSSL_CONF", &task_signer.pgp_home.openssl_config)
+                        .env("GNUPGHOME", &gpg_home)
+                        .env("SEQUOIA_HOME", &task_signer.pgp_home.sq_homedir)
+                        .arg("--resign")
+                        .arg(format!("--key-id={fingerprint}"));
+                    match task_signer.config.rpm.signing_tool {
+                        SigningTool::Sq => command.arg("--define").arg("_openpgp_sign sq"),
+                        SigningTool::Gpg => command
+                            .arg("--define")
+                            .arg("_openpgp_sign gpg")
+                            .arg("--define")
+                            .arg("_gpg_sign_cmd_extra_args --batch --pinentry-mode cancel"),
+                    };
+                    if task_signer.config.rpm.with_rpmv4 {
+                        command.arg("--rpmv4");
+                    }
+                    if let (Some(file_signing_key), Some(cert)) =
+                        (&file_signing_key, &ima_certificate)
+                    {
+                        let cert = openssl::x509::X509::from_pem(cert.certificate.as_bytes())?;
+                        let keyid = cert
+                            .subject_key_id()
+                            .ok_or_else(|| {
+                                anyhow::anyhow!(
+                                    "IMA certificate is missing a Subject Key Identifier extension"
+                                )
+                            })?
+                            .as_slice()
+                            .last_chunk::<4>()
+                            .map(|b| u32::from_be_bytes(*b))
+                            .ok_or_else(|| {
+                                anyhow::anyhow!(
+                                    "IMA certificate's Subject Key Identifier is too short"
+                                )
+                            })?;
+                        command
+                            .arg("--signfiles")
+                            .arg("--fskpath")
+                            .arg(format!(
+                                "pkcs11:model=Siguldry;token={};type=private",
+                                file_signing_key.siguldry_key
+                            ))
+                            .arg("--define")
+                            .arg(format!("_file_signing_key_id {keyid}"));
+                        tracing::debug!(
+                            siguldry_key = file_signing_key.siguldry_key,
+                            siguldry_cert = file_signing_key.siguldry_x509_cert,
+                            ima_keyid = keyid,
+                            "Signing RPM for IMA"
+                        );
+                    }
+                    let sign_start_time = std::time::Instant::now();
+                    let output = command
+                        .arg(&path)
+                        .output()
+                        .await
+                        .context("Failed to spawn rpmsign; is it installed?")?;
+                    let sign_time = sign_start_time.elapsed();
+                    crate::metrics_utils::rpms_sign_time().record(sign_time.as_secs() as f64);
+                    drop(signing_permit);
+
+                    if !output.status.success() {
+                        tracing::error!(
+                            exit_code = ?output.status.code(),
+                            stdout = %String::from_utf8_lossy(&output.stdout),
+                            stderr = %String::from_utf8_lossy(&output.stderr),
+                            "Signing command failed: '{command:?}'",
+                        );
+
+                        return Err(anyhow::anyhow!("Failed to run rpmsign"));
+                    } else {
+                        tracing::debug!(
+                            signing_command = ?command,
+                            "Successfully ran signing command"
+                        );
+                        let siguldry_key_ima = file_signing_key
+                            .as_ref()
+                            .map(|ima| ima.siguldry_key.as_str());
+                        tracing::info!(
+                            rpm.id,
+                            rpm.name,
+                            rpm.version,
+                            rpm.release,
+                            siguldry_key,
+                            siguldry_key_ima,
+                            "Successfully signed RPM"
+                        );
+                    }
+
+                    task_signer
+                        .koji
+                        .add_signature(rpm.id, expected_sigkey, path)
+                        .await?;
+
+                    Ok::<_, anyhow::Error>(())
+                }
+                .instrument(rpm_span),
+            );
+        }
+
+        // Wait for all the signatures to complete and, if all succeed, move the build over.
+        // In the event that some fail we return the error and retry later; we'll skip over
+        // any RPM that has been signed by the requested key ID, so we'll keep making forward
+        // progress.
+        signing_tasks
+            .join_all()
+            .await
+            .into_iter()
+            .inspect(|result| {
+                if result.is_err() {
+                    crate::metrics_utils::rpms_failed().increment(1);
+                } else {
+                    crate::metrics_utils::rpms_signed().increment(1);
+                }
+            })
+            .collect::<Result<(), _>>()?;
+
+        tracing::info!(
+            sigkey,
+            tag_from,
+            tag_to,
+            "All RPMs successfully signed; sending build move request to Koji"
+        );
+        self.koji
+            .move_build(build.build_id, sigkey, tag_from, tag_to)
+            .await?;
+
+        // This won't catch cleanup failures where the drop happens in prior error paths
+        let path = temp_dir.path().display().to_string();
+        if let Err(error) = temp_dir.close() {
+            tracing::error!(
+                ?error,
+                path,
+                "Temporary directory used for RPMs failed to clean up"
+            );
+        }
+
+        Ok(())
+    }
+}
+
+#[instrument(skip_all, err)]
+async fn download(
+    http_client: &reqwest::Client,
+    dest_dir: PathBuf,
+    rpm: &Rpm,
+) -> anyhow::Result<PathBuf> {
+    let url = reqwest::Url::parse(&rpm.url)?;
+    // We don't have the RPM arch, and this seems like the easiest way to make a unique name
+    let destination = dest_dir.join(Uuid::new_v4().to_string());
+
+    tracing::debug!(path = url.path(), "Attempting to download RPM from Koji");
+
+    // TODO: be more precise
+    let mut response = http_client.get(url).send().await?.error_for_status()?;
+    let content_length = response.content_length();
+    tracing::debug!(content_length, rpm.size, "Response received");
+
+    let file = tokio::fs::OpenOptions::new()
+        .create_new(true)
+        .write(true)
+        .mode(0o600)
+        .open(&destination)
+        .await?;
+    let mut file = BufWriter::new(file);
+    let mut bytes_written = 0;
+    let artifact_size_gauge = crate::metrics_utils::rpms_storage();
+    let mut digest = Hasher::new(MessageDigest::sha256())?;
+    while let Some(chunk) = response.chunk().await? {
+        let chunk_size = chunk.len();
+        tracing::trace!(?destination, chunk_size, "Writing chunk to file");
+        file.write_all(&chunk).await?;
+        bytes_written += chunk_size;
+        artifact_size_gauge.increment(chunk_size as f64);
+        digest.update(&chunk)?;
+    }
+    file.shutdown().await?;
+    drop(file);
+
+    let expected_digest = hex::decode(&rpm.sha256sum)?;
+    let actual_digest = digest.finish()?;
+    let hex_checksum = hex::encode(actual_digest);
+    if expected_digest.as_slice() != actual_digest.as_ref() {
+        tracing::error!(
+            expected_bytes = rpm.size,
+            expected_checksum = rpm.sha256sum,
+            actual_bytes = bytes_written,
+            actual_checksum = hex_checksum,
+            "RPM checksum mismatch"
+        );
+        return Err(anyhow::anyhow!(
+            "Downloaded RPM checksum did not match advertised checksum"
+        ));
+    }
+    tracing::info!(
+        bytes_written,
+        sha256sum = hex_checksum,
+        rpm.name,
+        rpm.epoch,
+        rpm.version,
+        rpm.release,
+        "Completed RPM download"
+    );
+
+    Ok(destination)
+}
+
+// Wrapper that decrements on drop.
+struct Gauge {
+    inner: metrics::Gauge,
+    amount: f64,
+}
+
+impl Gauge {
+    /// Increment the gauge by the given amount, then decrement by that amount on drop.
+    fn increment(inner: metrics::Gauge, amount: f64) -> Self {
+        inner.increment(amount);
+        Self { inner, amount }
+    }
+
+    /// Decrement the given amount from the gauge on drop.
+    fn from_gauge(inner: metrics::Gauge, amount: f64) -> Self {
+        Self { inner, amount }
+    }
+}
+
+impl Drop for Gauge {
+    fn drop(&mut self) {
+        self.inner.decrement(self.amount);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::os::unix::fs::MetadataExt;
+
+    use tokio::sync::{
+        Mutex,
+        mpsc::{self, UnboundedReceiver, UnboundedSender},
+    };
+
+    use siguldry::protocol::{Certificate, CertificateType, KeyAlgorithm};
+    use wiremock::{
+        Mock, MockServer, ResponseTemplate,
+        matchers::{method, path},
+    };
+
+    use crate::{
+        config::Tag,
+        koji::{Build, TagEvent},
+    };
+
+    use super::*;
+
+    /// Build a `signing_keys` map containing the `demo` key referenced by [`sample_tag`].
+    fn demo_signing_keys() -> HashMap<String, Key> {
+        let mut keys = HashMap::new();
+        keys.insert(
+            "demo".to_string(),
+            Key {
+                name: "demo".to_string(),
+                key_algorithm: KeyAlgorithm::default(),
+                handle: "demo-handle".to_string(),
+                public_key: String::new(),
+                certificates: vec![Certificate {
+                    certificate: String::new(),
+                    certificate_type: CertificateType::Pgp,
+                    fingerprint: "DEADBEEF".to_string(),
+                    name: "demo-openpgp".to_string(),
+                }],
+            },
+        );
+        keys
+    }
+
+    fn signer_with_keys(
+        config: Config,
+        koji: StubKoji,
+        signing_keys: HashMap<String, Key>,
+    ) -> KojiSigner<StubKoji> {
+        let http_client = reqwest::Client::builder().build().unwrap();
+        let pgp_home = PgpConfig {
+            openssl_config: PathBuf::new(),
+            sq_homedir: PathBuf::new(),
+            gpg_homedirs: HashMap::new(),
+        };
+        KojiSigner::new(
+            Arc::new(config),
+            Arc::new(Semaphore::new(4)),
+            Arc::new(pgp_home),
+            Arc::new(signing_keys),
+            http_client,
+            koji,
+        )
+    }
+
+    fn sample_tag(from: &str, to: &str) -> Tag {
+        Tag {
+            from: from.to_string(),
+            to: to.to_string(),
+            siguldry_key: "demo".to_string(),
+            siguldry_openpgp_cert: "demo-openpgp".to_string(),
+            file_signing_key: None,
+            trusted_taggers: vec!["bodhi".to_string()],
+            sidetags: None,
+        }
+    }
+
+    #[test]
+    fn active_tag_returns_none_for_empty_history() {
+        let build = Build::default();
+        assert!(build.tag_history.is_empty());
+        assert!(build.active_tag().is_none());
+    }
+
+    #[test]
+    fn active_tag_returns_event_with_largest_create_event() {
+        let build = Build {
+            tag_history: vec![
+                TagEvent {
+                    create_event: 1,
+                    creator_name: "nobody".into(),
+                    tag_name: "old".into(),
+                },
+                TagEvent {
+                    create_event: 5,
+                    creator_name: "somebody".into(),
+                    tag_name: "newest".into(),
+                },
+                TagEvent {
+                    create_event: 3,
+                    creator_name: "everybody".into(),
+                    tag_name: "middle".into(),
+                },
+            ],
+            ..Default::default()
+        };
+
+        let active = build.active_tag().unwrap();
+        assert_eq!(active.create_event, 5);
+        assert_eq!(active.tag_name, "newest");
+        assert_eq!(active.creator_name, "somebody");
+    }
+
+    fn sample_build_msg(instance: &str) -> BuildsysTag {
+        BuildsysTag {
+            build_id: 0,
+            name: "pkg".into(),
+            tag_id: 1,
+            instance: instance.into(),
+            tag: "f45-signing-pending".into(),
+            user: "bodhi".into(),
+            version: "1".into(),
+            owner: "owner".into(),
+            release: "1.fc45".into(),
+        }
+    }
+
+    /// A mock [`KojiOps`] implementation that returns a fake build and records requests.
+    #[derive(Clone)]
+    struct StubKoji {
+        build: Build,
+        signatures: Arc<UnboundedReceiver<(i64, String, PathBuf)>>,
+        signature_sender: UnboundedSender<(i64, String, PathBuf)>,
+        #[allow(clippy::type_complexity)]
+        move_build: Arc<Mutex<UnboundedReceiver<(i64, String, String, String)>>>,
+        move_build_sender: UnboundedSender<(i64, String, String, String)>,
+    }
+
+    impl StubKoji {
+        pub fn new(build: Build) -> Self {
+            let (signature_sender, signatures) = mpsc::unbounded_channel();
+            let (move_build_sender, move_build) = mpsc::unbounded_channel();
+            Self {
+                build,
+                signatures: Arc::new(signatures),
+                signature_sender,
+                move_build: Arc::new(Mutex::new(move_build)),
+                move_build_sender,
+            }
+        }
+    }
+
+    impl KojiOps for StubKoji {
+        async fn build_info(&self, build_id: i64) -> anyhow::Result<Build> {
+            assert_eq!(self.build.id, build_id);
+            Ok(self.build.clone())
+        }
+        async fn add_signature(
+            &self,
+            rpm_id: i64,
+            expected_sigkey: String,
+            signed_package: PathBuf,
+        ) -> anyhow::Result<()> {
+            self.signature_sender
+                .send((rpm_id, expected_sigkey, signed_package))?;
+            Ok(())
+        }
+        async fn move_build(
+            &self,
+            build_id: i64,
+            expected_sigkey: String,
+            tag_from: String,
+            tag_to: String,
+        ) -> anyhow::Result<i64> {
+            assert_eq!(self.build.id, build_id);
+            self.move_build_sender
+                .send((build_id, expected_sigkey, tag_from, tag_to))?;
+            Ok(1)
+        }
+    }
+
+    fn keyless_signer(config: Config, koji: StubKoji) -> KojiSigner<StubKoji> {
+        let http_client = reqwest::Client::builder().build().unwrap();
+        let pgp_home = PgpConfig {
+            openssl_config: PathBuf::new(),
+            sq_homedir: PathBuf::new(),
+            gpg_homedirs: HashMap::new(),
+        };
+        KojiSigner::new(
+            Arc::new(config),
+            Arc::new(Semaphore::new(4)),
+            Arc::new(pgp_home),
+            Arc::new(HashMap::new()),
+            http_client,
+            koji,
+        )
+    }
+
+    #[tokio::test]
+    async fn sign_returns_ok_when_no_tag_rule_matches() {
+        let mut config = Config::default();
+        config.koji.instance = "primary".into();
+        config.koji.tags = vec![sample_tag("some-other-tag", "some-other-dest")];
+        let stub = StubKoji::new(Build {
+            tag_history: vec![TagEvent {
+                create_event: 1,
+                creator_name: "bodhi".into(),
+                tag_name: "f45-signing-pending".into(),
+            }],
+            ..Default::default()
+        });
+        let signer = keyless_signer(config, stub);
+        signer.sign(sample_build_msg("primary")).await.unwrap();
+        assert!(signer.koji.signatures.is_empty());
+    }
+
+    /// A missing signing key in the lookup table results in a useful error message
+    #[tokio::test]
+    async fn sign_is_missing_key() {
+        let mut config = Config::default();
+        config.koji.instance = "primary".into();
+        config.koji.tags = vec![sample_tag("f45-signing-pending", "f45-testing-pending")];
+        let stub = StubKoji::new(Build {
+            tag_history: vec![TagEvent {
+                create_event: 1,
+                creator_name: "bodhi".into(),
+                tag_name: "f45-signing-pending".into(),
+            }],
+            ..Default::default()
+        });
+        let signer = keyless_signer(config, stub);
+        let result = signer.sign(sample_build_msg("primary")).await.unwrap_err();
+        assert_eq!(
+            format!("{result}"),
+            "Failed to find the OpenPGP certificate demo-openpgp for signing key demo"
+        );
+    }
+
+    /// A bit of a weird case, but a build with no RPMs shouldn't crash
+    #[tokio::test]
+    async fn sign_no_rpms() {
+        let mut config = Config::default();
+        config.koji.instance = "primary".into();
+        config.koji.tags = vec![sample_tag("f45-signing-pending", "f45-testing-pending")];
+        let stub = StubKoji::new(Build {
+            tag_history: vec![TagEvent {
+                create_event: 1,
+                creator_name: "bodhi".into(),
+                tag_name: "f45-signing-pending".into(),
+            }],
+            ..Default::default()
+        });
+        let signer = signer_with_keys(config, stub, demo_signing_keys());
+        signer.sign(sample_build_msg("primary")).await.unwrap();
+        assert!(signer.koji.signatures.is_empty());
+        let (_build_id, _sigkey, from, to) =
+            signer.koji.move_build.lock().await.recv().await.unwrap();
+
+        assert_eq!(from, "f45-signing-pending");
+        assert_eq!(to, "f45-testing-pending");
+    }
+
+    fn rpm_for(url: String, body: &[u8]) -> Rpm {
+        let mut hasher = Hasher::new(MessageDigest::sha256()).unwrap();
+        hasher.update(body).unwrap();
+        let sha256sum = hex::encode(hasher.finish().unwrap());
+
+        Rpm {
+            id: 1,
+            draft: false,
+            epoch: None,
+            name: "hello".into(),
+            version: "1".into(),
+            release: "1.fc45".into(),
+            size: body.len() as u64,
+            url,
+            sha256sum,
+            existing_sigkeys: vec![],
+        }
+    }
+
+    #[tokio::test]
+    async fn download_succeeds() -> anyhow::Result<()> {
+        let body = b"hello, world".to_vec();
+        let server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path("/hello.rpm"))
+            .respond_with(ResponseTemplate::new(200).set_body_bytes(body.clone()))
+            .mount(&server)
+            .await;
+
+        let temp_dir = tempfile::tempdir()?;
+        let client = reqwest::Client::builder().build()?;
+        let rpm = rpm_for(format!("{}/hello.rpm", server.uri()), &body);
+
+        let path = download(&client, temp_dir.path().to_path_buf(), &rpm).await?;
+
+        assert!(path.exists());
+        assert!(path.starts_with(temp_dir.path()));
+        let metadata = tokio::fs::metadata(&path).await?;
+        assert_eq!(metadata.mode() & 0o777, 0o600);
+        let written = tokio::fs::read(&path).await?;
+        assert_eq!(written, body);
+
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn download_checksum_mismatch_errors() -> anyhow::Result<()> {
+        let body = b"hello, world".to_vec();
+        let server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path("/hello.rpm"))
+            .respond_with(ResponseTemplate::new(200).set_body_bytes(body.clone()))
+            .mount(&server)
+            .await;
+
+        let temp_dir = tempfile::tempdir()?;
+        let client = reqwest::Client::builder().build()?;
+        let mut rpm = rpm_for(format!("{}/hello.rpm", server.uri()), &body);
+        rpm.sha256sum = "42".repeat(32);
+
+        let error = download(&client, temp_dir.path().to_path_buf(), &rpm)
+            .await
+            .unwrap_err();
+        assert!(
+            format!("{error}")
+                .contains("Downloaded RPM checksum did not match advertised checksum"),
+            "unexpected error: {error}"
+        );
+
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn download_http_5xx_errors() {
+        let body = b"hello, world".to_vec();
+        let server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path("/hello.rpm"))
+            .respond_with(ResponseTemplate::new(500))
+            .mount(&server)
+            .await;
+
+        let temp_dir = tempfile::tempdir().unwrap();
+        let client = reqwest::Client::builder().build().unwrap();
+        let rpm = rpm_for(format!("{}/hello.rpm", server.uri()), &body);
+
+        let _error = download(&client, temp_dir.path().to_path_buf(), &rpm)
+            .await
+            .unwrap_err();
+    }
+}

--- a/siguldry-fedora-autopen/tests/ostree.rs
+++ b/siguldry-fedora-autopen/tests/ostree.rs
@@ -1,0 +1,197 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) Microsoft Corporation.
+
+//! Integration tests for OSTree signing.
+
+use std::path::{Path, PathBuf};
+
+use anyhow::Context;
+use siguldry_test::{InstanceBuilder, keys};
+
+fn autopen_binary() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .parent()
+        .unwrap()
+        .join("target/debug/siguldry-fedora-autopen")
+}
+
+async fn ostree(args: &[&str]) -> anyhow::Result<String> {
+    let output = tokio::process::Command::new("ostree")
+        .args(args)
+        .output()
+        .await
+        .context("Failed to spawn ostree; is it installed?")?;
+    if !output.status.success() {
+        anyhow::bail!(
+            "ostree {args:?} failed:\nstdout: {}\nstderr: {}",
+            String::from_utf8_lossy(&output.stdout),
+            String::from_utf8_lossy(&output.stderr),
+        );
+    }
+    Ok(String::from_utf8(output.stdout)?)
+}
+
+async fn init_repo_with_commit(
+    repo_dir: &Path,
+    content_dir: &Path,
+    branch: &str,
+) -> anyhow::Result<String> {
+    tokio::fs::create_dir_all(repo_dir).await?;
+    tokio::fs::create_dir_all(content_dir).await?;
+    tokio::fs::write(content_dir.join("hello.txt"), b"hello, ostree\n").await?;
+
+    ostree(&[
+        &format!("--repo={}", repo_dir.display()),
+        "init",
+        "--mode=archive",
+    ])
+    .await?;
+
+    let commit = ostree(&[
+        &format!("--repo={}", repo_dir.display()),
+        "commit",
+        &format!("--branch={branch}"),
+        &format!("--tree=dir={}", content_dir.display()),
+        "--subject=test",
+    ])
+    .await?;
+
+    Ok(commit.trim().to_string())
+}
+
+#[tokio::test]
+#[tracing_test::traced_test]
+async fn process_ostree_compose() -> anyhow::Result<()> {
+    let instance = InstanceBuilder::new()
+        .with_pgp_key()
+        .auto_unlock_keys()
+        .with_client_proxy()
+        .build()
+        .await?;
+
+    // Find the OpenPGP cert that was auto-created for the PGP key.
+    let key = instance
+        .client
+        .get_key(keys::PGP_KEY_NAME.to_string())
+        .await?;
+    let cert = key
+        .openpgp_certificates()
+        .first()
+        .cloned()
+        .context("PGP key has no OpenPGP certificate")?;
+
+    let state = instance.state_dir.path();
+    let repo_dir = state.join("ostree-repo");
+    let content_dir = state.join("ostree-content");
+    let reference = "fedora/test/x86_64/iot";
+    let commit = init_repo_with_commit(&repo_dir, &content_dir, reference).await?;
+
+    let proxy_socket = instance.client_proxy_socket();
+    let config_path = state.join("fedora-autopen.toml");
+    let config = format!(
+        r#"
+[amqp]
+amqp_url = "amqp://example.com/%2Fpublic_pubsub"
+[amqp.tls]
+ca_cert = "/dev/null"
+keyfile = "/dev/null"
+certfile = "/dev/null"
+[[amqp.bindings]]
+exchange = "amq.topic"
+routing_keys = []
+
+[siguldry]
+client_proxy_socket = "{proxy_socket}"
+
+[[ostree]]
+reference = "{reference}"
+directory = "{repo_dir}"
+siguldry_key = "{key_name}"
+siguldry_openpgp_cert = "{cert_name}"
+"#,
+        proxy_socket = proxy_socket.display(),
+        repo_dir = repo_dir.display(),
+        key_name = keys::PGP_KEY_NAME,
+        cert_name = cert.name,
+    );
+    tokio::fs::write(&config_path, config).await?;
+
+    let message_path = state.join("message.json");
+    let message = serde_json::json!({
+        "body": {
+            "arch": "x86_64",
+            "commitid": commit,
+            "compose_date": "20260501",
+            "compose_id": "Fedora-IoT-45-20260501.0",
+            "compose_label": "RC-20260501.0",
+            "compose_path": "/mnt/koji/compose/iot/Fedora-IoT-45-20260501.0",
+            "compose_respin": 0,
+            "compose_type": "production",
+            "local_repo_path": "/mnt/koji/compose/iot/repo/",
+            "location": "https://example.com/compose",
+            "ref": reference,
+            "release_is_layered": false,
+            "release_name": "Fedora-IoT",
+            "release_short": "Fedora-IoT",
+            "release_type": "ga",
+            "release_version": "45",
+            "repo_path": "https://example.com/repo",
+            "variant": "IoT",
+        },
+        "headers": {
+            "fedora_messaging_schema": "base.message",
+            "fedora_messaging_severity": 20,
+            "priority": 10,
+            "sent-at": "2026-05-01T00:00:00+00:00",
+        },
+        "id": "f4b148e2-f492-43c4-9dc0-24e903f003fa",
+        "priority": 10,
+        "queue": null,
+        "topic": "org.fedoraproject.prod.pungi.compose.ostree",
+    });
+    tokio::fs::write(&message_path, serde_json::to_vec_pretty(&message)?).await?;
+
+    let output = tokio::process::Command::new(autopen_binary())
+        .env_clear()
+        .arg("--config")
+        .arg(&config_path)
+        .arg("process")
+        .arg(&message_path)
+        .output()
+        .await
+        .context("Failed to spawn siguldry-fedora-autopen; run `cargo build -p siguldry-fedora-autopen` first")?;
+    assert!(
+        output.status.success(),
+        "siguldry-fedora-autopen process exited with {:?}\nstdout: {}\nstderr: {}",
+        output.status.code(),
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr),
+    );
+
+    let refs = ostree(&[&format!("--repo={}", repo_dir.display()), "refs"]).await?;
+    assert!(
+        refs.lines().any(|line| line.trim() == reference),
+        "expected ref {reference} in refs list, got {refs}"
+    );
+    let revision = ostree(&[
+        &format!("--repo={}", repo_dir.display()),
+        "rev-parse",
+        reference,
+    ])
+    .await?;
+    assert_eq!(
+        revision.trim(),
+        commit,
+        "ref does not point to signed commit"
+    );
+
+    // The commit should have GPG signature metadata attached.
+    let show = ostree(&[&format!("--repo={}", repo_dir.display()), "show", &commit]).await?;
+    assert!(
+        show.to_lowercase().contains("signature"),
+        "expected signature:\n{show}"
+    );
+
+    instance.halt().await?;
+    Ok(())
+}

--- a/siguldry-test/src/lib.rs
+++ b/siguldry-test/src/lib.rs
@@ -672,9 +672,24 @@ impl InstanceBuilder {
         let listener = UnixListener::bind(&socket_path)?;
 
         let proxy = tokio::spawn(async move {
-            let (stream, _) = listener.accept().await?;
-            let (reader, writer) = tokio::io::split(stream);
-            siguldry::client::proxy(client, proxy_halt, reader, writer).await?;
+            loop {
+                tokio::select! {
+                    _ = proxy_halt.cancelled() => break,
+                    accepted = listener.accept() => {
+                        let (stream, _) = accepted?;
+                        let client = client.clone();
+                        let conn_halt = proxy_halt.clone();
+                        tokio::spawn(async move {
+                            let (reader, writer) = tokio::io::split(stream);
+                            if let Err(error) =
+                                siguldry::client::proxy(client, conn_halt, reader, writer).await
+                            {
+                                tracing::warn!(?error, "client proxy connection failed");
+                            }
+                        });
+                    }
+                }
+            }
             Ok::<_, anyhow::Error>(())
         });
 


### PR DESCRIPTION
This provides feature parity with robosignatory. It handles RPMs with rpmsign (rpm v6.1.0 required), ostree, and CoreOS artifacts.

A more general file signing protocol, discussed in #204, will follow, and container support also needs to be worked out.
