### PR TITLE
Various log verbosity adjustments

### DIFF
--- a/siguldry/src/bin/siguldry-bridge/main.rs
+++ b/siguldry/src/bin/siguldry-bridge/main.rs
@@ -33,6 +33,13 @@ struct Cli {
     #[arg(long, short, env = "SIGULDRY_BRIDGE_CONFIG")]
     config: Option<PathBuf>,
 
+    /// Emit logs when new tracing spans are created, and when they are closed.
+    ///
+    /// This is useful in debugging scenarios to trace functions and tasks, but can lead to rather
+    /// verbose logs.
+    #[arg(long)]
+    pub span_events: bool,
+
     /// A set of one or more comma-separated directives to filter logs.
     ///
     /// The general format is "target_name[span_name{field=value}]=level" where level is
@@ -95,13 +102,17 @@ async fn main() -> anyhow::Result<()> {
             https://docs.rs/tracing-subscriber/0.3.19/tracing_subscriber/\
             filter/struct.EnvFilter.html#directives for format details.",
     )?;
+
+    let registry = tracing_subscriber::registry();
     let stderr_layer = tracing_subscriber::fmt::layer()
-        .with_span_events(FmtSpan::NEW | FmtSpan::CLOSE)
         .without_time()
         .with_writer(std::io::stderr);
-    let registry = tracing_subscriber::registry()
-        .with(stderr_layer)
-        .with(log_filter);
+    let registry = if opts.span_events {
+        registry.with(stderr_layer.with_span_events(FmtSpan::NEW | FmtSpan::CLOSE))
+    } else {
+        registry.with(stderr_layer)
+    };
+    let registry = registry.with(log_filter);
     tracing::subscriber::set_global_default(registry)
         .expect("Programming error: set_global_default should only be called once.");
 

--- a/siguldry/src/bin/siguldry-client/main.rs
+++ b/siguldry/src/bin/siguldry-client/main.rs
@@ -32,6 +32,13 @@ struct Cli {
     #[arg(long, short, env = "SIGULDRY_CLIENT_CONFIG")]
     config: Option<PathBuf>,
 
+    /// Emit logs when new tracing spans are created, and when they are closed.
+    ///
+    /// This is useful in debugging scenarios to trace functions and tasks, but can lead to rather
+    /// verbose logs.
+    #[arg(long)]
+    pub span_events: bool,
+
     /// The directory containing the client's authentication secrets.
     ///
     /// Any file referenced in the configuration that are not absolute paths are
@@ -130,13 +137,16 @@ async fn main() -> anyhow::Result<()> {
             https://docs.rs/tracing-subscriber/0.3.19/tracing_subscriber/\
             filter/struct.EnvFilter.html#directives for format details.",
     )?;
+    let registry = tracing_subscriber::registry();
     let stderr_layer = tracing_subscriber::fmt::layer()
-        .with_span_events(FmtSpan::NEW | FmtSpan::CLOSE)
         .without_time()
         .with_writer(std::io::stderr);
-    let registry = tracing_subscriber::registry()
-        .with(stderr_layer)
-        .with(log_filter);
+    let registry = if opts.span_events {
+        registry.with(stderr_layer.with_span_events(FmtSpan::NEW | FmtSpan::CLOSE))
+    } else {
+        registry.with(stderr_layer)
+    };
+    let registry = registry.with(log_filter);
     tracing::subscriber::set_global_default(registry)
         .expect("Programming error: set_global_default should only be called once.");
 

--- a/siguldry/src/bin/siguldry-server/cli.rs
+++ b/siguldry/src/bin/siguldry-server/cli.rs
@@ -34,6 +34,13 @@ pub struct Cli {
     #[arg(long, short, env = "SIGULDRY_SERVER_CONFIG")]
     pub config: Option<PathBuf>,
 
+    /// Emit logs when new tracing spans are created, and when they are closed.
+    ///
+    /// This is useful in debugging scenarios to trace functions and tasks, but can lead to rather
+    /// verbose logs.
+    #[arg(long)]
+    pub span_events: bool,
+
     /// A set of one or more comma-separated directives to filter logs.
     ///
     /// The general format is "target_name[span_name{field=value}]=level" where level is

--- a/siguldry/src/bin/siguldry-server/main.rs
+++ b/siguldry/src/bin/siguldry-server/main.rs
@@ -51,13 +51,17 @@ async fn main() -> anyhow::Result<()> {
         )
     }?;
 
+    let registry = tracing_subscriber::registry();
     let stderr_layer = tracing_subscriber::fmt::layer()
-        .with_span_events(FmtSpan::NEW | FmtSpan::CLOSE)
         .without_time()
         .with_writer(std::io::stderr);
-    let registry = tracing_subscriber::registry()
-        .with(stderr_layer)
-        .with(log_filter);
+
+    let registry = if opts.span_events {
+        registry.with(stderr_layer.with_span_events(FmtSpan::NEW | FmtSpan::CLOSE))
+    } else {
+        registry.with(stderr_layer)
+    };
+    let registry = registry.with(log_filter);
     tracing::subscriber::set_global_default(registry)
         .expect("Programming error: set_global_default should only be called once.");
 

--- a/siguldry/src/bin/siguldry-signer/main.rs
+++ b/siguldry/src/bin/siguldry-signer/main.rs
@@ -35,6 +35,13 @@ struct Cli {
     #[arg(long, env = "SIGULDRY_SIGNER_LOG", default_value = "INFO")]
     pub log_filter: String,
 
+    /// Emit logs when new tracing spans are created, and when they are closed.
+    ///
+    /// This is useful in debugging scenarios to trace functions and tasks, but can lead to rather
+    /// verbose logs.
+    #[arg(long)]
+    pub span_events: bool,
+
     /// If provided, bind a Unix socket to the given location and proxy clients
     /// that connect to it rather than using stdin/stdout.
     #[arg(long)]
@@ -52,13 +59,16 @@ async fn main() -> anyhow::Result<()> {
             https://docs.rs/tracing-subscriber/0.3.19/tracing_subscriber/\
             filter/struct.EnvFilter.html#directives for format details.",
     )?;
+    let registry = tracing_subscriber::registry();
     let stderr_layer = tracing_subscriber::fmt::layer()
-        .with_span_events(FmtSpan::NEW | FmtSpan::CLOSE)
         .without_time()
         .with_writer(std::io::stderr);
-    let registry = tracing_subscriber::registry()
-        .with(stderr_layer)
-        .with(log_filter);
+    let registry = if opts.span_events {
+        registry.with(stderr_layer.with_span_events(FmtSpan::NEW | FmtSpan::CLOSE))
+    } else {
+        registry.with(stderr_layer)
+    };
+    let registry = registry.with(log_filter);
     tracing::subscriber::set_global_default(registry)
         .expect("Programming error: set_global_default should only be called once.");
     let halt_token = CancellationToken::new();

--- a/siguldry/src/bridge.rs
+++ b/siguldry/src/bridge.rs
@@ -99,9 +99,9 @@ async fn accept_conn(
 
     let peer_name = peer_common_name(&stream);
     match &peer_name {
-        Ok(username) => {
+        Ok(user) => {
             // We defer acking good connections until we have both sides so that they can share a session id
-            tracing::info!(username, ?role, "Sigul connection established");
+            tracing::info!(user, ?role, "Connection established");
         }
         Err(protocol::Error::MissingCommonName) => {
             tracing::warn!(
@@ -299,7 +299,7 @@ pub async fn listen(config: Config) -> anyhow::Result<Listener> {
     fields(
         client_addr = ?client.1,
         server_addr = ?server.1,
-        session_id = Uuid::from_u128(ack.session_id.get()).to_string()
+        session_id = %Uuid::from_u128(ack.session_id.get())
     )
 )]
 async fn bridge(

--- a/siguldry/src/server/crypto/signing.rs
+++ b/siguldry/src/server/crypto/signing.rs
@@ -45,6 +45,8 @@ pub fn sign_with_softkey(
             KeyAlgorithm::Rsa2K | KeyAlgorithm::Rsa4K => protocol::SignaturePayload::RSA(signature),
             KeyAlgorithm::P256 => protocol::SignaturePayload::P256(signature),
         };
+
+        tracing::info!(digest_algorithm=%algorithm, digest=hex_hash, "Signature issued");
         signatures.push(protocol::Signature {
             signature,
             digest: algorithm,
@@ -113,6 +115,7 @@ pub fn sign_with_pkcs11(
             }
         };
 
+        tracing::info!(digest_algorithm=%algorithm, digest=hex_hash, "Signature issued");
         signatures.push(protocol::Signature {
             signature,
             digest: algorithm,

--- a/siguldry/src/server/handlers.rs
+++ b/siguldry/src/server/handlers.rs
@@ -37,6 +37,7 @@ impl Handler {
 
     #[instrument(skip_all, err)]
     pub(crate) fn who_am_i(&self) -> Result<Response, ServerError> {
+        tracing::debug!("WhoAmI request successfully processed");
         Ok(Response::WhoAmI {
             user: self.user.name.clone(),
         })
@@ -59,17 +60,24 @@ impl Handler {
                 certificates,
             });
         }
-
+        tracing::debug!(
+            num_keys = keys.len(),
+            "ListKeys request successfully processed"
+        );
         Ok(Response::ListKeys { keys })
     }
 
-    #[instrument(skip_all, err, fields(key))]
+    #[instrument(skip_all, err, fields(key = key))]
     pub(crate) async fn unlock(
         &mut self,
         key: String,
         password: String,
     ) -> Result<Response, ServerError> {
-        self.ipc_helper.unlock_request(key, password).await
+        let result = self.ipc_helper.unlock_request(key, password).await;
+        if result.is_err() {
+            tracing::error!("Failed to unlock key");
+        }
+        result
     }
 
     #[instrument(skip_all, err, fields(key = key_name))]
@@ -80,6 +88,7 @@ impl Handler {
     ) -> Result<Response, ServerError> {
         let key = db::Key::get(conn, &key_name).await?;
         let certificates = certs_for_key(conn, &key).await?;
+        tracing::debug!("GetKey request successfully processed");
 
         Ok(Response::GetKey {
             key: protocol::Key {
@@ -104,6 +113,7 @@ impl Handler {
             .sign_request(key_name.to_string(), vec![(digest_algorithm, digest)])
             .await?;
 
+        tracing::debug!("Sign request successfully processed");
         Ok(Response::Sign {
             signature: response.pop().unwrap(),
         })
@@ -120,11 +130,13 @@ impl Handler {
             .sign_request(key_name.to_string(), digests)
             .await?;
 
+        tracing::debug!("SignAll request successfully processed");
         Ok(Response::SignPrehashed { signatures })
     }
 
     #[instrument(skip_all, err)]
     pub(crate) async fn shutdown(self) -> anyhow::Result<()> {
+        tracing::debug!("Shutting down IPC client");
         self.ipc_helper.shutdown().await
     }
 }

--- a/siguldry/src/server/ipc.rs
+++ b/siguldry/src/server/ipc.rs
@@ -208,7 +208,7 @@ pub async fn serve<
     requests: R,
     mut responses: W,
 ) -> anyhow::Result<()> {
-    tracing::info!("Handling requests");
+    tracing::debug!("Handling requests");
     let mut requests = BufReader::new(requests).lines();
 
     // Keys that the client has unlocked are stored in this map of key names to key passwords.
@@ -389,6 +389,8 @@ async fn unlock(
         .await?;
         key_passwords.insert(key.name, UnlockedKey::Private { key: private_key });
     }
+
+    tracing::info!("Unlocked key");
     return Ok(());
 }
 

--- a/siguldry/src/server/ipc.rs
+++ b/siguldry/src/server/ipc.rs
@@ -199,7 +199,7 @@ impl Client {
 }
 
 /// Start a siguldry-signer helper server.
-#[instrument(name = "siguldry-signer", skip_all, fields(session_id = tracing::field::Empty))]
+#[instrument(name = "siguldry-signer", skip_all, fields(user = tracing::field::Empty, session_id = tracing::field::Empty))]
 pub async fn serve<
     R: AsyncRead + Unpin + std::fmt::Debug,
     W: AsyncWrite + Unpin + std::fmt::Debug,
@@ -226,7 +226,7 @@ pub async fn serve<
                     let request: Request = serde_json::from_str(&request)?;
                     match request {
                         Request::Config { user, database_path, session_id, pkcs11_bindings } => {
-                            tracing::Span::current().record("session_id", session_id.to_string());
+                            tracing::Span::current().record("session_id", tracing::field::display(session_id));
                             let mut response = serde_json::to_string(&Response::Success {  })?;
                             response.push('\n');
                             responses.write_all(response.as_bytes()).await?;
@@ -243,8 +243,9 @@ pub async fn serve<
     let db_pool = db::pool(&database_path, true).await?;
     let mut db_conn = db_pool.acquire().await?;
     let user = db::User::get(&mut db_conn, &user).await?;
+    tracing::Span::current().record("user", &user.name);
     drop(db_conn);
-    tracing::debug!(user.name, "siguldry-signer is configured and ready to use");
+    tracing::info!("siguldry-signer is configured and ready to accept requests");
 
     loop {
         let request = tokio::select! {

--- a/siguldry/src/server/service.rs
+++ b/siguldry/src/server/service.rs
@@ -111,7 +111,7 @@ impl Server {
 
                 match conn {
                     Some(Ok(Ok(conn))) => {
-                        tracing::info!("New request accepted");
+                        tracing::info!("New connection accepted");
                         while connection_pool.len() < self.config.connection_pool_size {
                             self.accept(&mut connection_pool)?;
                         }
@@ -189,8 +189,10 @@ async fn handle(
         .peer_common_name()
         .ok_or(protocol::Error::MissingCommonName)?;
     let mut db_conn = db.acquire().await?;
-    let user = db::User::get(&mut db_conn, &user).await?;
-    tracing::info!(user.name, "User authenticated");
+    let user = db::User::get(&mut db_conn, &user)
+        .await
+        .with_context(|| format!("Failed to look up user '{user}"))?;
+    tracing::info!("User authenticated");
     drop(db_conn);
 
     let mut request_handler =
@@ -201,7 +203,9 @@ async fn handle(
         let frame = protocol::Frame::try_ref_from_bytes(&frame_buffer)
             .map_err(|e| protocol::Error::Framing(format!("Invalid frame: {e:?}")))?;
         if frame.is_empty() {
-            tracing::info!("Connection sent empty frame indicating it is done; closing connection");
+            tracing::debug!(
+                "Connection sent empty frame indicating it is done; closing connection"
+            );
             break;
         } else {
             tracing::debug!(?frame, "New request frame received");
@@ -293,5 +297,7 @@ async fn handle(
     }
     request_handler.shutdown().await?;
     conn.shutdown().await?;
+    tracing::info!("Connection completed successfully");
+
     Ok(())
 }

--- a/siguldry/src/server/service.rs
+++ b/siguldry/src/server/service.rs
@@ -149,6 +149,9 @@ impl Server {
             tracing::debug!("Request tracker closed");
             connection_pool.shutdown().await;
             tracing::debug!("Connection pool shutdown");
+            if !request_tracker.is_empty() {
+                tracing::info!("Waiting for {} pending requests to complete", request_tracker.len());
+            }
             request_tracker.wait().await;
             tracing::info!("All pending requests are now complete");
 

--- a/siguldry/src/server/service.rs
+++ b/siguldry/src/server/service.rs
@@ -179,7 +179,7 @@ impl Server {
     }
 }
 
-#[instrument(skip_all, err, fields(session_id = conn.session_id().to_string(), client = conn.peer_common_name()))]
+#[instrument(skip_all, err, fields(session_id = %conn.session_id(), user = conn.peer_common_name()))]
 async fn handle(
     config: Arc<Config>,
     db: Pool<Sqlite>,


### PR DESCRIPTION
This series attempts to reduce the logging noise at INFO level. INFO should provide an overview of happenings without nitty gritty implementation detail logs (which should be debug or trace level).

The end result is that a client connection that unlocks one key and signs one digest looks like this on the server:

```text
2026-05-28T19:33:09.893123Z  INFO ec_prehashed_signature:handle{session_id=019e7013-8c54-7322-ba56-c9fda4bdc09e user="siguldry-client"}: siguldry::server::service: User authenticated
2026-05-28T19:33:09.895912Z  INFO ec_prehashed_signature:siguldry-signer{session_id=019e7013-8c54-7322-ba56-c9fda4bdc09e user="siguldry-client"}: siguldry::server::ipc: siguldry-signer is configured and ready to accept requests
2026-05-28T19:33:09.958596Z  INFO ec_prehashed_signature:siguldry-signer{session_id=019e7013-8c54-7322-ba56-c9fda4bdc09e user="siguldry-client"}:unlock{key="test-ec-key"}: siguldry::server::ipc: Unlocked key
2026-05-28T19:33:10.006496Z  INFO ec_prehashed_signature:siguldry-signer{session_id=019e7013-8c54-7322-ba56-c9fda4bdc09e user="siguldry-client"}:sign{key="test-ec-key"}: siguldry::server::crypto::signing: Signature issued digest_algorithm=sha256 digest="cf874cb88205c64e3c58fe3d76b4756ff8fb53421ee79c12ec5f68fe9de84ab5"
2026-05-28T19:33:10.064254Z  INFO ec_prehashed_signature:siguldry-signer{session_id=019e7013-8c54-7322-ba56-c9fda4bdc09e user="siguldry-client"}: siguldry::server::ipc: siguldry-signer received shut down signal
2026-05-28T19:33:10.064994Z  INFO ec_prehashed_signature:handle{session_id=019e7013-8c54-7322-ba56-c9fda4bdc09e user="siguldry-client"}: siguldry::server::service: Connection completed successfully
```

It's still possible to enable synthetic span events on open and close should it be necessary to get more verbose logs, and it's likely further work is required to ensure there's sufficient debug and trace level logs.