### PR TITLE
siguldry-client: support running the client with systemd and Accept=no

### DIFF
--- a/siguldry-fedora-autopen/siguldry-fedora-autopen.service
+++ b/siguldry-fedora-autopen/siguldry-fedora-autopen.service
@@ -1,7 +1,7 @@
 [Unit]
 Description=Siguldry autosigning service
-Requires=siguldry-client-proxy.socket
-After=siguldry-client-proxy.socket
+Requires=siguldry-client-shared-proxy.socket
+After=siguldry-client-shared-proxy.socket
 
 [Service]
 Type=simple

--- a/siguldry-fedora-autopen/src/amqp.rs
+++ b/siguldry-fedora-autopen/src/amqp.rs
@@ -179,7 +179,10 @@ async fn consume<K: KojiOps>(
             }
             _ = halt_token.cancelled() => {
                 tracing::info!(pending_tasks=signing_tasks.len(), "Consumer halting, waiting for pending tasks to complete");
-                drain_tasks(&mut signing_tasks);
+                let result = signing_tasks.join_all().await.into_iter().collect::<Result<Vec<()>, anyhow::Error>>();
+                if let Err(error) = result {
+                    tracing::error!(?error, "One or more signing tasks did not succeed and will be retried later");
+                }
 
                 if let Err(error) = channel.close(0, "Normal shutdown".into()).await {
                     tracing::error!(?error, "Failed to gracefully shut down the AMQP channel");

--- a/siguldry/Cargo.toml
+++ b/siguldry/Cargo.toml
@@ -19,7 +19,7 @@ default = ["server", "cli"]
 # Enable the server APIs
 server = ["dep:cryptoki", "dep:sqlx", "dep:rustix"]
 # Build command-line interfaces for enabled components
-cli = ["dep:clap", "dep:tracing-subscriber", "tokio/rt-multi-thread", "rustix/process"]
+cli = ["dep:clap", "dep:tracing-subscriber", "tokio/rt-multi-thread", "rustix/process", "rustix/fs"]
 
 # Build the Sigul 1.2 client
 sigul-client = []
@@ -46,6 +46,9 @@ optional = true
 
 [dependencies.hex]
 version = "0.4"
+
+[dependencies.libc]
+version = "0.2"
 
 [dependencies.openssl]
 version = "0.10.81"

--- a/siguldry/siguldry-client-shared-proxy.service
+++ b/siguldry/siguldry-client-shared-proxy.service
@@ -1,0 +1,72 @@
+[Unit]
+Description=Siguldry client shared proxy
+After=siguldry-client-shared-proxy.socket
+CollectMode=inactive-or-failed
+
+[Service]
+Type=simple
+ExecStart=/usr/bin/siguldry-client proxy --mode=accept-no
+User=siguldry
+Group=siguldry
+Environment=SIGULDRY_CLIENT_LOG=INFO
+# The default configuration location is "siguldry/client.toml" relative to /etc/ for system units
+# and relative to $XDG_CONFIG_HOME for user units. It can be manually specified as an absolute
+# path, for example:
+# Environment=SIGULDRY_CLIENT_CONFIG=/etc/siguldry/client.toml
+
+ConfigurationDirectory=siguldry
+
+# Isolate the client proxy process
+#
+# The proxy needs to be able to:
+#   - connect to the siguldry bridge over TCP
+#   - read the client configuration
+#
+# Admins must allow the necessary devices via a unit override file containing
+# the `DeviceAllow=` directive as by default, no devices are exposed to this
+# service.
+CapabilityBoundingSet=
+LockPersonality=true
+MemoryDenyWriteExecute=true
+NoNewPrivileges=true
+PrivateDevices=true
+# Credentials may require the TPM to decrypt.
+#
+# For systemd 257 and older you'll need to explicitly allow access to the TPM
+# Refer to https://github.com/systemd/systemd/issues/35959.
+# DeviceAllow=/dev/tpmrm0
+PrivateTmp=true
+ProtectClock=true
+ProtectControlGroups=true
+ProtectHome=true
+ProtectHostname=true
+ProtectKernelLogs=true
+ProtectKernelModules=true
+ProtectKernelTunables=true
+ProtectProc=invisible
+ProtectSystem=strict
+RemoveIPC=true
+
+# Filesystem restrictions
+ReadOnlyPaths=/
+NoExecPaths=/
+ExecPaths=/usr/bin/siguldry-client /usr/lib /usr/lib64
+
+# The service needs to connect to the Siguldry bridge
+RestrictAddressFamilies=AF_INET AF_INET6
+RestrictNamespaces=true
+RestrictRealtime=true
+RestrictSUIDSGID=true
+
+# System call filtering
+SystemCallFilter=@system-service
+SystemCallArchitectures=native
+SystemCallErrorNumber=EPERM
+
+# The service used TLS to authenticate with the Siguldry bridge and with the Siguldry server
+#
+# You can use the systemd-creds utility to encrypt the private key.
+#
+# For example:
+# $ systemd-creds encrypt /secure/ramfs/private-key.pem /etc/credstore.encrypted/siguldry.client.private_key
+ImportCredential=siguldry.*

--- a/siguldry/siguldry-client-shared-proxy.socket
+++ b/siguldry/siguldry-client-shared-proxy.socket
@@ -1,0 +1,22 @@
+[Unit]
+Description=Siguldry shared client proxy
+# By default both the Accept=yes flavor listens on the same socket path.
+# If, for some unconceivable reason you want both, use an override file to
+# change the path and drop this Conflicts= directive.
+Conflicts=siguldry-client-proxy.socket
+
+[Socket]
+Accept=no
+SocketUser=siguldry
+SocketGroup=siguldry
+SocketMode=0660
+ListenStream=%t/siguldry-client-proxy/siguldry-client-proxy.socket
+Service=siguldry-client-shared-proxy.service
+# In the event that you need to provide additional users access to the socket,
+# You can add a unit override snippet that includes one or more post-start
+# commands that are similar to:
+#
+#ExecStartPost=/usr/bin/setfacl -m u:kojibuilder:rwx %t/siguldry-client-proxy/siguldry-client-proxy.socket
+
+[Install]
+WantedBy=sockets.target

--- a/siguldry/src/bin/siguldry-client/main.rs
+++ b/siguldry/src/bin/siguldry-client/main.rs
@@ -1,12 +1,12 @@
 // SPDX-License-Identifier: MIT
 // Copyright (c) Microsoft Corporation.
 
-use std::path::PathBuf;
+use std::{path::PathBuf, time::Duration};
 
 use anyhow::Context;
 use clap::Parser;
 use siguldry::{
-    client::{Client, Config, proxy},
+    client::{Client, Config},
     config::load_config,
     signal_handler,
 };
@@ -91,20 +91,60 @@ enum Command {
     Config,
     /// Proxy commands from a local process to the server.
     ///
-    /// By default, commands and responses are sent over stdin and stdout respectively.
+    /// The mode has security implications. Running with `accept-yes` ensures clients are isolated
+    /// from one another since each connection runs as its own systemd instance. Running with
+    /// `accept-no` does not isolate clients, but does sandbox the proxy which is okay if the proxy
+    /// unlocks the signing keys.
+    ///
+    /// `bind` should only be used for testing purposes as there is no isolation from the host system.
     Proxy {
+        /// Control how the proxy accepts requests from clients.
+        #[arg(long, value_enum, default_value_t = ProxyMode::AcceptYes)]
+        mode: ProxyMode,
+
         /// If provided, bind a Unix socket to the given location and proxy clients
         /// that connect to it rather than using stdin/stdout.
         ///
         /// NOTE: Any user that has permission to read/write to this socket is able to
         /// connect to the Siguldry server and, if keys are configured to be unlocked,
         /// sign with those keys. Be *VERY* careful about the socket permissions.
-        #[arg(long)]
+        #[arg(long, required_if_eq("mode", "bind"))]
         socket: Option<PathBuf>,
     },
     /// See available keys and certificates.
     #[command(subcommand)]
     Key(KeyCommands),
+}
+
+#[derive(Clone, Debug, clap::ValueEnum)]
+enum ProxyMode {
+    /// Bind a Unix socket to the provided path and accept connections to it
+    ///
+    /// In this mode, there's no integration or dependency on systemd. This is primarily useful
+    /// for test environments and should not be used in production.
+    Bind,
+
+    /// Operate in a mode compatible with a systemd socket with the `Accept=yes` configuration
+    ///
+    /// In this mode, systemd accepts the connection and spawns a new unit instance for it; requests
+    /// are accepted over stdin and responses sent over stdout.
+    ///
+    /// In this mode, every request is isolated in its own process and sytemd sandbox. It's best used
+    /// when the client provides the secret to unlock the signing key, and when the request volume is
+    /// relatively low and maximum isolation between clients is desirable.
+    AcceptYes,
+
+    /// Operate in a mode compatible with a systemd socket with the `Accept=no` configuration
+    ///
+    /// In this mode, systemd binds the socket and passes the file descriptors on to us. A single
+    /// service is run to handle the requests. Different connections to the socket are handled by the
+    /// same process, so there is less isolation.
+    ///
+    /// Each connection still has its own client so keys unlocked by the client are not shared,
+    /// but there is no process isolation or separation via namespaces. This mode is best used
+    /// when the keys are configured to be unlocked by the proxy rather than by the user of the
+    /// socket since there are no user-provided secrets to isolate from each other.
+    AcceptNo,
 }
 
 #[derive(clap::Subcommand, Debug)]
@@ -228,50 +268,143 @@ async fn main() -> anyhow::Result<()> {
                 }
             }
         },
-        Command::Proxy { socket } => {
-            let halt_token = CancellationToken::new();
-            tokio::spawn(signal_handler(halt_token.clone()));
-            if let Some(socket) = socket {
-                let listener = UnixListener::bind(&socket)
-                    .with_context(|| format!("Failed to bind to {}", &socket.display()))?;
-                let request_tracker = TaskTracker::new();
-                loop {
-                    let stream = tokio::select! {
-                        _ = halt_token.cancelled() => {
-                            tracing::info!("proxy halted; shutting down");
-                            return Ok(());
-                        }
-                        result = listener.accept() => {
-                            match result {
-                                Ok((unix_stream, _)) => {
-                                    unix_stream
-                                },
-                                Err(error) => {
-                                    tracing::error!(?socket, ?error, "Failed to accept request");
-                                    break;
-                                },
-                            }
-                        }
-                    };
-                    let (reader, writer) = tokio::io::split(stream);
-                    request_tracker.spawn(
-                        proxy(
-                            Client::new(config.clone())?,
-                            halt_token.clone(),
-                            reader,
-                            writer,
-                        )
-                        .instrument(tracing::info_span!("proxy")),
-                    );
-                }
-                request_tracker.close();
-                request_tracker.wait().await;
-            } else {
-                let requests = tokio::io::stdin();
-                let responses = tokio::io::stdout();
-                proxy(client, halt_token.clone(), requests, responses).await?;
-            }
+        Command::Proxy { mode, socket } => {
+            run_proxy(config, client, mode, socket).await?;
         }
+    }
+
+    Ok(())
+}
+
+async fn run_proxy(
+    config: Config,
+    client: Client,
+    mode: ProxyMode,
+    socket: Option<PathBuf>,
+) -> anyhow::Result<()> {
+    let halt_token = CancellationToken::new();
+    tokio::spawn(signal_handler(halt_token.clone()));
+
+    let listener = match mode {
+        ProxyMode::Bind => {
+            let socket =
+                socket.expect("Clap is configured to require this argument when bind mode is set");
+            let listener = UnixListener::bind(&socket)
+                .with_context(|| format!("Failed to bind to {}", &socket.display()))?;
+            Some(listener)
+        }
+        ProxyMode::AcceptYes => None,
+        ProxyMode::AcceptNo => {
+            let fds = siguldry::listen_fds()
+                .context("Environment variables are set, but use invalid values")?;
+            if fds.len() > 1 {
+                return Err(anyhow::anyhow!(
+                    "An unexpected number of file descriptors ({}) were provided",
+                    fds.len()
+                ));
+            }
+            let (fd_name, fd) = if let Some(value) = fds.into_iter().next() {
+                value
+            } else {
+                return Err(anyhow::anyhow!(
+                    "No file descriptors were provided; this must be run by a systemd socket with Accept=no"
+                ));
+            };
+
+            let std_listener = std::os::unix::net::UnixListener::from(fd);
+            std_listener
+                .set_nonblocking(true)
+                .context("Failed to set systemd socket to non-blocking mode")?;
+            let listener = UnixListener::from_std(std_listener)
+                .with_context(|| format!("Failed to create async listener from fd {fd_name:?}"))?;
+            tracing::info!(?fd_name, "Listening on systemd-provided socket");
+            Some(listener)
+        }
+    };
+
+    if let Some(listener) = listener {
+        let semaphore = std::sync::Arc::new(tokio::sync::Semaphore::new(config.proxy_concurrency));
+        let request_tracker = TaskTracker::new();
+        let mut client = client;
+        loop {
+            // Once we hit our limit, connections should stack up until they hit the `somaxconn`
+            // limit, at which point clients will start getting a connection refused error.
+            let permit = tokio::select! {
+                _ = halt_token.cancelled() => {
+                    break;
+                }
+                result = semaphore.clone().acquire_owned() => {
+                    result
+                }
+            }?;
+
+            let stream = tokio::select! {
+                _ = halt_token.cancelled() => {
+                    break;
+                }
+                result = listener.accept() => {
+                    match result {
+                        Ok((unix_stream, _)) => {
+                            unix_stream
+                        },
+                        Err(error) => {
+                            // We should be really careful here since if we break, we'll wait for existing
+                            // connections to complete and never accept new connections, and if we exit immediately
+                            // existing connections will fail. To start with, we can log errors loudly and if cases
+                            // emerge we really have to exit for, we can add them here.
+                            match error.kind() {
+                                std::io::ErrorKind::ConnectionAborted => {
+                                    tracing::debug!(?error, "Client connection was aborted");
+                                },
+                                _ => {
+                                    match error.raw_os_error() {
+                                        Some(libc::EMFILE | libc::ENFILE | libc::ENOMEM | libc::ENOBUFS) => {
+                                            tracing::warn!(?error, "Not enough system resources to open another connection - delaying before trying again!");
+                                            tokio::select! {
+                                                _ = halt_token.cancelled() => break,
+                                                _ = tokio::time::sleep(Duration::from_secs(1)) => {}
+                                            }
+                                            continue;
+                                        },
+                                        errno => tracing::error!(?error, errno, "An error occurred while accepting the request"),
+                                    }
+                                }
+                            }
+                            continue;
+                        },
+                    }
+                }
+            };
+
+            let connection_halt_token = halt_token.clone();
+            let (reader, writer) = tokio::io::split(stream);
+            request_tracker.spawn(
+                async move {
+                    let _permit = permit;
+                    if let Err(error) =
+                        siguldry::client::proxy(client, connection_halt_token, reader, writer).await
+                    {
+                        tracing::warn!(?error, "Proxy connection did not shut down cleanly");
+                    }
+                }
+                .instrument(tracing::info_span!("proxy")),
+            );
+            client = Client::new(config.clone())?;
+        }
+
+        tracing::debug!("Proxy halted; shutting down");
+        request_tracker.close();
+        if !request_tracker.is_empty() {
+            tracing::info!(
+                "Waiting for {} connections to complete",
+                request_tracker.len()
+            );
+        }
+        request_tracker.wait().await;
+    } else {
+        let requests = tokio::io::stdin();
+        let responses = tokio::io::stdout();
+        siguldry::client::proxy(client, halt_token.clone(), requests, responses).await?;
     }
 
     Ok(())

--- a/siguldry/src/bin/siguldry-client/main.rs
+++ b/siguldry/src/bin/siguldry-client/main.rs
@@ -166,7 +166,7 @@ enum KeyCommands {
     },
 }
 
-#[tokio::main(flavor = "current_thread")]
+#[tokio::main]
 async fn main() -> anyhow::Result<()> {
     let opts = Cli::parse();
 

--- a/siguldry/src/client/config.rs
+++ b/siguldry/src/client/config.rs
@@ -31,11 +31,21 @@ pub struct Config {
     /// the certificate must have the `clientAuth` extended key usage extension.
     pub credentials: Credentials,
 
+    /// Enforce a limit on the number of concurrent connections to accept when running as a proxy.
+    ///
+    /// This only applies when using the `bind` or `accept-no` proxy modes. The default is unlimited.
+    #[serde(default = "default_concurrency")]
+    pub proxy_concurrency: usize,
+
     /// A list of keys to unlock for the client.
     ///
     /// This can be set for users of the client who can't (or don't want to) call unlock or safely
     /// store a password. One example would be the PKCS#11 module used inside a build environment.
     pub keys: Vec<Key>,
+}
+
+fn default_concurrency() -> usize {
+    tokio::sync::Semaphore::MAX_PERMITS
 }
 
 impl Default for Config {
@@ -50,6 +60,7 @@ impl Default for Config {
                 certificate: PathBuf::from("siguldry.client.certificate.pem"),
                 ca_certificate: PathBuf::from("siguldry.ca_certificate.pem"),
             },
+            proxy_concurrency: default_concurrency(),
             keys: vec![],
         }
     }

--- a/siguldry/src/lib.rs
+++ b/siguldry/src/lib.rs
@@ -49,6 +49,12 @@ By default, the server, bridge, and client for Siguldry along with their CLIs is
 [2]: https://crates.io/crates/siguldry-pkcs11
 */
 
+use std::{
+    num::NonZeroU32,
+    os::fd::{AsFd, FromRawFd, OwnedFd},
+};
+
+use anyhow::Context;
 use tokio::signal::unix::{SignalKind, signal};
 use tokio_util::sync::CancellationToken;
 
@@ -120,4 +126,116 @@ pub fn raise_nofiles() -> anyhow::Result<()> {
         .context("Failed to set file limits")?;
 
     Ok(())
+}
+
+/// Check for and return any file descriptors passed in from systemd
+///
+/// Refer to sd_listen_fds (3) for details.
+///
+/// Returns the list of (optional) file descriptor name and the descriptor itself.
+#[doc(hidden)]
+#[cfg(feature = "cli")]
+pub fn listen_fds() -> Result<Vec<(Option<String>, OwnedFd)>, anyhow::Error> {
+    const SD_LISTEN_FDS_START: u32 = 3;
+    const PID_FS_MAGIC: u64 = 0x50494446;
+
+    let our_pid = std::process::id();
+
+    match std::env::var("LISTEN_PID") {
+        Ok(listen_pid) => {
+            let listen_pid = listen_pid.parse::<u32>().with_context(|| {
+                format!("Failed to parse LISTEN_PID={listen_pid} as an unsigned 32 bit integer")
+            })?;
+            if our_pid != listen_pid {
+                tracing::warn!(listen_pid, our_pid, "LISTEN_PID provided, but not for us");
+                return Ok(vec![]);
+            }
+        }
+        Err(_) => return Ok(vec![]),
+    }
+
+    // Newer systemd versions will also provide the pidfd's inode so we can double check
+    // these variables really are meant for us.
+    if let Ok(listen_pidfdid) = std::env::var("LISTEN_PIDFDID") {
+        let listen_pidfdid = listen_pidfdid.parse::<u64>().with_context(|| {
+            format!("Failed to parse LISTEN_PIDFDID={listen_pidfdid} as an unsigned 64 bit integer")
+        })?;
+        tracing::debug!("systemd provided LISTEN_PIDFDID={listen_pidfdid}");
+
+        let pidfd = rustix::process::pidfd_open(
+            rustix::process::getpid(),
+            rustix::process::PidfdFlags::empty(),
+        )
+        .context("Failed to open a pidfd for our own process")?;
+        if rustix::fs::fstatfs(&pidfd)
+            .map(|statfs| {
+                tracing::debug!(statfs.f_type, "PIDFD filesystem type");
+                statfs.f_type as u64 == PID_FS_MAGIC
+            })
+            .inspect_err(|error| {
+                tracing::info!(
+                    ?error,
+                    "Failed to read PIDFD's filesystem statistics, skipping LISTEN_PIDFDID check"
+                );
+            })
+            .unwrap_or(false)
+        {
+            let our_pidfdid = rustix::fs::fstat(&pidfd)
+                .context("Failed to stat our pidfd")?
+                .st_ino;
+            if our_pidfdid != listen_pidfdid {
+                tracing::warn!(
+                    listen_pidfdid,
+                    our_pidfdid,
+                    "LISTEN_PIDFDID provided, but not for us"
+                );
+                return Ok(vec![]);
+            } else {
+                tracing::debug!(our_pidfdid, "LISTEN_PIDFDID matches our pidfd ID");
+            }
+        }
+    }
+
+    let mut fds = vec![];
+    let fd_names = std::env::var("LISTEN_FDNAMES")
+        .map(|names| names.split(":").map(|n| n.to_string()).collect::<Vec<_>>())
+        .inspect_err(|_| tracing::debug!("No LISTEN_FDNAMES variable provided"))
+        .unwrap_or_default();
+    if let Ok(num) = std::env::var("LISTEN_FDS") {
+        let fd_count = num.parse::<NonZeroU32>().with_context(|| {
+            format!("Failed to parse LISTEN_FDS={num} as a non-zero unsigned integer")
+        })?;
+        if fd_count.get() > u32::MAX - SD_LISTEN_FDS_START {
+            return Err(anyhow::anyhow!(
+                "Number of file descriptors provided would overflow a u32"
+            ));
+        }
+
+        let mut names = fd_names.into_iter();
+        for fd in SD_LISTEN_FDS_START..SD_LISTEN_FDS_START + fd_count.get() {
+            let raw_fd = fd.try_into().with_context(|| {
+                format!("Failed to convert the file descriptor {fd} to a RawFd")
+            })?;
+
+            // Safety:
+            //
+            // systemd promises that if it sets the LISTEN_FDS environment variable to a non-zero
+            // number, it shall provide that number of valid file descriptors to the program it
+            // executes. Furthermore, these file descriptors are guaranteed to start at 3 (e.g.
+            // directly after the stdin, stdout, and stderr descriptors) and continue up to the
+            // value provided in LISTEN_FDS + 3.
+            let owned_fd = unsafe { OwnedFd::from_raw_fd(raw_fd) };
+
+            let old_flags =
+                rustix::io::fcntl_getfd(owned_fd.as_fd()).context("Failed to retrieve fd flags")?;
+            let mut new_flags = old_flags;
+            new_flags.insert(rustix::io::FdFlags::CLOEXEC);
+            tracing::debug!(?old_flags, ?new_flags, "Setting CLOEXEC on fd");
+            rustix::io::fcntl_setfd(owned_fd.as_fd(), new_flags)
+                .context("Failed to set CLOEXEC")?;
+            fds.push((names.next(), owned_fd));
+        }
+    }
+
+    Ok(fds)
 }


### PR DESCRIPTION
For certain scenarios, the client proxy unlocks the keys with systemd credentials and any user with access to the socket can sign with those keys. In that scenario, there's no need to isolate the clients from each other, and there's serious performance penalties for doing so.

In addition to the unit startup cost, the proxy needs to access encrypted credentials to authenticate with the server. systemd-creds is extremely limited in the number of connections it accepts for decryption, which in turn limits the number of concurrent signing requests.