### PR TITLE
siguldry: shut down idle client connections on the server

### DIFF
--- a/siguldry-test/src/lib.rs
+++ b/siguldry-test/src/lib.rs
@@ -8,7 +8,7 @@ use std::{
     collections::HashMap,
     io::Write,
     net::SocketAddr,
-    num::NonZeroU16,
+    num::{NonZeroU16, NonZeroU64},
     path::{Path, PathBuf},
     process::Stdio,
     str::FromStr,
@@ -195,6 +195,8 @@ pub struct InstanceBuilder {
     with_client_proxy: bool,
     with_sigul_import: Option<String>,
     additional_users: Vec<(String, bool)>,
+    idle_client_timeout: Option<NonZeroU64>,
+    connection_watchdog_timeout: Option<NonZeroU64>,
 }
 
 impl InstanceBuilder {
@@ -270,6 +272,18 @@ impl InstanceBuilder {
     /// Create a Unix socket to proxy client requests (useful for PKCS #11 testing).
     pub fn with_client_proxy(mut self) -> Self {
         self.with_client_proxy = true;
+        self
+    }
+
+    /// Set the time, in seconds, a client can be idle before the server shuts down the connection.
+    pub fn with_idle_client_timeout(mut self, seconds: u64) -> Self {
+        self.idle_client_timeout = Some(NonZeroU64::new(seconds).expect("Use a non-zero value"));
+        self
+    }
+
+    pub fn with_connection_watchdog_timeout(mut self, seconds: u64) -> Self {
+        self.connection_watchdog_timeout =
+            Some(NonZeroU64::new(seconds).expect("Use a non-zero value"));
         self
     }
 
@@ -416,6 +430,12 @@ impl InstanceBuilder {
                 .expect("it's three geese"),
             pkcs11_bindings,
             connection_pool_size: 1,
+            idle_client_timeout: self
+                .idle_client_timeout
+                .unwrap_or(NonZeroU64::new(3600).unwrap()),
+            connection_watchdog_timeout: self
+                .connection_watchdog_timeout
+                .unwrap_or(NonZeroU64::new(10800).unwrap()),
             ..Default::default()
         };
         let server_config_file = tempdir.path().join("server.toml");

--- a/siguldry/src/client/inner.rs
+++ b/siguldry/src/client/inner.rs
@@ -125,7 +125,14 @@ impl Client {
                 bytes_read = connection.read_buf(&mut limited_buffer) => {
                     let bytes_read = bytes_read?;
                     if bytes_read == 0 {
-                        tokio::time::sleep(Duration::from_secs(5)).await;
+                        // The underlying buffer is unlimited, and we set the limit per-read,
+                        // so we know getting 0 here is a server-initiated EOF rather than a full buffer.
+                        tracing::warn!(
+                            pending_responses=pending_responses.len(),
+                            "Server sent EOF (possibly the server idle connection timeout)"
+                        );
+                        let _ = tokio::time::timeout(Duration::from_secs(5), connection.shutdown()).await;
+                        return Ok(());
                     }
                     tracing::trace!(bytes_read, "Handling incoming response data");
                 }

--- a/siguldry/src/server/config.rs
+++ b/siguldry/src/server/config.rs
@@ -1,7 +1,10 @@
 // SPDX-License-Identifier: MIT
 // Copyright (c) Microsoft Corporation.
 
-use std::{num::NonZeroU16, path::PathBuf};
+use std::{
+    num::{NonZeroU16, NonZeroU64},
+    path::PathBuf,
+};
 
 use sequoia_openpgp::crypto::Password;
 use serde::{Deserialize, Serialize};
@@ -48,6 +51,23 @@ pub struct Config {
     /// bridge allows enough idle connections to cover each server's pool size. The default is 32.
     pub connection_pool_size: usize,
 
+    /// The time, in seconds, a client can be idle (e.g. not send a request) before shutting down
+    /// the connection. Well-behaved clients should voluntarily shut down their idling connection
+    /// before this timeout is hit, so if you see logs related to this in production environments,
+    /// consider adjusting the client configuration to lower its idle timeout.
+    ///
+    /// The default is 3600 (1 hour).
+    #[serde(default = "default_idle_client_timeout")]
+    pub idle_client_timeout: NonZeroU64,
+
+    /// The time, in seconds, a client connection can run without providing a heartbeat.
+    /// This is primarily to handle mis-behaving server-side handling of requests (like hardware-backed
+    /// keys never respond to signing requests).
+    ///
+    /// Be sure to set this *higher* than `idle_client_timeout`. The default is 10800 (3 hour).
+    #[serde(default = "default_connection_watchdog_timeout")]
+    pub connection_watchdog_timeout: NonZeroU64,
+
     /// The minimum length for user's access password, in *bytes*. For example, the multi-byte
     /// UTF-8 character "🪿" counts as 4 bytes.
     pub user_password_length: NonZeroU16,
@@ -78,6 +98,14 @@ pub struct Config {
     /// password.
     #[serde(default)]
     pub pkcs11_bindings: Vec<Pkcs11Binding>,
+}
+
+const fn default_idle_client_timeout() -> NonZeroU64 {
+    NonZeroU64::new(60 * 60).expect("set a non-zero default")
+}
+
+const fn default_connection_watchdog_timeout() -> NonZeroU64 {
+    NonZeroU64::new(3 * 60 * 60).expect("set a non-zero default")
 }
 
 /// The values to use when creating x509 certificates in subject names.
@@ -151,6 +179,8 @@ impl Default for Config {
         Self {
             state_directory: default_state_directory(),
             signer_socket_path: default_socket_path(),
+            idle_client_timeout: default_idle_client_timeout(),
+            connection_watchdog_timeout: default_connection_watchdog_timeout(),
             bridge_hostname: "bridge.example.com".to_string(),
             bridge_port: 44333,
             connection_pool_size: 32,

--- a/siguldry/src/server/service.rs
+++ b/siguldry/src/server/service.rs
@@ -13,6 +13,7 @@ use sqlx::{Pool, Sqlite};
 use tokio::{
     io::{AsyncReadExt, AsyncWriteExt},
     task::JoinSet,
+    time::Instant,
 };
 use tokio_util::{sync::CancellationToken, task::TaskTracker};
 use tracing::{Instrument, Span, instrument};
@@ -115,10 +116,39 @@ impl Server {
                         while connection_pool.len() < self.config.connection_pool_size {
                             self.accept(&mut connection_pool)?;
                         }
-                        request_tracker.spawn(
-                            handle(self.config.clone(), self.db_pool.clone(), conn)
-                                .instrument(tracing::Span::current()),
-                        );
+                        let config = self.config.clone();
+                        let db_pool = self.db_pool.clone();
+
+                        // Each connection has an idle timeout, but in the event that something
+                        // after the request hangs, this watchdog will kick in (by default) after 3
+                        // hours, which is much longer than the client idle timeout and much longer
+                        // than any request should ever take to process.
+                        let timeout = Duration::from_secs(self.config.connection_watchdog_timeout.get());
+                        request_tracker.spawn( async move {
+                            let (watcher_tx, mut watcher_rx) = tokio::sync::watch::channel(Instant::now());
+                            let handler = handle(config, watcher_tx, db_pool, conn);
+                            tokio::pin!(handler);
+
+                            let mut last_activity = Instant::now();
+                            let sleep = tokio::time::sleep_until(last_activity + timeout);
+                            tokio::pin!(sleep);
+                            loop {
+                                tokio::select! {
+                                    result = &mut handler => {
+                                        break result;
+                                    }
+                                    _ = watcher_rx.changed() => {
+                                        last_activity = *watcher_rx.borrow_and_update();
+                                        sleep.as_mut().reset(last_activity + timeout);
+                                        tracing::trace!("Reset watchdog timeout");
+                                    }
+                                    _ = &mut sleep => {
+                                        tracing::error!("BUG: Shutting down client connection that hasn't shut down as expected!");
+                                        break Ok(());
+                                    }
+                                }
+                            }
+                        }.instrument(tracing::Span::current()));
                     }
                     Some(Ok(Err(error))) => {
                         tracing::error!(?error, "Failed to accept incoming client connection");
@@ -185,6 +215,7 @@ impl Server {
 #[instrument(skip_all, err, fields(session_id = %conn.session_id(), user = conn.peer_common_name()))]
 async fn handle(
     config: Arc<Config>,
+    watchdog: tokio::sync::watch::Sender<Instant>,
     db: Pool<Sqlite>,
     mut conn: Nestls,
 ) -> Result<(), anyhow::Error> {
@@ -198,38 +229,29 @@ async fn handle(
     tracing::info!("User authenticated");
     drop(db_conn);
 
+    let idle_timeout = Duration::from_secs(config.idle_client_timeout.get());
     let mut request_handler =
         handlers::Handler::new(config.clone(), user.clone(), conn.session_id()).await?;
     loop {
-        let mut frame_buffer = [0_u8; std::mem::size_of::<protocol::Frame>()];
-        conn.read_exact(&mut frame_buffer).await?;
-        let frame = protocol::Frame::try_ref_from_bytes(&frame_buffer)
-            .map_err(|e| protocol::Error::Framing(format!("Invalid frame: {e:?}")))?;
-        if frame.is_empty() {
-            tracing::debug!(
-                "Connection sent empty frame indicating it is done; closing connection"
-            );
-            break;
-        } else {
-            tracing::debug!(?frame, "New request frame received");
-        }
-
-        let frame_size: usize = frame
-            .json_size
-            .get()
-            .try_into()
-            .context("frame size must fit in usize")?;
-        // TODO: configurable size limits
-        if frame_size > MAX_JSON_SIZE {
-            return Err(anyhow::anyhow!(
-                "JSON payload larger than {MAX_JSON_SIZE} bytes"
-            ));
-        }
-        let mut request_buffer = BytesMut::with_capacity(frame_size).limit(frame_size);
-        while request_buffer.remaining_mut() != 0 {
-            conn.read_buf(&mut request_buffer).await?;
-        }
-        let request_bytes = request_buffer.into_inner().freeze();
+        let request_bytes = match tokio::time::timeout(idle_timeout, read_frame(&mut conn)).await {
+            Ok(frame) => {
+                if let Some(bytes) = frame.context("Failed to read incoming request frame")? {
+                    watchdog.send_replace(Instant::now());
+                    bytes
+                } else {
+                    break;
+                }
+            }
+            Err(_elapsed) => {
+                tracing::warn!(
+                    "Shutting down client connection that has been idle for {} seconds",
+                    idle_timeout.as_secs()
+                );
+                let _ = request_handler.shutdown().await;
+                let _ = tokio::time::timeout(Duration::from_secs(5), conn.shutdown()).await;
+                return Ok(());
+            }
+        };
 
         let request_value = serde_json::from_slice::<serde_json::Value>(&request_bytes)?;
         let outer_request = match serde_json::from_value::<protocol::OuterRequest>(request_value) {
@@ -327,4 +349,35 @@ async fn handle(
     .context("Timed out waiting for connection to close")??;
 
     Ok(())
+}
+
+async fn read_frame(conn: &mut Nestls) -> anyhow::Result<Option<bytes::Bytes>> {
+    let mut frame_buffer = [0_u8; std::mem::size_of::<protocol::Frame>()];
+    conn.read_exact(&mut frame_buffer).await?;
+    let frame = protocol::Frame::try_ref_from_bytes(&frame_buffer)
+        .map_err(|e| protocol::Error::Framing(format!("Invalid frame: {e:?}")))?;
+    if frame.is_empty() {
+        tracing::debug!("Connection sent empty frame indicating it is done; closing connection");
+        return Ok(None);
+    } else {
+        tracing::debug!(?frame, "New request frame received");
+    }
+
+    let frame_size: usize = frame
+        .json_size
+        .get()
+        .try_into()
+        .context("frame size must fit in usize")?;
+    // TODO: configurable size limits
+    if frame_size > MAX_JSON_SIZE {
+        return Err(anyhow::anyhow!(
+            "JSON payload larger than {MAX_JSON_SIZE} bytes"
+        ));
+    }
+    let mut request_buffer = BytesMut::with_capacity(frame_size).limit(frame_size);
+    while request_buffer.remaining_mut() != 0 {
+        conn.read_buf(&mut request_buffer).await?;
+    }
+
+    Ok(Some(request_buffer.into_inner().freeze()))
 }

--- a/siguldry/tests/end_to_end.rs
+++ b/siguldry/tests/end_to_end.rs
@@ -918,3 +918,67 @@ async fn user_without_access_cannot_sign() -> anyhow::Result<()> {
     instance.halt().await?;
     Ok(())
 }
+
+#[tokio::test]
+#[tracing_test::traced_test]
+async fn idle_client_connection_timeout() -> anyhow::Result<()> {
+    let instance = InstanceBuilder::new()
+        .with_idle_client_timeout(1)
+        .build()
+        .await?;
+
+    let user = instance.client.who_am_i().await?;
+    assert_eq!("siguldry-client", &user);
+
+    tokio::time::sleep(std::time::Duration::from_secs(2)).await;
+    assert!(logs_contain(
+        "Shutting down client connection that has been idle for"
+    ));
+
+    instance.halt().await?;
+    Ok(())
+}
+
+#[tokio::test]
+#[tracing_test::traced_test]
+async fn idle_client_connection_watchdog() -> anyhow::Result<()> {
+    let instance = InstanceBuilder::new()
+        .with_connection_watchdog_timeout(1)
+        .build()
+        .await?;
+
+    let user = instance.client.who_am_i().await?;
+    assert_eq!("siguldry-client", &user);
+
+    tokio::time::sleep(std::time::Duration::from_secs(2)).await;
+    assert!(logs_contain(
+        "BUG: Shutting down client connection that hasn't shut down as expected!"
+    ));
+
+    instance.halt().await?;
+    Ok(())
+}
+
+#[tokio::test]
+#[tracing_test::traced_test]
+async fn idle_client_connection_timeout_refresh() -> anyhow::Result<()> {
+    let instance = InstanceBuilder::new()
+        .with_idle_client_timeout(2)
+        .build()
+        .await?;
+
+    let user = instance.client.who_am_i().await?;
+    assert_eq!("siguldry-client", &user);
+    for _ in 0..8 {
+        tokio::time::sleep(std::time::Duration::from_millis(250)).await;
+        instance.client.who_am_i().await?;
+    }
+    instance.halt().await?;
+
+    assert!(logs_contain("Reset watchdog timeout"));
+    assert!(!logs_contain(
+        "Shutting down client connection that has been idle for"
+    ));
+
+    Ok(())
+}


### PR DESCRIPTION
Add a new configuration value, `idle_client_timeout`, to the server (defaults to 1 hour) and forcibly halt connection handlers if the idle timeout is reached.

The connection is _not_ shut down gracefully and the server will log a warning when this occurs. Clients should shut down idling connections before this timeout is reached.

Fixes: #219