### PR TITLE
siguldry: ensure connections are cleanly shut down

### DIFF
--- a/siguldry-test/src/lib.rs
+++ b/siguldry-test/src/lib.rs
@@ -570,19 +570,21 @@ impl InstanceBuilder {
             let signer_halt = halt_token.clone();
 
             let signer = tokio::spawn(async move {
-                let stream = tokio::select! {
-                    _ = signer_halt.cancelled() => {
-                        return Ok(());
-                    }
-                    result = listener.accept() => {
-                        let (unix_stream, _) = result?;
-                        unix_stream
-                    }
-                };
-                tracing::info!("signing helper accepted connection");
-                let (reader, writer) = tokio::io::split(stream);
-                siguldry::server::ipc::serve(signer_halt, reader, writer).await?;
-                Ok::<_, anyhow::Error>(())
+                loop {
+                    let stream = tokio::select! {
+                        _ = signer_halt.cancelled() => {
+                            return Ok(());
+                        }
+                        result = listener.accept() => {
+                            let (unix_stream, _) = result?;
+                            unix_stream
+                        }
+                    };
+                    tracing::info!("signing helper accepted connection");
+                    let (reader, writer) = tokio::io::split(stream);
+                    let conn_halt = signer_halt.clone();
+                    siguldry::server::ipc::serve(conn_halt, reader, writer).await?;
+                }
             });
             (halt_token, signer)
         };

--- a/siguldry/src/bridge.rs
+++ b/siguldry/src/bridge.rs
@@ -3,7 +3,7 @@
 
 //! The Siguldry bridge.
 
-use std::{fmt::Debug, net::SocketAddr, pin::Pin, str::FromStr};
+use std::{fmt::Debug, net::SocketAddr, pin::Pin, str::FromStr, time::Duration};
 
 use anyhow::{Context, anyhow};
 use openssl::ssl::Ssl;
@@ -294,7 +294,6 @@ pub async fn listen(config: Config) -> anyhow::Result<Listener> {
 
 #[instrument(
     skip_all,
-    ret,
     err,
     fields(
         client_addr = ?client.1,
@@ -315,20 +314,89 @@ async fn bridge(
     )?;
     tracing::info!("Bridging new connection");
 
-    let size = 1024 * 64;
-    match tokio::io::copy_bidirectional_with_sizes(&mut client_conn, &mut server_conn, size, size)
-        .await
-    {
-        Ok((client_sent_bytes, server_sent_bytes)) => tracing::info!(
-            client_sent_bytes,
-            server_sent_bytes,
-            "Connection bridge completed"
-        ),
-        Err(result) => tracing::info!(
-            ?result,
-            "Connection bridge completed; connection closed ungracefully"
-        ),
-    };
+    // Tokio offers a copy_bidirectional function, but for some reason it's causing
+    // the connections to end ungracefully. This is a gross manual implementation and
+    // at some point we should investigate further why copy_bidirectional causes the
+    // connections to end with tls_retry_write_records failures.
+    //
+    // This approach is definitely the slowest way we could handle this, but payloads
+    // should be extremely small and requests relatively infrequent.
+    let mut client_to_server_buf = [0u8; 1024 * 16];
+    let mut server_to_client_buf = [0u8; 1024 * 16];
+    let mut client_read_done = false;
+    let mut server_read_done = false;
+    let mut client_sent_bytes: u64 = 0;
+    let mut server_sent_bytes: u64 = 0;
+
+    loop {
+        if client_read_done && server_read_done {
+            break;
+        }
+        tokio::select! {
+            result = client_conn.read(&mut client_to_server_buf), if !client_read_done => {
+                match result {
+                    Ok(0) => {
+                        tracing::trace!("Client sent EOF");
+                        client_read_done = true;
+                        if !server_read_done {
+                            match tokio::time::timeout(Duration::from_secs(10), server_conn.shutdown()).await {
+                                Ok(Ok(())) => tracing::trace!("Successfully closed server connection"),
+                                Ok(Err(error)) => tracing::warn!(?error, "Failed to gracefully shut down server connection"),
+                                Err(_elapsed) => tracing::warn!("Timed out waiting for the server connection to shut down"),
+                            }
+                        }
+                    }
+                    Ok(n) => {
+                        let slice = client_to_server_buf.get(..n).expect("AsyncRead impl provided invalid value");
+                        if let Err(error) = server_conn.write_all(slice).await {
+                            tracing::warn!(?error, "Failed to write client data to server connection");
+                        } else {
+                            tracing::trace!("Successfully forwarded {} bytes from client to server", n);
+                            client_sent_bytes += n as u64;
+                        }
+                    }
+                    Err(error) => {
+                        tracing::warn!(?error, "Error reading from client");
+                        client_read_done = true;
+                    }
+                }
+            }
+            result = server_conn.read(&mut server_to_client_buf), if !server_read_done => {
+                match result {
+                    Ok(0) => {
+                        tracing::trace!("Server sent EOF");
+                        server_read_done = true;
+                        if !client_read_done {
+                            match tokio::time::timeout(Duration::from_secs(10), client_conn.shutdown()).await {
+                                Ok(Ok(())) => tracing::trace!("Successfully closed client connection"),
+                                Ok(Err(error)) => tracing::warn!(?error, "Failed to gracefully shut down client connection"),
+                                Err(_elapsed) => tracing::warn!("Timed out waiting for the client connection to shut down"),
+                            }
+                        }
+                    }
+                    Ok(n) => {
+                        let slice = server_to_client_buf.get(..n).expect("AsyncRead impl provided invalid value");
+                        if let Err(error) = client_conn.write_all(slice).await {
+                            tracing::warn!(?error, "Failed to write server data to client connection");
+                        } else {
+                            tracing::trace!("Successfully forwarded {} bytes from server to client", n);
+                            server_sent_bytes += n as u64;
+                        }
+                    }
+                    Err(error) => {
+                        tracing::warn!(?error, "Error reading from server");
+                        server_read_done = true;
+                    }
+                }
+            }
+        }
+    }
+
+    tracing::info!(
+        client_sent_bytes,
+        server_sent_bytes,
+        "Connection bridge completed"
+    );
 
     Ok(())
 }

--- a/siguldry/src/client/proxy.rs
+++ b/siguldry/src/client/proxy.rs
@@ -12,6 +12,7 @@
 //! service provided by [`proxy`] except via [`ProxyClient`].
 
 use std::path::PathBuf;
+use std::time::Duration;
 
 use anyhow::Context;
 use serde::{Deserialize, Serialize};
@@ -99,16 +100,16 @@ pub async fn proxy<R: AsyncRead + Unpin, W: AsyncWrite + Unpin>(
     let mut requests = BufReader::new(requests).lines();
 
     let mut ipc_header: Option<IpcHeader> = None;
-    loop {
+    let result = loop {
         let line = tokio::select! {
             _ = halt_token.cancelled() => {
                 tracing::info!("proxy halted; shutting down");
-                return Ok(());
+                break Ok(());
             }
             line = requests.next_line() => {
                 if let Some(line) = line? { line } else {
                     tracing::debug!("EOF received for proxy");
-                    return Ok(());
+                    break Ok(());
                 }
             }
         };
@@ -125,7 +126,7 @@ pub async fn proxy<R: AsyncRead + Unpin, W: AsyncWrite + Unpin>(
                     server_version = IPC_VERSION,
                     "The IPC client is requesting an unknown protocol version"
                 );
-                return Err(anyhow::anyhow!(
+                break Err(anyhow::anyhow!(
                     "Unknown protocol version {version} requested by client"
                 ));
             }
@@ -162,15 +163,15 @@ pub async fn proxy<R: AsyncRead + Unpin, W: AsyncWrite + Unpin>(
                 match error.classify() {
                     serde_json::error::Category::Io => {
                         tracing::error!("Failed to read bytes from input stream");
-                        return Err(anyhow::anyhow!("Failed to read bytes from input stream"));
+                        break Err(anyhow::anyhow!("Failed to read bytes from input stream"));
                     }
                     serde_json::error::Category::Syntax => {
                         tracing::error!(column = error.column(), "Client sent invalid JSON");
-                        return Err(anyhow::anyhow!("Client sent invalid JSON"));
+                        break Err(anyhow::anyhow!("Client sent invalid JSON"));
                     }
                     serde_json::error::Category::Eof => {
                         tracing::error!("Unexpected end-of-line when deserializing JSON!");
-                        return Err(anyhow::anyhow!(
+                        break Err(anyhow::anyhow!(
                             "Unexpected end-of-line when deserializing JSON!"
                         ));
                     }
@@ -185,7 +186,13 @@ pub async fn proxy<R: AsyncRead + Unpin, W: AsyncWrite + Unpin>(
         let mut response = serde_json::to_string(&response)?;
         response.push('\n');
         responses.write_all(response.as_bytes()).await?;
-    }
+    };
+
+    tracing::trace!("Shutting down client");
+    tokio::time::timeout(Duration::from_secs(30), client.shutdown()).await?;
+    tracing::trace!("Shutdown of client completed");
+
+    result
 }
 
 /// A client that proxies requests to the Siguldry server over a local Unix socket.
@@ -246,6 +253,9 @@ impl ProxyClient {
                     }
 
                     tracing::info!("Proxy client runtime thread shutting down");
+                    tokio::time::timeout(Duration::from_secs(30), client.shutdown())
+                        .await
+                        .context("Timed out waiting for client shutdown")??;
                     Ok::<_, anyhow::Error>(())
                 })?;
 

--- a/siguldry/src/server/service.rs
+++ b/siguldry/src/server/service.rs
@@ -299,8 +299,29 @@ async fn handle(
         }
     }
     request_handler.shutdown().await?;
-    conn.shutdown().await?;
-    tracing::info!("Connection completed successfully");
+
+    // At this point the client shouldn't send it anything else, but we need to poll
+    // the connection to gracefully shut down the TLS session.
+    tokio::time::timeout(Duration::from_secs(15), async {
+        tracing::debug!("Waiting for EOF from client");
+        let mut buf = [0u8; 1024];
+        while let Ok(n) = conn.read(&mut buf).await {
+            if n == 0 {
+                tracing::debug!("Client sent EOF");
+                break;
+            } else {
+                tracing::warn!("Client unexpectedly sent us {} bytes of data", n);
+            }
+        }
+        conn.shutdown()
+            .await
+            .context("Failed to shutdown connection to client")?;
+        tracing::info!("Connection completed successfully");
+
+        Ok::<_, anyhow::Error>(())
+    })
+    .await
+    .context("Timed out waiting for connection to close")??;
 
     Ok(())
 }


### PR DESCRIPTION
This fixes the somewhat longstanding issue where the bridge and server logged complaints about connections ending early. There were issues on all sides, with the server needing to read the client connection until the EOF, the client proxy failing to call shutdown at all, and the bridge needing to be a bit more careful about reading both ends of the connection.