### PR TITLE
siguldry-fedora-autopen: automatically bump the file limit

### DIFF
--- a/docs/src/user-guide/configuration.md
+++ b/docs/src/user-guide/configuration.md
@@ -10,6 +10,12 @@ directory is `/etc/siguldry/`.
 > For production deployments, it is expected that the server, bridge, and any clients are
 > separate hosts.
 
+## Systemd units
+
+Units may need to be granted access to additional directories or devices. The defaults minimize what they have access to. Common cases are called out, but be aware that the systemd units will require overrides.
+
+Socket units may need their `MaxConnections` settings raised, depending on how many concurrent requests are allowed.
+
 ## systemd-creds
 
 None of the configuration files contain any secrets directly. All secrets are provided via file

--- a/siguldry-fedora-autopen/Cargo.toml
+++ b/siguldry-fedora-autopen/Cargo.toml
@@ -51,6 +51,10 @@ version = "0.13"
 default-features = false
 features = ["http2", "native-tls"]
 
+[dependencies.rustix]
+version = "1"
+features = ["process"]
+
 [dependencies.serde]
 version = "1.0.145"
 features = ["derive"]

--- a/siguldry-fedora-autopen/src/main.rs
+++ b/siguldry-fedora-autopen/src/main.rs
@@ -54,6 +54,18 @@ async fn main() -> anyhow::Result<()> {
     tracing::subscriber::set_global_default(registry)
         .expect("Programming error: set_global_default should only be called once.");
 
+    // We really need a siguldry-common crate for stuff like this
+    let current_nofile_limits = rustix::process::getrlimit(rustix::process::Resource::Nofile);
+    let mut new_nofile_limits = current_nofile_limits;
+    new_nofile_limits.current = current_nofile_limits.maximum;
+    tracing::debug!(
+        "Raising the RLIMIT_NOFILE value from {:?} to {:?}",
+        current_nofile_limits.current,
+        new_nofile_limits.current
+    );
+    rustix::process::setrlimit(rustix::process::Resource::Nofile, new_nofile_limits)
+        .context("Failed to set file limits")?;
+
     let config = {
         let mut config: config::Config =
             config::load_config(opts.config, &PathBuf::from(DEFAULT_CONFIG))?;

--- a/siguldry/Cargo.toml
+++ b/siguldry/Cargo.toml
@@ -19,7 +19,7 @@ default = ["server", "cli"]
 # Enable the server APIs
 server = ["dep:cryptoki", "dep:sqlx", "dep:rustix"]
 # Build command-line interfaces for enabled components
-cli = ["dep:clap", "dep:tracing-subscriber", "tokio/rt-multi-thread"]
+cli = ["dep:clap", "dep:tracing-subscriber", "tokio/rt-multi-thread", "rustix/process"]
 
 # Build the Sigul 1.2 client
 sigul-client = []

--- a/siguldry/src/bin/siguldry-bridge/main.rs
+++ b/siguldry/src/bin/siguldry-bridge/main.rs
@@ -116,6 +116,8 @@ async fn main() -> anyhow::Result<()> {
     tracing::subscriber::set_global_default(registry)
         .expect("Programming error: set_global_default should only be called once.");
 
+    siguldry::raise_nofiles()?;
+
     let mut config = load_config::<Config>(opts.config, PathBuf::from(DEFAULT_CONFIG).as_path())?;
     tracing::info!("Loaded configuration");
 

--- a/siguldry/src/bin/siguldry-client/main.rs
+++ b/siguldry/src/bin/siguldry-client/main.rs
@@ -150,6 +150,8 @@ async fn main() -> anyhow::Result<()> {
     tracing::subscriber::set_global_default(registry)
         .expect("Programming error: set_global_default should only be called once.");
 
+    siguldry::raise_nofiles()?;
+
     let mut config = load_config::<Config>(opts.config, PathBuf::from(DEFAULT_CONFIG).as_path())?;
 
     if let Command::Config = opts.command {

--- a/siguldry/src/bin/siguldry-server/main.rs
+++ b/siguldry/src/bin/siguldry-server/main.rs
@@ -65,6 +65,8 @@ async fn main() -> anyhow::Result<()> {
     tracing::subscriber::set_global_default(registry)
         .expect("Programming error: set_global_default should only be called once.");
 
+    siguldry::raise_nofiles()?;
+
     let mut config = load_config::<Config>(opts.config, PathBuf::from(DEFAULT_CONFIG).as_path())?;
 
     match opts.command {

--- a/siguldry/src/bin/siguldry-signer/main.rs
+++ b/siguldry/src/bin/siguldry-signer/main.rs
@@ -71,6 +71,9 @@ async fn main() -> anyhow::Result<()> {
     let registry = registry.with(log_filter);
     tracing::subscriber::set_global_default(registry)
         .expect("Programming error: set_global_default should only be called once.");
+
+    siguldry::raise_nofiles()?;
+
     let halt_token = CancellationToken::new();
     tokio::spawn(signal_handler(halt_token.clone()));
 

--- a/siguldry/src/lib.rs
+++ b/siguldry/src/lib.rs
@@ -98,3 +98,26 @@ pub async fn signal_handler(halt_token: CancellationToken) -> Result<(), anyhow:
         }
     }
 }
+
+/// Set the process's open file limit to the maximum allowable.
+///
+/// The default soft limit is 1024 to protect programs that use syscalls that cannot
+/// operate on fd > 1024; we don't so we can opt out and use the real system limits.
+#[cfg(feature = "cli")]
+#[doc(hidden)]
+pub fn raise_nofiles() -> anyhow::Result<()> {
+    use anyhow::Context;
+
+    let current_nofile_limits = rustix::process::getrlimit(rustix::process::Resource::Nofile);
+    let mut new_nofile_limits = current_nofile_limits;
+    new_nofile_limits.current = current_nofile_limits.maximum;
+    tracing::debug!(
+        "Raising the RLIMIT_NOFILE value from {:?} to {:?}",
+        current_nofile_limits.current,
+        new_nofile_limits.current
+    );
+    rustix::process::setrlimit(rustix::process::Resource::Nofile, new_nofile_limits)
+        .context("Failed to set file limits")?;
+
+    Ok(())
+}


### PR DESCRIPTION
The default soft limit is 1024 to protect programs using select(2) and
other calls that can't handle file descriptors above 1024. While systemd
can force the soft limit higher, it documents that it's best for the
program to bump the limit itself to indicate it's fine with higher
limits.