### PR TITLE
siguldry: drop usage of openssl's deprecated as_utf8()

### DIFF
--- a/siguldry-fedora-autopen/Cargo.toml
+++ b/siguldry-fedora-autopen/Cargo.toml
@@ -40,7 +40,7 @@ version = "0.10"
 
 # Used for RPM signing to interact with Koji via its Python library
 [dependencies.pyo3]
-version = "0.28"
+version = "0.29"
 features = ["auto-initialize"]
 
 [dependencies.regex]

--- a/siguldry/Cargo.toml
+++ b/siguldry/Cargo.toml
@@ -48,7 +48,7 @@ optional = true
 version = "0.4"
 
 [dependencies.openssl]
-version = "0.10"
+version = "0.10.81"
 
 [dependencies.rustix]
 version = "1"

--- a/siguldry/Cargo.toml
+++ b/siguldry/Cargo.toml
@@ -128,7 +128,7 @@ version = "0.2"
 features = ["no-env-filter"]
 
 [dev-dependencies.pyo3]
-version = "0.28"
+version = "0.29"
 features = ["auto-initialize"]
 
 [dev-dependencies.sequoia-openpgp]

--- a/siguldry/src/nestls.rs
+++ b/siguldry/src/nestls.rs
@@ -87,16 +87,12 @@ impl Nestls {
 
     /// Get the remote connection's commonName from its certificate.
     pub fn peer_common_name(&self) -> Option<String> {
-        self.inner
-            .ssl()
-            .peer_certificate()
-            .and_then(|cert| {
-                cert.subject_name()
-                    .entries_by_nid(Nid::COMMONNAME)
-                    .next()
-                    .and_then(|entry| entry.data().as_utf8().ok())
-            })
-            .map(|common_name| common_name.to_string())
+        self.inner.ssl().peer_certificate().and_then(|cert| {
+            cert.subject_name()
+                .entries_by_nid(Nid::COMMONNAME)
+                .next()
+                .and_then(|entry| entry.data().to_string().ok())
+        })
     }
 }
 
@@ -156,16 +152,12 @@ impl NestlsBuilder {
         tracing::debug!(?bridge_addr, "TCP connection to the bridge established");
         let mut outer_stream = tokio_openssl::SslStream::new(bridge_ssl, outer_stream)?;
         Pin::new(&mut outer_stream).connect().await?;
-        let username = outer_stream
-            .ssl()
-            .certificate()
-            .and_then(|cert| {
-                cert.subject_name()
-                    .entries_by_nid(Nid::COMMONNAME)
-                    .next()
-                    .and_then(|entry| entry.data().as_utf8().ok())
-            })
-            .map(|common_name| common_name.to_string());
+        let username = outer_stream.ssl().certificate().and_then(|cert| {
+            cert.subject_name()
+                .entries_by_nid(Nid::COMMONNAME)
+                .next()
+                .and_then(|entry| entry.data().to_string().ok())
+        });
         tracing::debug!(?username, "TLS session with the bridge established");
 
         let protocol_header: ProtocolHeader = role.into();

--- a/siguldry/src/protocol.rs
+++ b/siguldry/src/protocol.rs
@@ -242,9 +242,8 @@ pub(crate) fn peer_common_name<S>(stream: &SslStream<S>) -> Result<String, Error
             cert.subject_name()
                 .entries_by_nid(Nid::COMMONNAME)
                 .next()
-                .and_then(|entry| entry.data().as_utf8().ok())
+                .and_then(|entry| entry.data().to_string().ok())
         })
-        .map(|common_name| common_name.to_string())
         .ok_or(Error::MissingCommonName)
 }
 


### PR DESCRIPTION
This switches to the `to_string()` function which does not halt on the first interior NUL byte. This was introduced in 0.10.81, so the minimum required version has also been adjusted.

This is, I think, a (minor) security issue since the strings in question are certificate subject. If a certificate is issued and contains a maliciously formed subject name it could authenticate as a different user. While it couldn't access its signing keys without the associated key access password, it would cause the server to log the wrong user.