### PR TITLE
siguldry: shut down idle connections in the client

### DIFF
--- a/siguldry-test/src/lib.rs
+++ b/siguldry-test/src/lib.rs
@@ -195,8 +195,11 @@ pub struct InstanceBuilder {
     with_client_proxy: bool,
     with_sigul_import: Option<String>,
     additional_users: Vec<(String, bool)>,
+    /// Time before the server shuts down an idle client connection
     idle_client_timeout: Option<NonZeroU64>,
     connection_watchdog_timeout: Option<NonZeroU64>,
+    /// Time before a client shuts down its connection
+    idle_timeout: Option<NonZeroU64>,
 }
 
 impl InstanceBuilder {
@@ -284,6 +287,14 @@ impl InstanceBuilder {
     pub fn with_connection_watchdog_timeout(mut self, seconds: u64) -> Self {
         self.connection_watchdog_timeout =
             Some(NonZeroU64::new(seconds).expect("Use a non-zero value"));
+        self
+    }
+
+    /// Set the time, in seconds, the client will leave an idle connection to the server open.
+    ///
+    /// Not to be confused with `with_idle_client_timeout`. Names are hard, sorry.
+    pub fn with_idle_timeout(mut self, seconds: u64) -> Self {
+        self.idle_timeout = Some(NonZeroU64::new(seconds).expect("Use a non-zero value"));
         self
     }
 
@@ -630,6 +641,7 @@ impl InstanceBuilder {
             bridge_port: bridge.client_port(),
             credentials: creds.client.clone(),
             keys: keys.clone(),
+            idle_timeout: self.idle_timeout.unwrap_or(NonZeroU64::new(600).unwrap()),
             ..Default::default()
         };
         let client_config_file = tempdir.path().join("client.toml");

--- a/siguldry/CHANGELOG.md
+++ b/siguldry/CHANGELOG.md
@@ -6,6 +6,17 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 
+## [Unreleased]
+
+### Added
+
+- The client now gracefully shuts down idle connections to the signing server
+  after a configurable `idle_timeout` (default 600 seconds). The connection is
+  transparently re-established on the next request. This should be set somewhat
+  lower than the server's idle client timeout, and larger than the client's
+  `request_timeout`.
+
+
 ## [0.7.3] - 2026-07-06
 
 ### Fixed

--- a/siguldry/CHANGELOG.md
+++ b/siguldry/CHANGELOG.md
@@ -16,6 +16,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   lower than the server's idle client timeout, and larger than the client's
   `request_timeout`.
 
+### Changed
+
+- **Breaking** The client's `request_timeout` configuration is now expressed as
+  an integer number of seconds (for example `request_timeout = 30`) rather than
+  a duration table (`[request_timeout]` with `secs` and `nanos`).
+
 
 ## [0.7.3] - 2026-07-06
 

--- a/siguldry/client.toml.example
+++ b/siguldry/client.toml.example
@@ -25,6 +25,17 @@ bridge_port = 44334
 # passphrase_path = "siguldry.signing_key.passphrase"
 keys = []
 
+# The time, in seconds, to leave an idle connection to the signing server open.
+#
+# Idle time is measured from the last time the client sent a request to the server,
+# and clients transparently restart the connection on the next request. The server
+# will also shut down idle client connections after a time (in a much less graceful
+# manner) so this value should be somewhat less than the server-set timeout. It should
+# also be *larger* than the `request_timeout` setting.
+#
+# The default idle timeout is 600 (10 minutes).
+idle_timeout = 600
+
 # The amount of time to wait before giving up on a request and retrying.
 #
 # This covers both sending requests and receiving responses. In other words, the client

--- a/siguldry/client.toml.example
+++ b/siguldry/client.toml.example
@@ -36,15 +36,13 @@ keys = []
 # The default idle timeout is 600 (10 minutes).
 idle_timeout = 600
 
-# The amount of time to wait before giving up on a request and retrying.
+# The amount of time, in seconds, to wait before giving up on a request and retrying.
 #
 # This covers both sending requests and receiving responses. In other words, the client
 # will retry the request on a new connection if it cannot write the request to the socket
 # within `request_timeout`, *and* it will retry if it fails to read a response to that
 # request from the socket within `request_timeout`.
-[request_timeout]
-secs = 30
-nanos = 0
+request_timeout = 30
 
 # The credentials to use when authenticating to the Siguldry bridge and server. Note that
 # the certificate must have the `clientAuth` extended key usage extension.

--- a/siguldry/src/client/config.rs
+++ b/siguldry/src/client/config.rs
@@ -3,7 +3,7 @@
 
 //! The Siguldry client configuration.
 
-use std::{num::NonZeroU64, path::PathBuf, time::Duration};
+use std::{num::NonZeroU64, path::PathBuf};
 
 use sequoia_openpgp::crypto::Password;
 use serde::{Deserialize, Serialize};
@@ -33,13 +33,16 @@ pub struct Config {
     #[serde(default = "default_idle_timeout")]
     pub idle_timeout: NonZeroU64,
 
-    /// The amount of time to wait before giving up on a request and retrying.
+    /// The amount of time, in seconds, to wait before giving up on a request and retrying.
     ///
     /// This covers both sending requests and receiving responses. In other words, the client
     /// will retry the request on a new connection if it cannot write the request to the socket
     /// within `request_timeout`, *and* it will retry if it fails to read a response to that
     /// request from the socket within `request_timeout`.
-    pub request_timeout: Duration,
+    ///
+    /// The default is 30 seconds.
+    #[serde(default = "default_request_timeout")]
+    pub request_timeout: NonZeroU64,
 
     /// The credentials to use when authenticating to the Siguldry bridge and server. Note that
     /// the certificate must have the `clientAuth` extended key usage extension.
@@ -62,6 +65,10 @@ const fn default_idle_timeout() -> NonZeroU64 {
     NonZeroU64::new(600).expect("Set a non-zero default")
 }
 
+const fn default_request_timeout() -> NonZeroU64 {
+    NonZeroU64::new(30).expect("Set a non-zero default")
+}
+
 fn default_concurrency() -> usize {
     tokio::sync::Semaphore::MAX_PERMITS
 }
@@ -73,7 +80,7 @@ impl Default for Config {
             bridge_hostname: "bridge.example.com".to_string(),
             bridge_port: 44334,
             idle_timeout: default_idle_timeout(),
-            request_timeout: Duration::from_secs(30),
+            request_timeout: default_request_timeout(),
             credentials: Credentials {
                 private_key: PathBuf::from("siguldry.client.private_key.pem"),
                 certificate: PathBuf::from("siguldry.client.certificate.pem"),
@@ -213,36 +220,7 @@ bridge_hostname = "bridge.example.com"
 bridge_port = 44333
 another_key = 42
 
-[request_timeout]
-secs = 30
-nanos = 0
-
-[credentials]
-private_key = "siguldry.client.private_key.pem"
-certificate = "/etc/siguldry/client.cert"
-ca_certificate = "/etc/siguldry/ca.crt"
-        "#;
-
-        if let Err(error) = toml::from_str::<super::Config>(config) {
-            assert!(error.message().contains("unknown field `another_key`"));
-        } else {
-            panic!("Config should fail to load");
-        }
-
-        Ok(())
-    }
-
-    #[test]
-    fn timeout_extra_key() -> anyhow::Result<()> {
-        let config = r#"
-server_hostname = "server.example.com"
-bridge_hostname = "bridge.example.com"
-bridge_port = 44333
-
-[request_timeout]
-secs = 30
-nanos = 0
-another_key = 42
+request_timeout = 30
 
 [credentials]
 private_key = "siguldry.client.private_key.pem"

--- a/siguldry/src/client/config.rs
+++ b/siguldry/src/client/config.rs
@@ -3,7 +3,7 @@
 
 //! The Siguldry client configuration.
 
-use std::{path::PathBuf, time::Duration};
+use std::{num::NonZeroU64, path::PathBuf, time::Duration};
 
 use sequoia_openpgp::crypto::Password;
 use serde::{Deserialize, Serialize};
@@ -20,6 +20,19 @@ pub struct Config {
     pub bridge_hostname: String,
     /// The port on the Siguldry bridge to connect to; the default is 44334.
     pub bridge_port: u16,
+
+    /// The time, in seconds, to leave an idle connection to the signing server open.
+    ///
+    /// Idle time is measured from the last time the client sent a request to the server,
+    /// and clients transparently restart the connection on the next request. The server
+    /// will also shut down idle client connections after a time (in a much less graceful
+    /// manner) so this value should be somewhat less than the server-set timeout. It should
+    /// also be *larger* than the `request_timeout` setting.
+    ///
+    /// The default idle timeout is 600 (10 minutes).
+    #[serde(default = "default_idle_timeout")]
+    pub idle_timeout: NonZeroU64,
+
     /// The amount of time to wait before giving up on a request and retrying.
     ///
     /// This covers both sending requests and receiving responses. In other words, the client
@@ -27,6 +40,7 @@ pub struct Config {
     /// within `request_timeout`, *and* it will retry if it fails to read a response to that
     /// request from the socket within `request_timeout`.
     pub request_timeout: Duration,
+
     /// The credentials to use when authenticating to the Siguldry bridge and server. Note that
     /// the certificate must have the `clientAuth` extended key usage extension.
     pub credentials: Credentials,
@@ -44,6 +58,10 @@ pub struct Config {
     pub keys: Vec<Key>,
 }
 
+const fn default_idle_timeout() -> NonZeroU64 {
+    NonZeroU64::new(600).expect("Set a non-zero default")
+}
+
 fn default_concurrency() -> usize {
     tokio::sync::Semaphore::MAX_PERMITS
 }
@@ -54,6 +72,7 @@ impl Default for Config {
             server_hostname: "server.example.com".to_string(),
             bridge_hostname: "bridge.example.com".to_string(),
             bridge_port: 44334,
+            idle_timeout: default_idle_timeout(),
             request_timeout: Duration::from_secs(30),
             credentials: Credentials {
                 private_key: PathBuf::from("siguldry.client.private_key.pem"),

--- a/siguldry/src/client/mod.rs
+++ b/siguldry/src/client/mod.rs
@@ -97,16 +97,12 @@ impl Client {
 
     // Send a request to the server, retrying if the connection fails.
     async fn reconnecting_send(&self, request: Request) -> Result<protocol::Response, ClientError> {
+        let request_timeout = Duration::from_secs(self.config.request_timeout.get());
         loop {
             let mut service_lock = self.inner.lock().await;
             self.activity_tx.send_replace(Instant::now());
             let response = if let Some(mut service) = service_lock.take() {
-                match tokio::time::timeout(
-                    self.config.request_timeout,
-                    service.send(request.clone()),
-                )
-                .await
-                {
+                match tokio::time::timeout(request_timeout, service.send(request.clone())).await {
                     Ok(Ok(response)) => {
                         *service_lock = Some(service);
                         Some(response)
@@ -186,7 +182,7 @@ impl Client {
             // Don't hold the lock while we wait for a server response
             drop(service_lock);
             if let Some(response) = response {
-                match tokio::time::timeout(self.config.request_timeout, response).await {
+                match tokio::time::timeout(request_timeout, response).await {
                     Ok(Ok(response)) => break Ok(response),
                     Ok(Err(_recv_error)) => {
                         // This case is when the task owning the connection halts before it sends us the server response
@@ -233,19 +229,17 @@ impl Client {
         };
         let conn = conn?;
         let mut client = inner::Client::new(conn);
+        let request_timeout = Duration::from_secs(self.config.request_timeout.get());
         let keys = self.keys.lock().await.clone();
         for key in keys {
             let request = protocol::Request::Unlock {
                 key: key.key_name.clone(),
                 password: key.password(),
             };
-            match tokio::time::timeout(self.config.request_timeout, client.send(request)).await {
+            match tokio::time::timeout(request_timeout, client.send(request)).await {
                 Ok(Ok(pending_response)) => {
-                    let response = match tokio::time::timeout(
-                        self.config.request_timeout,
-                        pending_response,
-                    )
-                    .await
+                    let response = match tokio::time::timeout(request_timeout, pending_response)
+                        .await
                     {
                         Ok(Ok(response)) => response,
                         Ok(Err(_error)) => {

--- a/siguldry/src/client/mod.rs
+++ b/siguldry/src/client/mod.rs
@@ -7,6 +7,7 @@ use std::path::PathBuf;
 use std::{sync::Arc, time::Duration};
 
 use tokio::sync::Mutex;
+use tokio::time::Instant;
 
 use crate::error::ConnectionError;
 use crate::protocol::DigestAlgorithm;
@@ -28,6 +29,7 @@ pub use proxy::{ProxyClient, proxy};
 #[derive(Clone, Debug)]
 pub struct Client {
     config: Arc<Config>,
+    activity_tx: tokio::sync::watch::Sender<Instant>,
     // Keys to unlock on reconnection; this is a combination of keys from the config and those
     // unlocked manually via the Client::unlock call.
     keys: Arc<Mutex<Vec<Key>>>,
@@ -38,10 +40,53 @@ impl Client {
     /// Create a new client
     pub fn new(config: Config) -> Result<Self, ClientError> {
         let keys = config.keys.clone();
+        let idle_timeout = Duration::from_secs(config.idle_timeout.get());
+        let inner: Option<inner::Client> = None;
+        let inner = Arc::new(Mutex::new(inner));
+
+        let (activity_tx, mut activity_rx) = tokio::sync::watch::channel(Instant::now());
+        let watchdog_inner = Arc::clone(&inner);
+        tokio::spawn(async move {
+            let mut last_activity = *activity_rx.borrow();
+            let inner = watchdog_inner;
+
+            loop {
+                // Shutdown the active connection, if there is one, on the timeout. Exit when
+                // the client holding the sender side of the activity channel is dropped.
+                match tokio::time::timeout(idle_timeout, activity_rx.changed()).await {
+                    Ok(Ok(_)) => {
+                        last_activity = *activity_rx.borrow_and_update();
+                        tracing::trace!("Client reported activity to the watchdog");
+                    }
+                    Ok(Err(_recv_error)) => {
+                        tracing::debug!("Shutting down client watchdog");
+                        break;
+                    }
+                    Err(_elapsed) => {
+                        let mut lock_guard = inner.lock().await;
+                        if let Ok(false) = activity_rx.has_changed()
+                            && let Some(inner_client) = lock_guard.take()
+                        {
+                            drop(lock_guard);
+                            tracing::info!(
+                                "Shutting down idle connection to the server to conserve resources (idle {} seconds)",
+                                last_activity.elapsed().as_secs()
+                            );
+                            let _ = tokio::time::timeout(
+                                Duration::from_secs(5),
+                                inner_client.shutdown(),
+                            )
+                            .await;
+                        }
+                    }
+                }
+            }
+        });
         Ok(Self {
             config: Arc::new(config),
             keys: Arc::new(Mutex::new(keys)),
-            inner: Arc::new(Mutex::new(None)),
+            activity_tx,
+            inner,
         })
     }
 
@@ -54,6 +99,7 @@ impl Client {
     async fn reconnecting_send(&self, request: Request) -> Result<protocol::Response, ClientError> {
         loop {
             let mut service_lock = self.inner.lock().await;
+            self.activity_tx.send_replace(Instant::now());
             let response = if let Some(mut service) = service_lock.take() {
                 match tokio::time::timeout(
                     self.config.request_timeout,

--- a/siguldry/tests/end_to_end.rs
+++ b/siguldry/tests/end_to_end.rs
@@ -982,3 +982,62 @@ async fn idle_client_connection_timeout_refresh() -> anyhow::Result<()> {
 
     Ok(())
 }
+
+#[tokio::test]
+#[tracing_test::traced_test]
+async fn client_shuts_down_idle_connection() -> anyhow::Result<()> {
+    let instance = InstanceBuilder::new().with_idle_timeout(1).build().await?;
+
+    let user = instance.client.who_am_i().await?;
+    assert_eq!("siguldry-client", &user);
+
+    tokio::time::sleep(std::time::Duration::from_secs(2)).await;
+    assert!(logs_contain(
+        "Shutting down idle connection to the server to conserve resources"
+    ));
+    assert!(!logs_contain(
+        "Shutting down client connection that has been idle for"
+    ));
+
+    instance.halt().await?;
+    Ok(())
+}
+
+#[tokio::test]
+#[tracing_test::traced_test]
+async fn client_restarts_idle_connection() -> anyhow::Result<()> {
+    let instance = InstanceBuilder::new().with_idle_timeout(1).build().await?;
+
+    let user = instance.client.who_am_i().await?;
+    assert_eq!("siguldry-client", &user);
+
+    tokio::time::sleep(std::time::Duration::from_secs(2)).await;
+    assert!(logs_contain(
+        "Shutting down idle connection to the server to conserve resources"
+    ));
+
+    let user = instance.client.who_am_i().await?;
+    assert_eq!("siguldry-client", &user);
+
+    instance.halt().await?;
+    Ok(())
+}
+
+#[tokio::test]
+#[tracing_test::traced_test]
+async fn client_keeps_active_connection_open() -> anyhow::Result<()> {
+    let instance = InstanceBuilder::new().with_idle_timeout(1).build().await?;
+
+    for _ in 0..12 {
+        let user = instance.client.who_am_i().await?;
+        assert_eq!("siguldry-client", &user);
+        tokio::time::sleep(std::time::Duration::from_millis(250)).await;
+    }
+
+    assert!(!logs_contain(
+        "Shutting down idle connection to the server to conserve resources"
+    ));
+
+    instance.halt().await?;
+    Ok(())
+}


### PR DESCRIPTION
Add a watchdog to the client which shuts down the connection to the
server in a graceful manner after a configurable idle timeout is
reached. The next request will restart the connection so this is largely
transparent to users of the client.